### PR TITLE
Add more details to validation error message

### DIFF
--- a/MetadataModel.py
+++ b/MetadataModel.py
@@ -212,6 +212,10 @@ class MetadataModel(object):
                 """
                 errorRow = i + 2
                 errorMessage = e.message[0:1000]
+                if "data." in errorMessage:
+                    errorMessage = errorMessage[5:1000]
+
+
                 errors.append([errorRow, e.path[1], e.value, errorMessage])    
                 
          return errors


### PR DESCRIPTION
@xdoan will this format work?

[
[errorRow, errorColumnName, errorValue, errorMessage],
[errorRow, errorColumnName, errorValue, errorMessage],
...
]

errorRow and errorColumnName are provided as in the earlier version of validation results; similarly errorValue (e.g. if the user entered 'asd' for a column that allows 'Yes' or 'No', errorValue would be 'asd'' if they left blank a required field, errorValue would be '').

errorMessage is the detailed message we want to show the user (w/o 'data.' in the beginning).



