### PR TITLE
fixing a bug where manifest is not found 

### DIFF
--- a/schematic/synapse/store.py
+++ b/schematic/synapse/store.py
@@ -240,7 +240,7 @@ class SynapseStorage(object):
         """
 
         # get a list of files containing the manifest for this dataset (if any)
-        manifest = self.getFilesInStorageDataset(datasetId, fileNames = [self.manifest])
+        manifest = self.getFilesInStorageDataset(datasetId, fileNames = [os.path.basename(self.manifest)])
         
         if not manifest:
             return []


### PR DESCRIPTION
The manifest filename in the config is now a path; store.py should extract the manifest filename to successfully locate existing manifest files in dataset folders on synapse.

@sujaypatil96 and @xdoan could you verify this fix resolves #279 on your ends?