### PR TITLE
Added code to flag when wrong schema is detected in a manifest during validation

### DIFF
--- a/MetadataModel.py
+++ b/MetadataModel.py
@@ -215,12 +215,16 @@ class MetadataModel(object):
                 errorMessage = e.message[0:1000]
                 if "data." in errorMessage:
                     errorMessage = errorMessage[5:1000]
-
+                
+                
+                errors.append([errorRow, e.path[1], e.value, errorMessage])    
+                
+                """
                 if len(e.path) < 2:
                     errors.append([errorRow, "Manifest with wrong schema provided", e.value, errorMessage])    
                 else:
                     errors.append([errorRow, e.path[1], e.value, errorMessage])    
-                
+                """
          return errors
 
      


### PR DESCRIPTION
This is lower priority to handle, but I realized we can easily flag a schema error (e.g. manifest being uploaded contains wrong fields compared to selected schema).

If such an error is detected the returned array contains "Manifest with wrong schema provided" instead of the column name. (In this case we shouldn't attempt to highlight the cell containing an error in the data table preview.)
   