### PR TITLE
Ensure Synapse annotations are provided in a form that Synapse can store

### DIFF
--- a/HTAPP_manifest_valid.csv
+++ b/HTAPP_manifest_valid.csv
@@ -1,4 +1,4 @@
 HTAN Participant ID,Library Construction Method,Cancer Type,HTAN Sample ID,Filename
-HTAN_12,10x,Malignant Brain Neoplasm,HTAN_12_1,1.txt
-HTAN_12,10x,Malignant Brain Neoplasm,HTAN_12_2,2.txt
-HTAN_12,10x,Malignant Brain Neoplasm,HTAN_12_3,3.txt
+HTAN_12,10x,Malignant Brain Neoplasm,,1.txt
+HTAN_12,10x,Malignant Brain Neoplasm,,2.txt
+HTAN_12,10x,Malignant Brain Neoplasm,,3.txt


### PR DESCRIPTION
For synapse annotation, for now until Synapse schemas change, use schema labels to store attributes and annotations (and not the associated human readable name of those for displaying purposes, say in the manifest; e.g. Synapse doesn't like spaces in the annotation keys).