### PR TITLE
change google auth port

### DIFF
--- a/manifest_generator.py
+++ b/manifest_generator.py
@@ -62,7 +62,7 @@ class ManifestGenerator(object):
             else:
                 flow = InstalledAppFlow.from_client_secrets_file(
                     self.credentials_path, self.scopes)
-                creds = flow.run_local_server()
+                creds = flow.run_local_server(port = 8090) ### on ShinyServer 8080(default) is taken
             # Save the credentials for the next run
             with open('token.pickle', 'wb') as token:
                 pickle.dump(creds, token)


### PR DESCRIPTION
default port 8080 is taken by ShinyServer, use 8090 instead