### PR TITLE
refactor Synapse-specific code to live in synapse/store module only

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -685,9 +685,6 @@ class ManifestGenerator(object):
 
             syn_store = SynapseStorage()
 
-            # determine path to the user-specified manifests folder where the manifest should be downloaded to
-            manifests_folder_path = CONFIG["synapse"]["manifest_folder"]
-
             # get manifest file associated with given dataset
             syn_id_and_path = syn_store.getDatasetManifest(datasetId=dataset_id)
 
@@ -695,7 +692,7 @@ class ManifestGenerator(object):
             if syn_id_and_path and sheet_url:
 
                 # get synapse ID manifest associated with dataset
-                manifest_data = syn_store.syn.get(syn_id_and_path[0], downloadLocation=manifests_folder_path, ifcollision="overwrite.local")
+                manifest_data = syn_store.getDatasetManifest(datasetId=dataset_id, downloadFile=True)
 
                 # get URL of an empty manifest file created based on schema component
                 empty_manifest_url = self.get_empty_manifest()
@@ -707,7 +704,7 @@ class ManifestGenerator(object):
 
             # Case 2: manifest exists in the given dataset and dataframe is to be returned
             elif syn_id_and_path and not sheet_url:
-                manifest_data = syn_store.syn.get(syn_id_and_path[0], downloadLocation=manifests_folder_path, ifcollision="overwrite.local")
+                manifest_data = syn_store.getDatasetManifest(datasetId=dataset_id, downloadFile=True)
 
                 # convert downloaded/existing manifest contents into dataframe
                 manifest_data_df = pd.read_csv(manifest_data.path)

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -680,13 +680,10 @@ class ManifestGenerator(object):
             Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
         """
 
+        # get manifest associated with dataset `dataset_id`
         if dataset_id:
 
-            # get manifest associated with dataset `dataset_id`
-            syn = synapseclient.Synapse(configPath=CONFIG["definitions"]["synapse_config"])
-            syn.login()
-
-            syn_store = SynapseStorage(syn=syn)
+            syn_store = SynapseStorage()
 
             # determine path to the user-specified manifests folder where the manifest should be downloaded to
             manifests_folder_path = CONFIG["synapse"]["manifest_folder"]
@@ -698,7 +695,7 @@ class ManifestGenerator(object):
             if syn_id_and_path and sheet_url:
 
                 # get synapse ID manifest associated with dataset
-                manifest_data = syn.get(syn_id_and_path[0], downloadLocation=manifests_folder_path, ifcollision="overwrite.local")
+                manifest_data = syn_store.syn.get(syn_id_and_path[0], downloadLocation=manifests_folder_path, ifcollision="overwrite.local")
 
                 # get URL of an empty manifest file created based on schema component
                 empty_manifest_url = self.get_empty_manifest()
@@ -710,7 +707,7 @@ class ManifestGenerator(object):
 
             # Case 2: manifest exists in the given dataset and dataframe is to be returned
             elif syn_id_and_path and not sheet_url:
-                manifest_data = syn.get(syn_id_and_path[0], downloadLocation=manifests_folder_path, ifcollision="overwrite.local")
+                manifest_data = syn_store.syn.get(syn_id_and_path[0], downloadLocation=manifests_folder_path, ifcollision="overwrite.local")
 
                 # convert downloaded/existing manifest contents into dataframe
                 manifest_data_df = pd.read_csv(manifest_data.path)

--- a/schematic/synapse/store.py
+++ b/schematic/synapse/store.py
@@ -233,13 +233,17 @@ class SynapseStorage(object):
         return file_list
 
 
-    def getDatasetManifest(self, datasetId: str) -> List[str]:
+    def getDatasetManifest(self, datasetId: str, downloadFile: bool = False) -> List[str]:
         """Gets the manifest associated with a given dataset.
 
         Args:
             datasetId: synapse ID of a storage dataset.
+            downloadFile: boolean argument indicating if manifest file in dataset should be downloaded or not.
 
-        Returns: a tuple of manifest file ID and manifest name -- (fileId, fileName); returns empty list if no manifest is found.
+        Returns: 
+            A tuple of manifest file ID and manifest name -- (fileId, fileName); returns empty list if no manifest is found.
+            (or)
+            synapseclient.entity.File: A new Synapse Entity object of the appropriate type.
         """
 
         # get a list of files containing the manifest for this dataset (if any)
@@ -248,6 +252,15 @@ class SynapseStorage(object):
         if not manifest:
             return []
         else:
+            # if the downloadFile option is set to True
+            if downloadFile:
+                # retreive data in (synID, /dataset/path/) format
+                syn_id_and_path = manifest[0]
+
+                # pass synID to synapseclient.Synapse.get() method to download (and overwrite) file to a location
+                manifest_data = self.syn.get(syn_id_and_path[0], downloadLocation=CONFIG["synapse"]["manifest_folder"], ifcollision="overwrite.local")
+                return manifest_data
+            
             return manifest[0] # extract manifest tuple from list
 
 

--- a/schematic/synapse/store.py
+++ b/schematic/synapse/store.py
@@ -32,7 +32,6 @@ class SynapseStorage(object):
     """
 
     def __init__(self,
-                syn: synapseclient = None,
                 token: str = None # optional parameter retreived from browser cookie
                 ) -> None:
 
@@ -51,9 +50,7 @@ class SynapseStorage(object):
             ValueError: when Admin fileview cannot be found (describe further).
 
         Typical usage example:
-            syn_store = SynapseStorage(syn=syn)
-
-            where 'syn' is an object of type synapseclient.
+            syn_store = SynapseStorage()
         """
 
         # login using a token
@@ -65,12 +62,10 @@ class SynapseStorage(object):
             except synapseclient.core.exceptions.SynapseHTTPError:
                 print("Please enter a valid session token.")
                 return
-        elif syn: # if no token, assume a logged in synapseclient instance has been provided
-            if isinstance(syn, synapseclient.Synapse):
-                self.syn = syn
-            else:
-                print("Please make sure 'syn' argument is of type synapseclient.Synapse().")
-                return
+
+        # login using synapse credentials provided by user in .synapseConfig (default) file
+        self.syn = synapseclient.Synapse(configPath=CONFIG.SYNAPSE_CONFIG_PATH)
+        self.syn.login()
 
         try:
             self.storageFileview = CONFIG["synapse"]["master_fileview"]

--- a/schematic/synapse/store.py
+++ b/schematic/synapse/store.py
@@ -62,10 +62,10 @@ class SynapseStorage(object):
             except synapseclient.core.exceptions.SynapseHTTPError:
                 print("Please enter a valid session token.")
                 return
-
-        # login using synapse credentials provided by user in .synapseConfig (default) file
-        self.syn = synapseclient.Synapse(configPath=CONFIG.SYNAPSE_CONFIG_PATH)
-        self.syn.login()
+        else:
+            # login using synapse credentials provided by user in .synapseConfig (default) file
+            self.syn = synapseclient.Synapse(configPath=CONFIG.SYNAPSE_CONFIG_PATH)
+            self.syn.login()
 
         try:
             self.storageFileview = CONFIG["synapse"]["master_fileview"]


### PR DESCRIPTION
Based on a review comment in PR #353, this PR seeks to move Synapse-specific code (being used in [`get_manifest()` ](https://github.com/Sage-Bionetworks/schematic/blob/develop/schematic/manifest/generator.py#L686)), back into `synapse/store` module. For this, the [`SynapseStorage`](https://github.com/Sage-Bionetworks/schematic/blob/develop/schematic/synapse/store.py) class constructor had to be modified to be able to read from the `.synapseConfig` file (synapse configuration file as in `config.yml`). I created a separate PR to test it's downstream integration with `get_manifest()` first, before moving onto the method `submit_metadata_manifest()` as in PR #353.