### PR TITLE
Added Google Cloud upload code example

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -41,8 +41,7 @@ This option would typically be useful for uploading files residing on your local
 
   * Navigate to your project, following the Synapse link provided by your DCC liaison; if prompted, please login with your Synapse account (or an associated Google account).
 
-  <details>* Create a folder to store your first dataset. 
-  <summary style = "display:inline;"><i>How to create a folder</i></summary>
+  * <details>Create a folder to store your first dataset. <summary style = "display:inline;"><i>How to create a folder</i></summary>
   <p>
      * Go to the Files tab 
 <img width="1419" alt="Screen Shot 2019-10-15 at 4 03 02 PM" src="https://user-images.githubusercontent.com/15043209/66940461-d7ec6600-eff9-11e9-9825-18b6b1e3f014.png">


### PR DESCRIPTION
@vthorsson we've been aggregating various documentation on the overall ingress process, providing details for various upload options, with associated screenshots when applicable, and filling in code vignettes. This require some clean up, organization and formatting but this is where we are for now. Next, we are adding Synapse documentation, curation app screenshots (and text), and code vignettes for AWS + one code vignette remaining for GC. 

I wanted to test the programmatic Google Cloud vignette in the documentation, but can't associate a service account with the test bucket I created (which is hta-x). Could we add the service account hta-x-673@htan-dcc.iam.gserviceaccount.com (which I created just for testing) with a role allowing read/write access to the hta-x bucket?






