### PR TITLE
add positional arguments to example scripts

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,7 @@ model:
   input:
     location: 'data/schema_org_schemas/HTAN.jsonld'
     file_type: 'local'
+    validation_schema: 'data/validation_schemas/HTAN_validation_schema_FamilyHistory.json'
     log_location: 'data/json_schema_logs/json_schema_log.json'
   biothings:
     location: 'data/schema_org_schemas/biothings.jsonld'

--- a/config.yml
+++ b/config.yml
@@ -17,11 +17,6 @@ model:
     log_location: 'data/json_schema_logs/json_schema_log.json'
   biothings:
     location: 'data/schema_org_schemas/biothings.jsonld'
-  demo:
-    location: 'data/schema_org_schemas/HTAPP.jsonld'
-    file_type: 'local'
-    validation_file_location: 'data/validation_schemas/minimalHTAPPJSONSchema.json'
-    valid_manifest: 'data/manifests/HTAPP_manifest_valid.csv'
 
 style:
   google_manifest:

--- a/data/validation_schemas/HTAN_validation_schema_FamilyHistory.json
+++ b/data/validation_schemas/HTAN_validation_schema_FamilyHistory.json
@@ -1,0 +1,518 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://example.com/FamilyHistory",
+    "title": "FamilyHistory",
+    "type": "object",
+    "properties": {
+      "HTAN Patient ID": {
+        "not": {
+          "type": "null"
+        },
+        "minLength": 1
+      },
+      "Relative with Cancer History": {
+        "enum": [
+          "None",
+          "not reported",
+          "Unknown",
+          "Yes - Cancer History Relative",
+          ""
+        ]
+      },
+      "Component": {
+        "not": {
+          "type": "null"
+        },
+        "minLength": 1
+      },
+      "Relationship Age at Diagnosis": {},
+      "Relationship Gender": {
+        "enum": [
+          "female",
+          "male",
+          "Not Reported",
+          "Unknown",
+          "unspecified",
+          ""
+        ]
+      },
+      "Relationship Primary Diagnosis": {
+        "enum": [
+          "Adrenal Gland Cancer",
+          "Basal Cell Cancer",
+          "Bile Duct Cancer",
+          "Bladder Cancer",
+          "Blood Cancer",
+          "Bone Cancer",
+          "Brain Cancer",
+          "Breast Cancer",
+          "CNS Cancer",
+          "Cancer",
+          "Cervical Cancer",
+          "Chondrosarcoma",
+          "Colorectal Cancer",
+          "Esophageal Cancer",
+          "Ewing Sarcoma",
+          "Gallbladder Cancer",
+          "Gastric Cancer",
+          "Glioblastoma",
+          "Gynecologic Cancer",
+          "Head and Neck Cancer",
+          "Hematologic Cancer",
+          "Kaposi Sarcoma",
+          "Kidney Cancer",
+          "Laryngeal Cancer",
+          "Leukemia",
+          "Liver Cancer",
+          "Lung Cancer",
+          "Lymph Node Cancer",
+          "Lymphoma",
+          "Melanoma",
+          "Mesothelioma",
+          "Multiple Myeloma",
+          "Neuroblastoma",
+          "Not Reported",
+          "Osteosarcoma",
+          "Ovarian Cancer",
+          "Pancreas Cancer",
+          "Prostate Cancer",
+          "Rectal Cancer",
+          "Rhabdomyosarcoma",
+          "Sarcoma",
+          "Skin Cancer",
+          "Spleen Cancer",
+          "Testicular Cancer",
+          "Throat Cancer",
+          "Thyroid Cancer",
+          "Tongue Cancer",
+          "Tonsillar Cancer",
+          "Unknown",
+          "Uterine Cancer",
+          "Wilms Tumor",
+          ""
+        ]
+      },
+      "Relationship Type": {
+        "enum": [
+          "Adopted Daughter",
+          "Adopted Son",
+          "Adoptive Brother",
+          "Adoptive Father",
+          "Adoptive Mother",
+          "Adoptive Sister",
+          "Aunt",
+          "Brother",
+          "Brother-in-law",
+          "Child",
+          "Cousin",
+          "Daughter",
+          "Daughter-in-law",
+          "Domestic Partner",
+          "Father",
+          "Father-in-law",
+          "Female Cousin",
+          "First Cousin",
+          "First Cousin Once Removed",
+          "Foster Brother",
+          "Foster Daughter",
+          "Foster Father",
+          "Foster Mother",
+          "Foster Sister",
+          "Foster Son",
+          "Fraternal Twin Brother",
+          "Fraternal Twin Sibling",
+          "Fraternal Twin Sister",
+          "Full Brother",
+          "Full Sister",
+          "Grand Nephew",
+          "Grand Niece",
+          "Grandchild",
+          "Granddaughter",
+          "Grandfather",
+          "Grandmother",
+          "Grandparent",
+          "Grandson",
+          "Great Grandchild",
+          "Half Brother",
+          "Half Sibling",
+          "Half Sister",
+          "Husband",
+          "Identical Twin Brother",
+          "Identical Twin Sibling",
+          "Identical Twin Sister",
+          "Legal Guardian",
+          "Male Cousin",
+          "Maternal Aunt",
+          "Maternal First Cousin",
+          "Maternal First Cousin Once Removed",
+          "Maternal Grandfather",
+          "Maternal Grandmother",
+          "Maternal Grandparent",
+          "Maternal Great Aunt",
+          "Maternal Great Grandparent",
+          "Maternal Great Uncle",
+          "Maternal Half Brother",
+          "Maternal Half Sibling",
+          "Maternal Half Sister",
+          "Maternal Uncle",
+          "Mother",
+          "Mother-in-law",
+          "Natural Brother",
+          "Natural Child",
+          "Natural Daughter",
+          "Natural Father",
+          "Natural Grandchild",
+          "Natural Grandfather",
+          "Natural Grandmother",
+          "Natural Grandparent",
+          "Natural Mother",
+          "Natural Parent",
+          "Natural Sibling",
+          "Natural Sister",
+          "Natural Son",
+          "Nephew",
+          "Niece",
+          "Niece Second Degree Relative",
+          "Not Reported",
+          "Other",
+          "Parent",
+          "Paternal Aunt",
+          "Paternal First Cousin",
+          "Paternal First Cousin Once Removed",
+          "Paternal Grandfather",
+          "Paternal Grandmother",
+          "Paternal Grandparent",
+          "Paternal Great Aunt",
+          "Paternal Great Grandparent",
+          "Paternal Great Uncle",
+          "Paternal Half Brother",
+          "Paternal Half Sibling",
+          "Paternal Half Sister",
+          "Paternal Uncle",
+          "Refused",
+          "Sibling",
+          "Sister",
+          "Sister-in-law",
+          "Son",
+          "Son-in-law",
+          "Spouse",
+          "Step Child",
+          "Step Sibling",
+          "Stepbrother",
+          "Stepdaughter",
+          "Stepfather",
+          "Stepmother",
+          "Stepsister",
+          "Stepson",
+          "Twin Sibling",
+          "Uncle",
+          "Unknown",
+          "Unrelated",
+          "Ward",
+          "Wife",
+          ""
+        ]
+      },
+      "Relatives with Cancer History Count": {}
+    },
+    "required": [
+      "HTAN Patient ID",
+      "Component"
+    ],
+    "allOf": [
+      {
+        "if": {
+          "properties": {
+            "Relative with Cancer History": {
+              "enum": [
+                "Yes - Cancer History Relative"
+              ]
+            }
+          },
+          "required": [
+            "Relative with Cancer History"
+          ]
+        },
+        "then": {
+          "properties": {
+            "Relationship Age at Diagnosis": {}
+          },
+          "required": [
+            "Relationship Age at Diagnosis"
+          ]
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "Relative with Cancer History": {
+              "enum": [
+                "Yes - Cancer History Relative"
+              ]
+            }
+          },
+          "required": [
+            "Relative with Cancer History"
+          ]
+        },
+        "then": {
+          "properties": {
+            "Relationship Gender": {
+              "enum": [
+                "female",
+                "male",
+                "Not Reported",
+                "Unknown",
+                "unspecified",
+                ""
+              ]
+            }
+          },
+          "required": [
+            "Relationship Gender"
+          ]
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "Relative with Cancer History": {
+              "enum": [
+                "Yes - Cancer History Relative"
+              ]
+            }
+          },
+          "required": [
+            "Relative with Cancer History"
+          ]
+        },
+        "then": {
+          "properties": {
+            "Relationship Primary Diagnosis": {
+              "enum": [
+                "Adrenal Gland Cancer",
+                "Basal Cell Cancer",
+                "Bile Duct Cancer",
+                "Bladder Cancer",
+                "Blood Cancer",
+                "Bone Cancer",
+                "Brain Cancer",
+                "Breast Cancer",
+                "CNS Cancer",
+                "Cancer",
+                "Cervical Cancer",
+                "Chondrosarcoma",
+                "Colorectal Cancer",
+                "Esophageal Cancer",
+                "Ewing Sarcoma",
+                "Gallbladder Cancer",
+                "Gastric Cancer",
+                "Glioblastoma",
+                "Gynecologic Cancer",
+                "Head and Neck Cancer",
+                "Hematologic Cancer",
+                "Kaposi Sarcoma",
+                "Kidney Cancer",
+                "Laryngeal Cancer",
+                "Leukemia",
+                "Liver Cancer",
+                "Lung Cancer",
+                "Lymph Node Cancer",
+                "Lymphoma",
+                "Melanoma",
+                "Mesothelioma",
+                "Multiple Myeloma",
+                "Neuroblastoma",
+                "Not Reported",
+                "Osteosarcoma",
+                "Ovarian Cancer",
+                "Pancreas Cancer",
+                "Prostate Cancer",
+                "Rectal Cancer",
+                "Rhabdomyosarcoma",
+                "Sarcoma",
+                "Skin Cancer",
+                "Spleen Cancer",
+                "Testicular Cancer",
+                "Throat Cancer",
+                "Thyroid Cancer",
+                "Tongue Cancer",
+                "Tonsillar Cancer",
+                "Unknown",
+                "Uterine Cancer",
+                "Wilms Tumor",
+                ""
+              ]
+            }
+          },
+          "required": [
+            "Relationship Primary Diagnosis"
+          ]
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "Relative with Cancer History": {
+              "enum": [
+                "Yes - Cancer History Relative"
+              ]
+            }
+          },
+          "required": [
+            "Relative with Cancer History"
+          ]
+        },
+        "then": {
+          "properties": {
+            "Relationship Type": {
+              "enum": [
+                "Adopted Daughter",
+                "Adopted Son",
+                "Adoptive Brother",
+                "Adoptive Father",
+                "Adoptive Mother",
+                "Adoptive Sister",
+                "Aunt",
+                "Brother",
+                "Brother-in-law",
+                "Child",
+                "Cousin",
+                "Daughter",
+                "Daughter-in-law",
+                "Domestic Partner",
+                "Father",
+                "Father-in-law",
+                "Female Cousin",
+                "First Cousin",
+                "First Cousin Once Removed",
+                "Foster Brother",
+                "Foster Daughter",
+                "Foster Father",
+                "Foster Mother",
+                "Foster Sister",
+                "Foster Son",
+                "Fraternal Twin Brother",
+                "Fraternal Twin Sibling",
+                "Fraternal Twin Sister",
+                "Full Brother",
+                "Full Sister",
+                "Grand Nephew",
+                "Grand Niece",
+                "Grandchild",
+                "Granddaughter",
+                "Grandfather",
+                "Grandmother",
+                "Grandparent",
+                "Grandson",
+                "Great Grandchild",
+                "Half Brother",
+                "Half Sibling",
+                "Half Sister",
+                "Husband",
+                "Identical Twin Brother",
+                "Identical Twin Sibling",
+                "Identical Twin Sister",
+                "Legal Guardian",
+                "Male Cousin",
+                "Maternal Aunt",
+                "Maternal First Cousin",
+                "Maternal First Cousin Once Removed",
+                "Maternal Grandfather",
+                "Maternal Grandmother",
+                "Maternal Grandparent",
+                "Maternal Great Aunt",
+                "Maternal Great Grandparent",
+                "Maternal Great Uncle",
+                "Maternal Half Brother",
+                "Maternal Half Sibling",
+                "Maternal Half Sister",
+                "Maternal Uncle",
+                "Mother",
+                "Mother-in-law",
+                "Natural Brother",
+                "Natural Child",
+                "Natural Daughter",
+                "Natural Father",
+                "Natural Grandchild",
+                "Natural Grandfather",
+                "Natural Grandmother",
+                "Natural Grandparent",
+                "Natural Mother",
+                "Natural Parent",
+                "Natural Sibling",
+                "Natural Sister",
+                "Natural Son",
+                "Nephew",
+                "Niece",
+                "Niece Second Degree Relative",
+                "Not Reported",
+                "Other",
+                "Parent",
+                "Paternal Aunt",
+                "Paternal First Cousin",
+                "Paternal First Cousin Once Removed",
+                "Paternal Grandfather",
+                "Paternal Grandmother",
+                "Paternal Grandparent",
+                "Paternal Great Aunt",
+                "Paternal Great Grandparent",
+                "Paternal Great Uncle",
+                "Paternal Half Brother",
+                "Paternal Half Sibling",
+                "Paternal Half Sister",
+                "Paternal Uncle",
+                "Refused",
+                "Sibling",
+                "Sister",
+                "Sister-in-law",
+                "Son",
+                "Son-in-law",
+                "Spouse",
+                "Step Child",
+                "Step Sibling",
+                "Stepbrother",
+                "Stepdaughter",
+                "Stepfather",
+                "Stepmother",
+                "Stepsister",
+                "Stepson",
+                "Twin Sibling",
+                "Uncle",
+                "Unknown",
+                "Unrelated",
+                "Ward",
+                "Wife",
+                ""
+              ]
+            }
+          },
+          "required": [
+            "Relationship Type"
+          ]
+        }
+      },
+      {
+        "if": {
+          "properties": {
+            "Relative with Cancer History": {
+              "enum": [
+                "Yes - Cancer History Relative"
+              ]
+            }
+          },
+          "required": [
+            "Relative with Cancer History"
+          ]
+        },
+        "then": {
+          "properties": {
+            "Relatives with Cancer History Count": {}
+          },
+          "required": [
+            "Relatives with Cancer History Count"
+          ]
+        }
+      }
+    ]
+  }

--- a/examples/csv_to_schemaorg.py
+++ b/examples/csv_to_schemaorg.py
@@ -14,9 +14,8 @@ from schematic import CONFIG
 FIRST = 0
 
 # Create command-line argument parser
-parser = argparse.ArgumentParser()
-parser.add_argument("schema_csv_list", nargs="+", metavar="schema_csv",
-                    help="Input CSV schema files.")
+parser = argparse.ArgumentParser(allow_abbrev=False)
+parser.add_argument("schema_csv_list", nargs="+", metavar="schema_csv", help="Input CSV schema files.")
 parser.add_argument("--output_jsonld", "-o", help="Output JSON-LD schema file.")
 parser.add_argument("--config", "-c", help="Configuration YAML file.")
 args = parser.parse_args()

--- a/examples/csv_to_schemaorg.py
+++ b/examples/csv_to_schemaorg.py
@@ -15,7 +15,7 @@ FIRST = 0
 
 # Create command-line argument parser
 parser = argparse.ArgumentParser(allow_abbrev=False)
-parser.add_argument("schema_csv_list", nargs="+", metavar="schema_csv", help="Input CSV schema files.")
+parser.add_argument("schema_csv_list", nargs="+", metavar="CSV SCHEMA(S)", help="Input CSV schema file(s).")
 parser.add_argument("--output_jsonld", "-o", help="Output JSON-LD schema file.")
 parser.add_argument("--config", "-c", help="Configuration YAML file.")
 args = parser.parse_args()

--- a/examples/manifest_generator.py
+++ b/examples/manifest_generator.py
@@ -8,15 +8,20 @@ from schematic.manifest.generator import ManifestGenerator
 from schematic.utils.google_api_utils import download_creds_file
 from schematic import CONFIG
 
+# Constants (to avoid magic numbers)
+FIRST = 0
+
 # Create command-line argument parser
-parser = argparse.ArgumentParser()
-parser.add_argument("--config", "-c", help="Configuration YAML file.")
+parser = argparse.ArgumentParser(allow_abbrev=False)
+parser.add_argument("title", type=str, nargs=1, metavar="TITLE", help="Title of generated manifest file.")
+parser.add_argument("component", type=str, nargs=1, metavar="COMPONENT", help="Component from the schema.org schema.")
+parser.add_argument("--config", "-c", metavar="CONFIG", help="Configuration YAML file.")
 args = parser.parse_args()
 
 # Load configuration
 config_data = CONFIG.load_config(args.config)
 
-# path to schema.org/JSON-LD schema ass specified in `config.yml`
+# path to schema.org/JSON-LD schema as specified in `config.yml`
 PATH_TO_JSONLD = CONFIG["model"]["input"]["location"]
 
 # make sure the 'credentials.json' file is downloaded and is present in the right path/location
@@ -26,8 +31,7 @@ except synapseclient.core.exceptions.SynapseHTTPError:
     print("Make sure the credentials set in the config file are correct.")
 
 # create an instance of ManifestGenerator class
-TEST_NODE = "FollowUp"
-manifest_generator = ManifestGenerator(title="FollowUp Manifest", path_to_json_ld=PATH_TO_JSONLD, root=TEST_NODE)
+manifest_generator = ManifestGenerator(title=args.title[FIRST], path_to_json_ld=PATH_TO_JSONLD, root=args.component[FIRST])
 
 # get manifest (csv) url
 print(manifest_generator.get_manifest())

--- a/examples/manifest_generator.py
+++ b/examples/manifest_generator.py
@@ -14,7 +14,7 @@ FIRST = 0
 # Create command-line argument parser
 parser = argparse.ArgumentParser(allow_abbrev=False)
 parser.add_argument("title", type=str, nargs=1, metavar="TITLE", help="Title of generated manifest file.")
-parser.add_argument("component", type=str, nargs=1, metavar="COMPONENT", help="Component from the schema.org schema.")
+parser.add_argument("data_type", type=str, nargs=1, metavar="DATA TYPE", help="data type from the schema.org schema.")
 parser.add_argument("--config", "-c", metavar="CONFIG", help="Configuration YAML file.")
 args = parser.parse_args()
 
@@ -31,7 +31,7 @@ except synapseclient.core.exceptions.SynapseHTTPError:
     print("Make sure the credentials set in the config file are correct.")
 
 # create an instance of ManifestGenerator class
-manifest_generator = ManifestGenerator(title=args.title[FIRST], path_to_json_ld=PATH_TO_JSONLD, root=args.component[FIRST])
+manifest_generator = ManifestGenerator(title=args.title[FIRST], path_to_json_ld=PATH_TO_JSONLD, root=args.data_type[FIRST])
 
 # get manifest (csv) url
 print(manifest_generator.get_manifest())

--- a/examples/metadata_model.py
+++ b/examples/metadata_model.py
@@ -4,12 +4,19 @@ import os
 import sys
 import json
 import argparse
+import synapseclient
 
 from schematic.models.metadata import MetadataModel
+from schematic.utils.google_api_utils import download_creds_file
 from schematic import CONFIG
 
+# Constants (to avoid magic numbers)
+FIRST = 0
+
 # Create command-line argument parser
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(allow_abbrev=False)
+parser.add_argument("title", type=str, nargs=1, metavar="TITLE", help="Title of generated manifest file.")
+parser.add_argument("component", type=str, nargs=1, metavar="COMPONENT", help="Component from the schema.org schema.")
 parser.add_argument("--config", "-c", help="Configuration YAML file.")
 args = parser.parse_args()
 
@@ -22,54 +29,25 @@ MM_TYPE = CONFIG["model"]["input"]["file_type"]
 
 # create instance of MetadataModel class
 metadata_model_htan = MetadataModel(MM_LOC, MM_TYPE)
-print("*****************************************************")
 
-# TEST_COMP used for testing methods in 'metadata.py'
-TEST_COMP = "FollowUp"
+# TEST_COMP used for testing methods in `metadata.py`
+TEST_COMP = args.component[FIRST]
 
 # testing manifest generation - manifest is generated based on a JSON schema parsed from schema.org schema, which generates a google spreadsheet.
 # To generate the sheet, the backend requires Google API credentials in a file credentials.json stored locally in the same directory as this file
 # this credentials file is also stored on Synapse and can be retrieved given sufficient permissions to the Synapse project
 
-# Google API credentials file stored on Synapse
-API_CREDS = config_data["synapse"]["api_creds"]
-
-# try downloading 'credentials.json' file (if not present already)
-if not os.path.exists(CONFIG.CREDS_PATH):
-
-    print("Retrieving Google API credentials from Synapse..")
-    import synapseclient
-
-    syn = synapseclient.Synapse()
-    syn.login()
-
-    DIR_NAME = os.path.dirname(CONFIG.CONFIG_PATH)
-    syn.get(API_CREDS, downloadLocation = DIR_NAME)
-    print("Stored Google API credentials.")
-
-print("Google API credentials successfully located..")
+# make sure the 'credentials.json' file is downloaded and is present in the right path/location
+try:
+    download_creds_file()
+except synapseclient.core.exceptions.SynapseHTTPError:
+    print("Make sure the credentials set in the config file are correct.")
 
 print("*****************************************************")
 
 # testing manifest generation from a given root node without optionally provided JSON schema
 print("Testing manifest generation based on a provided schema.org schema..")
-manifest_url = metadata_model_htan.getModelManifest(title="Test_" + TEST_COMP, rootNode=TEST_COMP, filenames=["1.txt", "2.txt", "3.txt"])
-print(manifest_url)
-
-print("*****************************************************")
-
-# testing manifest generation with optionally provided JSON validation schema
-print("Testing manifest generation based on an additionally provided JSON schema..")
-HTAPP_VALIDATION_SCHEMA = CONFIG["model"]["demo"]["validation_file_location"]
-
-with open(HTAPP_VALIDATION_SCHEMA, "r") as f:
-    json_schema = json.load(f)
-
-HTAPP_SCHEMA = CONFIG["model"]["demo"]["location"]
-HTAPP_SCHEMA_TYPE = CONFIG["model"]["demo"]["file_type"]
-
-metadata_model_htapp = MetadataModel(HTAPP_SCHEMA, HTAPP_SCHEMA_TYPE)
-manifest_url = metadata_model_htapp.getModelManifest(title="Example Manifest", rootNode="", jsonSchema=json_schema)
+manifest_url = metadata_model_htan.getModelManifest(title=args.title[FIRST], rootNode=TEST_COMP, filenames=["1.txt", "2.txt", "3.txt"])
 print(manifest_url)
 
 print("*****************************************************")
@@ -81,14 +59,6 @@ print("Testing metadata model-based validation..")
 MANIFEST_PATH = CONFIG["model"]["demo"]["valid_manifest"]
 print("Testing validation with jsonSchema generation from schema.org schema..")
 annotation_errors = metadata_model_htan.validateModelManifest(MANIFEST_PATH, TEST_COMP)
-print(annotation_errors)
-
-print("*****************************************************")
-
-# use JSON schema object to validate the integrity of annotations in manifest file (track annotation errors)
-# with additionally provided JSON schema
-print("Testing validation with provided JSON schema..")
-annotation_errors = metadata_model_htapp.validateModelManifest(MANIFEST_PATH, TEST_COMP, json_schema)
 print(annotation_errors)
 
 print("*****************************************************")

--- a/examples/metadata_model.py
+++ b/examples/metadata_model.py
@@ -16,7 +16,7 @@ FIRST = 0
 # Create command-line argument parser
 parser = argparse.ArgumentParser(allow_abbrev=False)
 parser.add_argument("title", type=str, nargs=1, metavar="TITLE", help="Title of generated manifest file.")
-parser.add_argument("component", type=str, nargs=1, metavar="COMPONENT", help="Component from the schema.org schema.")
+parser.add_argument("data_type", type=str, nargs=1, metavar="DATA TYPE", help="data type from the schema.org schema.")
 parser.add_argument("--config", "-c", help="Configuration YAML file.")
 args = parser.parse_args()
 
@@ -28,10 +28,10 @@ MM_LOC = CONFIG["model"]["input"]["location"]
 MM_TYPE = CONFIG["model"]["input"]["file_type"]
 
 # create instance of MetadataModel class
-metadata_model_htan = MetadataModel(MM_LOC, MM_TYPE)
+metadata_model = MetadataModel(MM_LOC, MM_TYPE)
 
-# TEST_COMP used for testing methods in `metadata.py`
-TEST_COMP = args.component[FIRST]
+# TEST_DATA_TYPE used for testing methods in `metadata.py`
+TEST_DATA_TYPE = args.data_type[FIRST]
 
 # testing manifest generation - manifest is generated based on a JSON schema parsed from schema.org schema, which generates a google spreadsheet.
 # To generate the sheet, the backend requires Google API credentials in a file credentials.json stored locally in the same directory as this file
@@ -47,7 +47,7 @@ print("*****************************************************")
 
 # testing manifest generation from a given root node without optionally provided JSON schema
 print("Testing manifest generation based on a provided schema.org schema..")
-manifest_url = metadata_model_htan.getModelManifest(title=args.title[FIRST], rootNode=TEST_COMP, filenames=["1.txt", "2.txt", "3.txt"])
+manifest_url = metadata_model.getModelManifest(title=args.title[FIRST], rootNode=TEST_DATA_TYPE, filenames=["1.txt", "2.txt", "3.txt"])
 print(manifest_url)
 
 print("*****************************************************")
@@ -56,16 +56,16 @@ print("*****************************************************")
 # without optionally/additionally provided JSON schema
 print("Testing metadata model-based validation..")
 
-MANIFEST_PATH = CONFIG["model"]["demo"]["valid_manifest"]
+MANIFEST_PATH = CONFIG["synapse"]["manifest_filename"]
 print("Testing validation with jsonSchema generation from schema.org schema..")
-annotation_errors = metadata_model_htan.validateModelManifest(MANIFEST_PATH, TEST_COMP)
+annotation_errors = metadata_model.validateModelManifest(MANIFEST_PATH, TEST_DATA_TYPE)
 print(annotation_errors)
 
 print("*****************************************************")
 
 # populate a manifest with content from an already existing/filled out manifest
 print("Testing metadata model-based manifest population..")
-pre_populated_manifest_url = metadata_model_htan.populateModelManifest("Test_" + TEST_COMP, MANIFEST_PATH, TEST_COMP)
+pre_populated_manifest_url = metadata_model.populateModelManifest("Test_" + TEST_DATA_TYPE, MANIFEST_PATH, TEST_DATA_TYPE)
 print(pre_populated_manifest_url)
 
 print("*****************************************************")
@@ -73,24 +73,24 @@ print("*****************************************************")
 # get all the nodes that are dependent on a given node based on a specific relationship type
 print("Testing metadata model-based object dependency generation..")
 print("Generating dependency graph and ordering dependencies..")
-dependencies = metadata_model_htan.getOrderedModelNodes(TEST_COMP, "requiresDependency")
+dependencies = metadata_model.getOrderedModelNodes(TEST_DATA_TYPE, "requiresDependency")
 print(dependencies)
 
-with open(TEST_COMP + "_dependencies.json", "w") as f:
+with open(TEST_DATA_TYPE + "_dependencies.json", "w") as f:
     json.dump(dependencies, f, indent = 3)
 
-print("Dependencies stored in: " + TEST_COMP + "_dependencies.json")
+print("Dependencies stored in: " + TEST_DATA_TYPE + "_dependencies.json")
 
 print("*****************************************************")
 
-# get all nodes that are dependent on a given component
-print("Testing metadata model-based component dependency generation..")
+# get all nodes that are dependent on a given data type
+print("Testing metadata model-based data type dependency generation..")
 print("Generating dependency graph and ordering dependencies..")
 
-dependencies = metadata_model_htan.getOrderedModelNodes(TEST_COMP, "requiresComponent")
+dependencies = metadata_model.getOrderedModelNodes(TEST_DATA_TYPE, "requiresComponent")
 print(dependencies)
 
-with open(TEST_COMP + "component_dependencies.json", "w") as f:
+with open(TEST_DATA_TYPE + "data_type_dependencies.json", "w") as f:
     json.dump(dependencies, f, indent = 3)
 
-print("component dependencies stored: " + TEST_COMP + "component_dependencies.json")
+print("data type dependencies stored: " + TEST_DATA_TYPE + "data_type_dependencies.json")

--- a/examples/schema_explorer.py
+++ b/examples/schema_explorer.py
@@ -1,21 +1,24 @@
 #!/usr/bin/env python3
 
-import networkx as nx
 import os
 import argparse
+import networkx as nx
 
 from schematic.schemas.explorer import SchemaExplorer
 from schematic import CONFIG
 
+# Constants (to avoid magic numbers)
+FIRST = 0
+
 # Create command-line argument parser
 parser = argparse.ArgumentParser()
+parser.add_argument("schema_class", nargs=1, metavar="schema_class", help="Name of class from schema.")
 parser.add_argument("--config", "-c", help="Configuration YAML file.")
 args = parser.parse_args()
 
-# Load configuration
+# Load Configuration
 config_data = CONFIG.load_config(args.config)
 
-# path to schema.org/JSON-LD schema ass specified in `config.yml`
 PATH_TO_JSONLD = CONFIG["model"]["input"]["location"]
 
 # create an object of the SchemaExplorer() class
@@ -40,7 +43,7 @@ else:
     print("object of class SchemaExplorer could not be retreived.")
 
 # check if a particular class is in the current HTAN JSON-LD schema (or any schema that has been loaded)
-TEST_CLASS = 'Sequencing'
+TEST_CLASS = args.schema_class[FIRST]
 is_or_not = schema_explorer.is_class_in_schema(TEST_CLASS)
 
 if is_or_not == True:
@@ -53,7 +56,7 @@ gv_digraph = schema_explorer.full_schema_graph()
 
 # since the graph is very big, we will generate an svg viz. of it
 gv_digraph.format = 'svg'
-gv_digraph.render('data/viz/HTAN-GV', view=True)
+gv_digraph.render('viz/HTAN-GV', view=True)
 print("The svg visualization of the entire schema has been rendered.")
 
 # graph visualization of a sub-schema
@@ -119,7 +122,7 @@ class_mod = {
                 "sms:required": "sms:false"
             }
 
-# make edits to TEST_CLASS based on the above template and pass it to edit_class() 
+# make edits to TEST_CLASS based on the above template and pass it to edit_class()
 schema_explorer.edit_class(class_info=class_mod)
 
 # verify that the comment associated with TEST_CLASS has indeed been changed

--- a/examples/schema_explorer.py
+++ b/examples/schema_explorer.py
@@ -12,7 +12,7 @@ FIRST = 0
 
 # Create command-line argument parser
 parser = argparse.ArgumentParser()
-parser.add_argument("schema_class", nargs=1, metavar="schema_class", help="Name of class from schema.")
+parser.add_argument("schema_class", nargs=1, metavar="SCHEMA CLASS", help="Name of class from schema.")
 parser.add_argument("--config", "-c", help="Configuration YAML file.")
 args = parser.parse_args()
 
@@ -56,14 +56,14 @@ gv_digraph = schema_explorer.full_schema_graph()
 
 # since the graph is very big, we will generate an svg viz. of it
 gv_digraph.format = 'svg'
-gv_digraph.render('viz/HTAN-GV', view=True)
+gv_digraph.render('data/gviz/HTAN-GV', view=True)
 print("The svg visualization of the entire schema has been rendered.")
 
 # graph visualization of a sub-schema
 seq_subgraph = schema_explorer.sub_schema_graph(TEST_CLASS, "up")
 
 seq_subgraph.format = 'svg'
-seq_subgraph.render('SUB-GV', view=True)
+seq_subgraph.render('data/gviz/SUB-GV', view=True)
 print("The svg visualization of the sub-schema with {} as the source node has been rendered.".format(TEST_CLASS))
 
 # returns list of successors of a node

--- a/examples/schema_generator.py
+++ b/examples/schema_generator.py
@@ -11,10 +11,10 @@ FIRST = 0
 
 # Create command-line argument parser
 parser = argparse.ArgumentParser(allow_abbrev=False)
-parser.add_argument("schema_class", nargs=1, metavar="schema_class", help="Name of class from schema.")
-parser.add_argument("relationship", nargs=1, metavar="relationship_name", help="Name of relationship from schema.")
-parser.add_argument("component", nargs=1, metavar="component_name", help="Name of component from schema.")
-parser.add_argument("--schema_name", metavar="schema_name", help="Name of schema generated based on specified component.")
+parser.add_argument("schema_class", nargs=1, metavar="SCHEMA CLASS", help="Name of class from schema.")
+parser.add_argument("relationship", nargs=1, metavar="RELATIONSHIP NAME", help="Name of relationship from schema.")
+parser.add_argument("data_type", nargs=1, metavar="DATA TYPE NAME", help="Name of data type from schema.")
+parser.add_argument("--schema_name", metavar="SCHEMA NAME", help="Name of schema generated based on specified data_type.")
 parser.add_argument("--config", "-c", help="Configuration YAML file.")
 args = parser.parse_args()
 
@@ -58,20 +58,20 @@ if desc_nodes:
 else:
     print("The class does not have descendants.")
 
-# get all components associated with a given component
-TEST_COMP = args.component[FIRST]
-req_comps = schema_generator.get_component_requirements(TEST_COMP)
+# get all data_types associated with a given data_type
+TEST_DATA_TYPE = args.data_type[FIRST]
+req_comps = schema_generator.get_component_requirements(TEST_DATA_TYPE)
 
 if req_comps:
-    print("The component(s) that are associated with a given component: {}".format(req_comps))
+    print("The data type(s) that are associated with a given data type: {}".format(req_comps))
 else:
-    print("There are no components associated with {}".format(TEST_COMP))
+    print("There are no data_types associated with {}".format(TEST_DATA_TYPE))
 
 # get immediate dependencies that are related to a given node
-node_deps = schema_generator.get_node_dependencies(TEST_COMP)
+node_deps = schema_generator.get_node_dependencies(TEST_DATA_TYPE)
 
 if node_deps:
-    print("The immediate dependencies of {} are: {}".format(TEST_COMP, node_deps))
+    print("The immediate dependencies of {} are: {}".format(TEST_DATA_TYPE, node_deps))
 else:
     print("The node has no immediate dependencies.")
 
@@ -93,10 +93,10 @@ except KeyError:
 
 # gather dependencies and value-constraints for a particular node
 if args.schema_name:
-    json_schema = schema_generator.get_json_schema_requirements(TEST_COMP, args.schema_name + "-Schema")
+    json_schema = schema_generator.get_json_schema_requirements(TEST_DATA_TYPE, args.schema_name + "-Schema")
 else:
-    json_schema = schema_generator.get_json_schema_requirements(TEST_COMP, TEST_COMP + "-Schema")
+    json_schema = schema_generator.get_json_schema_requirements(TEST_DATA_TYPE, TEST_DATA_TYPE + "-Schema")
 
 
-print("The JSON schema based on {} as source node is:".format(TEST_COMP))
+print("The JSON schema based on {} as source node is:".format(TEST_DATA_TYPE))
 print(json_schema)

--- a/examples/schema_generator.py
+++ b/examples/schema_generator.py
@@ -6,15 +6,21 @@ import argparse
 from schematic.schemas.generator import SchemaGenerator
 from schematic import CONFIG
 
+# Constants (to avoid magic numbers)
+FIRST = 0
+
 # Create command-line argument parser
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(allow_abbrev=False)
+parser.add_argument("schema_class", nargs=1, metavar="schema_class", help="Name of class from schema.")
+parser.add_argument("relationship", nargs=1, metavar="relationship_name", help="Name of relationship from schema.")
+parser.add_argument("component", nargs=1, metavar="component_name", help="Name of component from schema.")
+parser.add_argument("--schema_name", metavar="schema_name", help="Name of schema generated based on specified component.")
 parser.add_argument("--config", "-c", help="Configuration YAML file.")
 args = parser.parse_args()
 
 # Load configuration
 config_data = CONFIG.load_config(args.config)
 
-# path to schema.org/JSON-LD schema ass specified in `config.yml`
 PATH_TO_JSONLD = CONFIG["model"]["input"]["location"]
 
 # create an object of SchemaGenerator() class
@@ -26,8 +32,8 @@ else:
     print("object of class SchemaGenerator could not be created.")
 
 # get list of the out-edges from a node based on a specific relationship
-TEST_NODE = "Sequencing"
-TEST_REL = "parentOf"
+TEST_NODE = args.schema_class[FIRST]
+TEST_REL = args.relationship[FIRST]
 
 out_edges = schema_generator.get_edges_by_relationship(TEST_NODE, TEST_REL)
 
@@ -53,7 +59,7 @@ else:
     print("The class does not have descendants.")
 
 # get all components associated with a given component
-TEST_COMP = "Patient"
+TEST_COMP = args.component[FIRST]
 req_comps = schema_generator.get_component_requirements(TEST_COMP)
 
 if req_comps:
@@ -86,7 +92,11 @@ except KeyError:
     print("Please try a valid node name.")
 
 # gather dependencies and value-constraints for a particular node
-json_schema = schema_generator.get_json_schema_requirements(TEST_COMP, "Patient-Schema")
+if args.schema_name:
+    json_schema = schema_generator.get_json_schema_requirements(TEST_COMP, args.schema_name + "-Schema")
+else:
+    json_schema = schema_generator.get_json_schema_requirements(TEST_COMP, TEST_COMP + "-Schema")
+
 
 print("The JSON schema based on {} as source node is:".format(TEST_COMP))
 print(json_schema)

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -10,7 +10,6 @@ from google.oauth2 import service_account
 
 from schematic import CONFIG
 
-
 # If modifying these scopes, delete the file token.pickle.
 SCOPES = ['https://www.googleapis.com/auth/spreadsheets', 'https://www.googleapis.com/auth/drive']
 


### PR DESCRIPTION
Added positional arguments to scripts in `examples/` folder. However, these scripts still show the usage of most of the functionalities/APIs within the core modules.

I will work on identifying key/atomic functionalities from these examples and put them into a `cli` folder as discussed. I'll start a new GitHub issue to discuss more about the contents of the CLI folder.

For now, feel free to test the working of these scripts through the command-line.