### PR TITLE
Fixing extra apostrophe added by google sheet API on string values

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -240,6 +240,7 @@ class ManifestGenerator(object):
                         "majorDimension":"COLUMNS",
                         "values":[values]
             }
+            
             target_range = 'Sheet2!' + target_col_letter + '2:' + target_col_letter + str(len(values) + 1)
             valid_values = [
                             { 
@@ -247,7 +248,7 @@ class ManifestGenerator(object):
                             }
             ]
 
-            response = self.sheet_service.spreadsheets().values().update(spreadsheetId=spreadsheet_id, range = target_range, valueInputOption = "RAW", body = body).execute()
+            response = self.sheet_service.spreadsheets().values().update(spreadsheetId=spreadsheet_id, range = target_range, valueInputOption = "USER_ENTERED", body = body).execute()
 
 
         # setup validation data request body


### PR DESCRIPTION
String values in data validation dropdowns when the latter are derived from workbook range were prefixed by ' in google API. That is now resolved. 

Addresses point 1 in https://github.com/Sage-Bionetworks/HTAN-coordination/issues/240#issuecomment-722706631