### PR TITLE
added submit_metadata_manifest() to metadata.py module

### DIFF
--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import networkx as nx
 import json
-import re
-import synapseclient
 from jsonschema import Draft7Validator, exceptions, validate, ValidationError
 
 # allows specifying explicit variable types


### PR DESCRIPTION
Wrap methods that are responsible for _validation_ of manifests for a given component, and _association_ of the same manifest file with a specified dataset, into a single method called `submit_metadata_manifest()`. We will need this method to expose through the CLI (and eventually the REST API).