### PR TITLE
Converting `example` scripts to CLI-based design

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,21 +7,21 @@ definitions:
 
 synapse:
   master_fileview: 'syn20446927'
-  manifest_filename: 'manifests/synapse_storage_manifest.csv'
+  manifest_filename: 'data/manifests/synapse_storage_manifest.csv'
   api_creds: 'syn21088684'
 
 model:
   input:
-    location: 'schema_org_schemas/HTAN.jsonld'
+    location: 'data/schema_org_schemas/HTAN.jsonld'
     file_type: 'local'
-    log_location: 'json_schema_logs/json_schema_log.json'
+    log_location: 'data/json_schema_logs/json_schema_log.json'
   biothings:
-    location: 'schema_org_schemas/biothings.jsonld'
+    location: 'data/schema_org_schemas/biothings.jsonld'
   demo:
-    location: 'schema_org_schemas/HTAPP.jsonld'
+    location: 'data/schema_org_schemas/HTAPP.jsonld'
     file_type: 'local'
-    validation_file_location: 'validation_schemas/minimalHTAPPJSONSchema.json'
-    valid_manifest: 'manifests/HTAPP_manifest_valid.csv'
+    validation_file_location: 'data/validation_schemas/minimalHTAPPJSONSchema.json'
+    valid_manifest: 'data/manifests/HTAPP_manifest_valid.csv'
 
 style:
   google_manifest:

--- a/examples/csv_to_schemaorg.py
+++ b/examples/csv_to_schemaorg.py
@@ -1,27 +1,29 @@
-import os
-import json
+#!/usr/bin/env python3
 
+import os
+import re
+import json
+import argparse
 import pandas as pd
 
 from schematic.schemas.explorer import SchemaExplorer
-
 from schematic.utils.csv_utils import create_schema_classes
-from schematic.utils.config_utils import load_yaml
+from schematic import CONFIG
 
-from definitions import CONFIG_PATH, DATA_PATH
+# Constants (to avoid magic numbers)
+FIRST = 0
 
-config_data = load_yaml(CONFIG_PATH)
+# Create command-line argument parser
+parser = argparse.ArgumentParser()
+parser.add_argument("schema_csv_list", nargs="+", metavar="schema_csv",
+                    help="Input CSV schema files.")
+parser.add_argument("--output_jsonld", "-o", help="Output JSON-LD schema file.")
+parser.add_argument("--config", "-c", help="Configuration YAML file.")
+args = parser.parse_args()
 
-# path to base schema
-base_schema_path = os.path.join(DATA_PATH, '', config_data["model"]["biothings"]["location"])
-
-# schema name (used to name schema json-ld file as well)
-output_schema_name = "HTAN"
-
-# schema extension definition csv files
-schema_extensions_csv = [
-                        os.path.join(DATA_PATH, '', 'csv/HTAN.csv')
-                        ]
+# Load configuration
+config_data = CONFIG.load_config(args.config)
+base_schema_path = CONFIG["model"]["biothings"]["location"]
 
 # instantiate schema explorer
 base_se = SchemaExplorer()
@@ -29,9 +31,20 @@ base_se = SchemaExplorer()
 # load base schema (BioThings)
 base_se.load_schema(base_schema_path)
 
-for schema_extension_csv in schema_extensions_csv:
+for schema_extension_csv in args.schema_csv_list:
     schema_extension = pd.read_csv(schema_extension_csv)
     base_se = create_schema_classes(schema_extension, base_se)
 
+# Default to outputting the JSON-LD alongside the first input CSV
+if args.output_jsonld is None:
+    # Default to first CSV since most users will only have one input CSV file
+    first_csv = args.schema_csv_list[FIRST]
+    first_csv_noext = re.sub("[.]csv$", "", first_csv)
+    args.output_jsonld = first_csv_noext + ".jsonld"
+    print("By default, the JSON-LD output will be stored alongside the first "
+          "input CSV file. In this case, it will appear here: '%s'. You can "
+          "use the `--output_jsonld` argument to specify another file path."
+          % args.output_jsonld)
+
 # saving updated schema.org schema
-base_se.export_schema(os.path.join(os.path.dirname(base_schema_path), output_schema_name + ".jsonld"))
+base_se.export_schema(args.output_jsonld)

--- a/examples/manifest_generator.py
+++ b/examples/manifest_generator.py
@@ -1,26 +1,31 @@
-import synapseclient
 import os
+import argparse
+import synapseclient
 
 from schematic.manifest.generator import ManifestGenerator
-
 from schematic.utils.google_api_utils import download_creds_file
-from schematic.utils.config_utils import load_yaml
+from schematic import CONFIG
 
-from definitions import CONFIG_PATH, DATA_PATH
+# Create command-line argument parser
+parser = argparse.ArgumentParser()
+parser.add_argument("--config", "-c", help="Configuration YAML file.")
+args = parser.parse_args()
 
-config_data = load_yaml(CONFIG_PATH)
+# Load configuration
+config_data = CONFIG.load_config(args.config)
 
-PATH_TO_JSONLD = os.path.join(DATA_PATH, config_data["model"]["input"]["location"])
-
-# create an instance of ManifestGenerator class
-TEST_NODE = "FollowUp"
-manifest_generator = ManifestGenerator(title="FollowUp Manifest", path_to_json_ld=PATH_TO_JSONLD, root=TEST_NODE)
+# path to schema.org/JSON-LD schema ass specified in `config.yml`
+PATH_TO_JSONLD = CONFIG["model"]["input"]["location"]
 
 # make sure the 'credentials.json' file is downloaded and is present in the right path/location
 try:
     download_creds_file()
 except synapseclient.core.exceptions.SynapseHTTPError:
     print("Make sure the credentials set in the config file are correct.")
+
+# create an instance of ManifestGenerator class
+TEST_NODE = "FollowUp"
+manifest_generator = ManifestGenerator(title="FollowUp Manifest", path_to_json_ld=PATH_TO_JSONLD, root=TEST_NODE)
 
 # get manifest (csv) url
 print(manifest_generator.get_manifest())

--- a/examples/manifest_generator.py
+++ b/examples/manifest_generator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import argparse
 import synapseclient

--- a/examples/metadata_model.py
+++ b/examples/metadata_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import sys
 import json

--- a/examples/schema_explorer.py
+++ b/examples/schema_explorer.py
@@ -13,6 +13,7 @@ args = parser.parse_args()
 # Load configuration
 config_data = CONFIG.load_config(args.config)
 
+# path to schema.org/JSON-LD schema ass specified in `config.yml`
 PATH_TO_JSONLD = CONFIG["model"]["input"]["location"]
 
 # create an object of the SchemaExplorer() class
@@ -50,7 +51,7 @@ gv_digraph = schema_explorer.full_schema_graph()
 
 # since the graph is very big, we will generate an svg viz. of it
 gv_digraph.format = 'svg'
-# gv_digraph.render('data/viz/HTAN-GV', view=True)
+gv_digraph.render('data/viz/HTAN-GV', view=True)
 print("The svg visualization of the entire schema has been rendered.")
 
 # graph visualization of a sub-schema

--- a/examples/schema_explorer.py
+++ b/examples/schema_explorer.py
@@ -1,15 +1,19 @@
-from schematic.schemas.explorer import SchemaExplorer
 import networkx as nx
 import os
-from networkx.drawing.nx_agraph import graphviz_layout, to_agraph
-from graphviz import Digraph, Source
+import argparse
 
-from definitions import DATA_PATH, CONFIG_PATH
-from schematic.utils.config_utils import load_yaml
+from schematic.schemas.explorer import SchemaExplorer
+from schematic import CONFIG
 
-config_data = load_yaml(CONFIG_PATH)
+# Create command-line argument parser
+parser = argparse.ArgumentParser()
+parser.add_argument("--config", "-c", help="Configuration YAML file.")
+args = parser.parse_args()
 
-PATH_TO_JSONLD = os.path.join(DATA_PATH, config_data["model"]["input"]["location"])
+# Load configuration
+config_data = CONFIG.load_config(args.config)
+
+PATH_TO_JSONLD = CONFIG["model"]["input"]["location"]
 
 # create an object of the SchemaExplorer() class
 schema_explorer = SchemaExplorer()
@@ -46,7 +50,7 @@ gv_digraph = schema_explorer.full_schema_graph()
 
 # since the graph is very big, we will generate an svg viz. of it
 gv_digraph.format = 'svg'
-gv_digraph.render(os.path.join(DATA_PATH, '', 'viz/HTAN-GV'), view=True)
+# gv_digraph.render('data/viz/HTAN-GV', view=True)
 print("The svg visualization of the entire schema has been rendered.")
 
 # graph visualization of a sub-schema

--- a/examples/schema_explorer.py
+++ b/examples/schema_explorer.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import networkx as nx
 import os
 import argparse

--- a/examples/schema_generator.py
+++ b/examples/schema_generator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import argparse
 

--- a/examples/schema_generator.py
+++ b/examples/schema_generator.py
@@ -1,12 +1,19 @@
 import os
+import argparse
+
 from schematic.schemas.generator import SchemaGenerator
+from schematic import CONFIG
 
-from definitions import DATA_PATH, CONFIG_PATH
-from schematic.utils.config_utils import load_yaml
+# Create command-line argument parser
+parser = argparse.ArgumentParser()
+parser.add_argument("--config", "-c", help="Configuration YAML file.")
+args = parser.parse_args()
 
-config_data = load_yaml(CONFIG_PATH)
+# Load configuration
+config_data = CONFIG.load_config(args.config)
 
-PATH_TO_JSONLD = os.path.join(DATA_PATH, config_data["model"]["input"]["location"])
+# path to schema.org/JSON-LD schema ass specified in `config.yml`
+PATH_TO_JSONLD = CONFIG["model"]["input"]["location"]
 
 # create an object of SchemaGenerator() class
 schema_generator = SchemaGenerator(PATH_TO_JSONLD)

--- a/examples/synapse_store.py
+++ b/examples/synapse_store.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import argparse
 import pandas as pd

--- a/examples/synapse_store.py
+++ b/examples/synapse_store.py
@@ -1,19 +1,21 @@
-import synapseclient
-import pandas as pd
 import os
+import argparse
+import pandas as pd
+import synapseclient
 
 from schematic.synapse.store import SynapseStorage
+from schematic import CONFIG
 
-from schematic.utils.config_utils import load_yaml
+# Create command-line argument parser
+parser = argparse.ArgumentParser()
+parser.add_argument("--config", "-c", help="Configuration YAML file.")
+args = parser.parse_args()
 
-from definitions import ROOT_DIR, CONFIG_PATH, DATA_PATH
-
-config_data = load_yaml(CONFIG_PATH)
-
-PATH_TO_SYN_CONF = os.path.join(ROOT_DIR, '.synapseConfig')
+# Load configuration
+config_data = CONFIG.load_config(args.config)
 
 # create an instance of synapseclient.Synapse() and login
-syn = synapseclient.Synapse(configPath=PATH_TO_SYN_CONF)
+syn = synapseclient.Synapse(configPath=CONFIG.SYNAPSE_CONFIG_PATH)
 
 try:
     syn.login()
@@ -47,7 +49,7 @@ print(files_df)
 
 # testing the association of entities with annotation(s) from manifest
 # synapse ID of "HTAN_CenterA_FamilyHistory" dataset and associating with it a validated manifest
-MANIFEST_LOC = os.path.join(DATA_PATH, '', config_data["synapse"]["manifest_filename"])
+MANIFEST_LOC = CONFIG["synapse"]["manifest_filename"]
 print("Testing association of entities with annotation from manifest...")
 manifest_syn_id = syn_store.associateMetadataWithFiles(MANIFEST_LOC, "syn21984120")
 print(manifest_syn_id)

--- a/schematic/utils/io_utils.py
+++ b/schematic/utils/io_utils.py
@@ -31,12 +31,12 @@ def export_json(json_doc, file_path):
 def load_default():
     """Load biolink vocabulary
     """
-    biothings_path = os.path.join('schema_org_schemas', 'biothings.jsonld')
+    biothings_path = os.path.join('data', 'schema_org_schemas', 'biothings.jsonld')
     return load_json(biothings_path)
 
 
 def load_schemaorg():
     """Load SchemOrg vocabulary
     """
-    schemaorg_path = os.path.join('schema_org_schemas', 'all_layer.jsonld')
+    schemaorg_path = os.path.join('data', 'schema_org_schemas', 'all_layer.jsonld')
     return load_json(schemaorg_path)

--- a/schematic/utils/validate_utils.py
+++ b/schematic/utils/validate_utils.py
@@ -23,6 +23,6 @@ def validate_property_schema(schema):
 def validate_class_schema(schema):
     """Validate schema against SchemaORG class definition standard
     """
-    json_schema_path = os.path.join('validation_schemas', 'class_json_schema.json')
+    json_schema_path = os.path.join('data', 'validation_schemas', 'class_json_schema.json')
     json_schema = load_json(json_schema_path)
     return validate(schema, json_schema)


### PR DESCRIPTION
All the scripts within `examples/` have now been converted to CLI-based design/paradigm.

To test the CLI, do this (from within the `schematic` folder, basically the location where the `config.yml` file lives):

```python
python[3] examples/manifest_generator.py --config config.yml
```