### PR TITLE
added create_nx_schema_objects() method in csv_utils

### DIFF
--- a/schematic/utils/csv_utils.py
+++ b/schematic/utils/csv_utils.py
@@ -185,7 +185,6 @@ def check_schema_definition(schema_definition: pd.DataFrame) -> bool:
         return
     raise Exception()
 
-
 def create_schema_classes(schema_extension: pd.DataFrame, se: SchemaExplorer) -> SchemaExplorer:
     
     """Creates classes for all attributes and adds them to the schema
@@ -193,7 +192,6 @@ def create_schema_classes(schema_extension: pd.DataFrame, se: SchemaExplorer) ->
         schema_extension: a pandas dataframe containing schema definition; see example here: https://docs.google.com/spreadsheets/d/1J2brhqO4kpeHIkNytzlqrdIiRanXDr6KD2hqjOTC9hs/edit#gid=0 
         se: a schema explorer object allowing the traversal and modification of a schema graph        
         base_schema_path: a path to a json-ld file containing an existing schema
-
     Returns: 
         An updated schema explorer object
     """
@@ -258,7 +256,6 @@ def create_schema_classes(schema_extension: pd.DataFrame, se: SchemaExplorer) ->
 
             """
             print(se.get_nx_schema().nodes[new_class["rdfs:label"]])
-
             # check if attribute doesn't already exist and add it
             if not attribute_exists(se, new_class["rdfs:label"]):
                 se.update_class(new_class)
@@ -584,5 +581,399 @@ def create_schema_classes(schema_extension: pd.DataFrame, se: SchemaExplorer) ->
     print("Done adding requirements and value ranges to attributes")
     print("=====================")
 
+
+    return se
+
+def create_nx_schema_objects(schema_extension: pd.DataFrame, se: SchemaExplorer) -> SchemaExplorer:
+    """Creates classes for all attributes and adds them to the schema.
+    Args:
+        schema_extension: a pandas dataframe containing schema definition; see example here: https://docs.google.com/spreadsheets/d/1J2brhqO4kpeHIkNytzlqrdIiRanXDr6KD2hqjOTC9hs/edit#gid=0 
+        se: a schema explorer object allowing the traversal and modification of a schema graph        
+        base_schema_path: a path to a json-ld file containing an existing schema
+    Returns: 
+        An updated schema explorer object
+    """
+
+    try:
+        check_schema_definition(schema_extension)
+        print("Schema definition csv ready for processing!")
+    except:
+        print("Schema extension headers: ")     
+        print(set(list(schema_extension.columns)))
+        print("do not match required schema headers: ")
+        print(required_headers)
+        print("ERROR: could not add extension to schema!")
+        exit()
+    
+    rel_dict = {
+        "rdfs:subClassOf": {
+            "parentOf": "in"
+        },
+        "schema:domainIncludes": {
+            "domainValue": "in"
+        },
+        "sms:requiresDependency": {
+            "requiresDependency": "out"
+        },
+        "sms:requiresComponent": {
+            "requiresComponent": "out"
+        },
+        "schema:rangeIncludes": {
+            "rangeValue": "out"
+        }
+    }
+
+    # get attributes from Attribute column
+    attributes = schema_extension[list(required_headers)].to_dict("records")
+    
+    # get all properties across all attributes from Properties column
+    props = set(schema_extension[["Properties"]].dropna().values.flatten())
+
+    # clean properties strings
+    all_properties = []
+    for prop in props:
+        all_properties += [p.strip() for p in prop.split(",")]
+
+    # get both attributes and their properties (if any)
+    properties = schema_extension[["Attribute", "Properties"]].to_dict("records")
+
+    # property to class map
+    prop_2_class = {}
+    for record in properties:
+        if not pd.isnull(record["Properties"]):
+            props = record["Properties"].strip().split(",")
+            for p in props:
+                prop_2_class[p.strip()] = record["Attribute"]
+
+    print("Adding attributes")
+    print("====================================================================================")
+    for attribute in attributes:
+
+        required = None
+        if not pd.isnull(attribute["Required"]):
+            required = attribute["Required"]
+
+
+        if not attribute["Attribute"] in all_properties:
+            display_name = attribute["Attribute"]
+           
+            subclass_of = None
+            if not pd.isnull(attribute["Parent"]):
+                subclass_of = [parent for parent in attribute["Parent"].strip().split(",")]
+
+            new_class = get_class(se, display_name,
+                                        description = attribute["Description"],
+                                        subclass_of = subclass_of,
+                                        required = required
+            )
+            
+            se.add_schema_object_nx(new_class, **rel_dict)
+
+            """
+            print(se.get_nx_schema().nodes[new_class["rdfs:label"]])
+            # check if attribute doesn't already exist and add it
+            if not attribute_exists(se, new_class["rdfs:label"]):
+                se.add_schema_object_nx(new_class, **rel_dict)
+            else:
+                print("ATTRIBUTE EXISTS")
+                print(new_class)
+            """
+
+        else:
+            display_name = attribute["Attribute"]
+
+            new_property = get_property(se, display_name,
+                                        prop_2_class[display_name],
+                                        description = attribute["Description"],
+                                        required = required
+            )
+            # check if attribute doesn't already exist and add it
+            if not attribute_exists(se, new_property["rdfs:label"]):
+                se.add_schema_object_nx(new_property, **rel_dict)
+    
+    print("Done adding attributes")
+    print("====================================================================================")
+
+    #TODO check if schema already contains property - may require property context in csv schema definition
+
+    print("Adding and editing properties")
+    print("====================================================================================")
+
+    for prop in properties:
+        if not pd.isnull(prop["Properties"]): # a class may have or not have properties
+            for p in prop["Properties"].strip().split(","): # a class may have multiple properties
+                attribute = prop["Attribute"]
+
+                # check if property is already present as attribute under attributes column
+                # TODO: adjust logic below to compactify code
+                p = p.strip()
+                if p in list(schema_extension["Attribute"]):
+                    description = schema_extension.loc[schema_extension["Attribute"] == p]["Description"].values[0]
+                    property_info = se.explore_property(se.get_property_label_from_display_name(p))
+                    range_values = property_info["range"] if "range" in property_info else None
+                    requires_dependencies = property_info["dependencies"] if "dependencies" in property_info else None
+                    required = property_info["required"] if "required" in property_info else None
+                                    
+                    new_property = get_property(se, p,
+                                                property_info["domain"],
+                                                description = description,
+                                                requires_range = range_values,
+                                                requires_dependencies = requires_dependencies,
+                                                required = required
+                    )
+                    se.edit_schema_object_nx(new_property)
+                else: 
+                    description = None
+                    new_property = get_property(se, p,
+                                                attribute,
+                                                description = description
+                    )
+                    se.add_schema_object_nx(new_property, **rel_dict)
+
+    print("Done adding properties")
+    print("====================================================================================")
+
+    # set range values and dependency requirements for each attribute
+    # if not already added, add each attribute in required values and dependencies to the schema extension
+    print("Editing attributes and properties to add requirements and value ranges")
+    print("====================================================================================")
+
+    for attribute in attributes:
+
+        # TODO: refactor processing of multi-valued cells in columns and corresponding schema updates; it would compactify code below if class and property are encapsulated as objects inheriting from a common attribute parent object
+
+        # get values in range for this attribute, if any are specified
+        range_values = attribute["Valid Values"]
+        if not pd.isnull(range_values):
+            # prepare the range values list and split based on appropriate delimiter
+            # if the string "range_values" starts with double quotes, then extract all "valid values" within double quotes
+            range_values_list = []
+            if range_values[0] == "\"":
+                range_values_list = re.findall(r'"([^"]*)"', range_values)
+            else:
+                range_values_list = range_values.strip().split(",")
+
+            for val in range_values_list:
+                # check if value is in attributes column; add it as a class if not
+                if not val.strip() in list(schema_extension["Attribute"]):
+
+                    #determine parent class of the new value class
+                    # if this attribute is not a property, set it as a parent class
+                    if not attribute["Attribute"] in all_properties:
+                        parent = attribute["Attribute"]
+                    else:
+                    # this attribute is a property, set the parent to the domain class of this attribute
+                        parent = se.get_class_by_property(attribute["Attribute"])
+                        if not parent:
+                            print("ERROR: Listed valid value " + val + " for attribute " + attribute["Attribute"] + " must have a class parent!")
+                            print("Could not add extension to schema!")
+                            exit()
+                    
+                    new_class = get_class(se, val,
+                                        description = None,
+                                        subclass_of = [parent]
+                    )
+                    # check if attribute doesn't already exist and add it
+                    if not attribute_exists(se, new_class["rdfs:label"]):
+                        se.add_schema_object_nx(new_class, **rel_dict)
+                                    
+                #update rangeIncludes of attribute
+                # if attribute is not a property, then assume it is a class
+                if not attribute["Attribute"] in all_properties:
+                    class_info = se.explore_class(se.get_class_label_from_display_name(attribute["Attribute"]))
+                    class_info["range"].append(se.get_class_label_from_display_name(val))
+                    class_range_edit = get_class(se, attribute["Attribute"],
+                                                description = attribute["Description"],\
+                                                subclass_of = [attribute["Parent"]],\
+                                                requires_dependencies = class_info["dependencies"],\
+                                                requires_range = class_info["range"],
+                                                required = class_info["required"],
+                                                validation_rules = class_info["validation_rules"] 
+                    )                    
+                    se.edit_schema_object_nx(class_range_edit)
+
+                else:
+                # the attribute is a property
+                    property_info = se.explore_property(se.get_property_label_from_display_name(attribute["Attribute"]))
+                    property_info["range"].append(se.get_class_label_from_display_name(val))
+                    property_range_edit = get_property(se, attribute["Attribute"],
+                                                    property_info["domain"],
+                                                    description = property_info["description"],
+                                                    requires_dependencies = property_info["dependencies"],
+                                                    requires_range = property_info["range"],
+                                                    required = property_info["required"],
+                                                    validation_rules = property_info["validation_rules"]
+                    )
+                    se.edit_schema_object_nx(property_range_edit)
+                # print(val + " added to value range")
+
+        # get validation rules for this attribute, if any are specified
+        validation_rules = attribute["Validation Rules"]
+        if not pd.isnull(validation_rules):
+            
+            # TODO: make validation rules delimiter configurable parameter
+            validation_rules = [val_rule.strip() for val_rule in validation_rules.strip().split("::")]
+
+            #update validation rules of attribute
+            # if attribute is not a property, then assume it is a class
+            if not attribute["Attribute"] in all_properties:
+                class_info = se.explore_class(se.get_class_label_from_display_name(attribute["Attribute"]))
+                class_info["validation_rules"] = validation_rules
+                class_val_rule_edit = get_class(se, attribute["Attribute"],
+                                                description = attribute["Description"],\
+                                                subclass_of = [attribute["Parent"]],\
+                                                requires_dependencies = class_info["dependencies"],\
+                                                requires_range = class_info["range"],
+                                                required = class_info["required"],
+                                                validation_rules = class_info["validation_rules"] 
+                )
+                se.edit_schema_object_nx(class_val_rule_edit)
+            else:
+            # the attribute is a property
+                property_info = se.explore_property(se.get_property_label_from_display_name(attribute["Attribute"]))
+                property_info["validation_rules"] = validation_rules  
+                property_val_rule_edit = get_property(se, attribute["Attribute"],
+                                                   property_info["domain"],
+                                                   description = property_info["description"],
+                                                   requires_dependencies = property_info["dependencies"],
+                                                   requires_range = property_info["range"],
+                                                   required = property_info["required"],
+                                                   validation_rules = property_info["validation_rules"]
+                )
+                se.edit_schema_object_nx(property_val_rule_edit)
+            # print(val + "validation rules added")
+
+        # get dependencies for this attribute, if any are specified
+        requires_dependencies = attribute["Requires"]
+        if not pd.isnull(requires_dependencies):
+
+            for dep in requires_dependencies.strip().split(","):
+                # check if dependency is a property or not
+                dep = dep.strip()
+                dep_is_property = dep in all_properties
+                dep_label = ""
+                # set dependency label based on kind of dependency: class or property 
+                if dep_is_property:
+                    dep_label = se.get_property_label_from_display_name(dep) 
+                else:
+                    dep_label = se.get_class_label_from_display_name(dep)
+
+              
+                # check if dependency is in attributes column; add it to the list if not
+                if not dep.strip() in list(schema_extension["Attribute"]):
+                    # if dependency is a property create a new property; else create a new class
+                    if not dep_is_property:
+                        # if this attribute is not a property, set it as a parent class
+                        if not attribute["Attribute"] in all_properties:
+                            parent = attribute["Attribute"]
+                        else:
+                        # this attribute is a property, set the parent to the domain class of this attribute
+                            parent = se.get_class_by_property(attribute["Attribute"])
+                            if not parent:
+                                print("ERROR: Listed required dependency " + dep + "for attribute " + attribute["Attribute"] + " must have a class parent!")
+                                print("Could not add extension to schema!")
+                                exit()
+
+                        new_class = get_class(se, dep,
+                                              description = None,
+                                              subclass_of = [parent]
+                        )
+                        #se.add_schema_object_nx(new_class, **rel_dict)
+                        # check if attribute doesn't already exist and add it
+                        if not attribute_exists(se, new_class["rdfs:label"]):
+                            se.add_schema_object_nx(new_class, **rel_dict)
+
+                    else:
+                        if not attribute["Attribute"] in all_properties:
+                            domain_attribute = attribute["Attribute"]
+                        else:
+                        # this attribute is a property, set the domain of this property to the domain class of the attribute
+                            domain_attribute = se.get_class_by_property(attribute["Attribute"])
+                            if not domain_attribute:
+                                print("ERROR: Listed required dependency " + dep + " must have a class parent!")
+                                print("Could not add extension to schema!")
+                                exit()
+
+                        description = None
+                        new_property = get_property(se, dep,
+                                                    domain_attribute,
+                                                    description = description
+                        )
+                        # check if attribute doesn't already exist and add it
+                        if not attribute_exists(se, new_property["rdfs:label"]):
+                            se.add_schema_object_nx(new_property, **rel_dict)
+
+                # update required dependencies of attribute
+                # if attribute is not a property then assume it is a class
+                if not attribute["Attribute"] in all_properties:
+                    class_info = se.explore_class(se.get_class_label_from_display_name(attribute["Attribute"]))
+                    class_info["dependencies"].append(dep_label)
+                    class_dependencies_edit = get_class(se, attribute["Attribute"],
+                                                description = attribute["Description"],
+                                                subclass_of = [attribute["Parent"]],
+                                                requires_dependencies = class_info["dependencies"], 
+                                                requires_range = class_info["range"],
+                                                required = class_info["required"],
+                                                validation_rules = class_info["validation_rules"]
+                    )
+                    se.edit_schema_object_nx(class_dependencies_edit)
+                else:
+                    # the attribute is a property then update as a property
+                    property_info = se.explore_property(se.get_property_label_from_display_name(attribute["Attribute"]))
+                    property_info["dependencies"].append(dep_label)
+                    property_dependencies_edit = get_property(se, attribute["Attribute"],
+                                                        property_info["domain"],
+                                                        description = property_info["description"],
+                                                        requires_dependencies = property_info["dependencies"],
+                                                        requires_range = property_info["range"],
+                                                        required = property_info["required"],
+                                                        validation_rules = property_info["validation_rules"]
+                    )
+                    se.edit_schema_object_nx(property_dependencies_edit)
+                # print(dep + " added to dependencies")
+
+            #TODO check for cycles in attribute dependencies schema subgraph
+
+        # check if the attribute requires any components
+        if not pd.isnull(attribute["Requires Component"]):
+            component_dependencies = attribute["Requires Component"] 
+        else: 
+            continue
+
+        # iterate over potentially multiple dependency components
+        for comp_dep in component_dependencies.strip().split(","):
+
+            # check if a component is already defined as an attribute; if not define it in the schema
+            if not comp_dep.strip() in list(schema_extension["Attribute"]):
+
+                #component is not in csv schema so try adding it as a class with a parent Thing
+                new_class = get_class(se, comp_dep,
+                                      description = None
+                )
+                
+                # check if attribute doesn't already exist in schema.org schema and add it
+                # (component may not be in csv schema, but could be in the base schema we are extending)
+                if not attribute_exists(se, new_class["rdfs:label"]):
+                    se.add_schema_object_nx(new_class, **rel_dict)
+        
+            #update this attribute requirements to include component
+            class_info = se.explore_class(se.get_class_label_from_display_name(attribute["Attribute"]))
+            class_info["component_dependencies"].append(se.get_class_label_from_display_name(comp_dep))
+            class_component_dependencies_edit = get_class(se, attribute["Attribute"],
+                                            description = class_info["description"],
+                                            subclass_of = class_info["subClassOf"],
+                                            requires_dependencies = class_info["dependencies"], 
+                                            requires_range = class_info["range"],
+                                            validation_rules = class_info["validation_rules"],
+                                            requires_components = class_info["component_dependencies"]
+            )
+            se.edit_schema_object_nx(class_component_dependencies_edit)
+        # print(comp_dep + " added to dependencies")
+
+
+        #TODO check for cycles in component dependencies schema subgraph
+
+    print("Done adding requirements and value ranges to attributes")
+    print("====================================================================================")
 
     return se

--- a/schematic/utils/schema_utils.py
+++ b/schematic/utils/schema_utils.py
@@ -148,6 +148,9 @@ def relationship_edges(schema_graph_nx: nx.MultiDiGraph, class_add_mod: dict, **
         "rdfs:subClassOf": {
             "parentOf": "in"
         },
+        "schema:domainIncludes": {
+            "domainValue": "in"
+        },
         "sms:requiresDependency": {
             "requiresDependency": "out"
         },
@@ -179,12 +182,12 @@ def relationship_edges(schema_graph_nx: nx.MultiDiGraph, class_add_mod: dict, **
                             schema_graph_nx.add_edge(n1, n2, key=rel_label)
                 elif type(parents) == dict:
                     if node_type == "in":
-                        n1 = extract_name_from_uri_or_curie(_parent["@id"])
+                        n1 = extract_name_from_uri_or_curie(parents["@id"])
                         n2 = class_add_mod["rdfs:label"]
 
                     if node_type == "out":
                         n1 = class_add_mod["rdfs:label"]
-                        n2 = extract_name_from_uri_or_curie(_parent["@id"])
+                        n2 = extract_name_from_uri_or_curie(parents["@id"])
 
                     # do not allow self-loops
                     if n1 != n2:


### PR DESCRIPTION
This PR adds the feature that improves the speed of the "CSV to schema.org" parser by operating on the networkx graph directly rather than on the JSON-LD schema.

How to test it?
Simply replace the call to `create_schema_classess()` with `create_nx_schema_objects()` and run `python[3] examples/csv_to_schemaorg.py` on the terminal.

Right now, you can test it with `example.csv` and no other csv file because it is failing due to some inconsistencies in label name provided in csv file ("0"/"1"/"2"/etc. specifically).