### PR TITLE
CLI for submit_metadata_manifest()

### DIFF
--- a/schematic/__main__.py
+++ b/schematic/__main__.py
@@ -2,35 +2,30 @@
 
 import logging
 import click
+import click_log
 
 from schematic.manifest.commands import manifest as manifest_cli    # get manifest commands
+from schematic.models.commands import model as model_cli    # submit manifest commands
 
 logger = logging.getLogger()
-logger.info("Starting `schematic`")
+click_log.basic_config(logger)
 
 # dict() -> new empty dictionary
 CONTEXT_SETTINGS = dict(help_option_names=['--help', '-h'])  # help options
 
 # invoke_without_command=True -> forces the application not to show aids before losing them with a --h
 @click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
-@click.option('--quiet', 'verbosity', flag_value='quiet',
-              help=("Only display printed outputs in the console - "
-                    "i.e., no log messages."))
-@click.option('--debug', 'verbosity', flag_value='debug',
-              help="Include all debug log messages in the console.")
-def main(verbosity):
+@click_log.simple_verbosity_option(logger)
+def main():
     """
-    Command line interface for the `schematic` library.
+    Command line interface to the `schematic` backend services.
     """
-    if verbosity == 'quiet':
-        logger.setLevel(logging.ERROR)
-    elif verbosity == 'debug':
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
+    logger.info("Starting schematic...")
+    logger.debug("Existing sub-commands need to be used with schematic.")
 
 
 main.add_command(manifest_cli) # add manifest commands
+main.add_command(model_cli) # add model commands
 
 
 if __name__ == '__main__':

--- a/schematic/exceptions.py
+++ b/schematic/exceptions.py
@@ -43,10 +43,12 @@ class MissingConfigAndArgumentValueError(Exception):
             self.message = message
         else:
             config_keys_str = ' > '.join(config_keys)
-            self.message = f"The value corresponding to the CLI argument '--{arg_name}'" + \
-                           " doesn't exist. " \
-                           "Please provide a value for either the CLI argument or " \
-                           f"({config_keys_str}) in the configuration file."
+            self.message = (
+                f"The value corresponding to the CLI argument '--{arg_name}'"
+                " doesn't exist. "
+                "Please provide a value for either the CLI argument or "
+                f"({config_keys_str}) in the configuration file."
+            )
         super().__init__(self.message)
 
     def __str__(self):

--- a/schematic/exceptions.py
+++ b/schematic/exceptions.py
@@ -15,9 +15,11 @@ class MissingConfigValueError(Exception):
             self.message = message
         else:
             config_keys_str = ' > '.join(config_keys)
-            self.message = "The configuration value corresponding to the argument " + \
-                           f"({config_keys_str}) doesn't exist. " + \
-                           "Please provide a value in the configuration file."
+            self.message = (
+                "The configuration value corresponding to the argument "
+                f"({config_keys_str}) doesn't exist. "
+                "Please provide a value in the configuration file."
+            )
         super().__init__(self.message)
 
     def __str__(self):

--- a/schematic/exceptions.py
+++ b/schematic/exceptions.py
@@ -1,0 +1,51 @@
+from typing import Any, Sequence
+
+class MissingConfigValueError(Exception):
+    """Exception raised when configuration value not provided in config file.
+
+    Args:
+        config_keys: tuple of keys as present in config file.
+        message: custom/pre-defined error message to be returned.
+
+    Returns:
+        message.
+    """
+    def __init__(self, config_keys: Sequence[Any], message: str = None) -> str:
+        if message is not None:
+            self.message = message
+        else:
+            config_keys_str = ' > '.join(config_keys)
+            self.message = "The configuration value corresponding to the argument " + \
+                           f"({config_keys_str}) doesn't exist. " + \
+                           "Please provide a value in the configuration file."
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"{self.message}"
+
+
+class MissingConfigAndArgumentValueError(Exception):
+    """Exception raised when configuration value not provided in config file.
+
+    Args:
+        arg_name: CLI argument name.
+        config_keys: tuple of keys as present in config file.
+        message: custom/pre-defined error message to be returned.
+
+    Returns:
+        message.
+    """
+    def __init__(self, arg_name: str, 
+                config_keys: Sequence[Any], message: str = None) -> str:
+        if message is not None:
+            self.message = message
+        else:
+            config_keys_str = ' > '.join(config_keys)
+            self.message = f"The value corresponding to the CLI argument '--{arg_name}'" + \
+                           " doesn't exist. " \
+                           "Please provide a value for either the CLI argument or " \
+                           f"({config_keys_str}) in the configuration file."
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"{self.message}"

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -22,7 +22,7 @@ def manifest(): # use as `schematic manifest ...`
 @manifest.command('get', short_help='Prepares the manifest URL based on provided schema.')
 # define the optional arguments
 @click.option('-t', '--title', help='Title of generated manifest file.')
-@click.option('-d', '--data_type', help='Data type/component from JSON-LD schema to be used for manifest generation.')
+@click.option('-dt', '--data_type', help='Data type/component from JSON-LD schema to be used for manifest generation.')
 @click.option('-p', '--jsonld', help='Path to JSON-LD schema.')
 @click.option('-d', '--dataset_id', help='SynID of existing dataset on Synapse.')
 @click.option('-s', '--sheet_url', type=bool, help='Enable/disable URL generation.')
@@ -39,16 +39,16 @@ def get_manifest(title, data_type, jsonld,
     # optional parameters that need to be passed to ManifestGenerator()
     # can be read from config.yml as well
     title = fill_in_from_config(
-        "title", title, ("manifest", "title")
+        "title", ("manifest", "title"), title
     )
     data_type = fill_in_from_config(
-        "data_type", data_type, ("manifest", "data_type")
+        "data_type", ("manifest", "data_type"), data_type
     )
     jsonld = fill_in_from_config(
-        "jsonld", jsonld, ("model", "input", "location")
+        "jsonld", ("model", "input", "location"), jsonld
     )
     json_schema = fill_in_from_config(
-        "json_schema", json_schema, ("model", "input", "validation_schema")
+        "json_schema", ("model", "input", "validation_schema"), json_schema
     )
     # create object of type ManifestGenerator
     manifest_generator = ManifestGenerator(title=title,

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -3,7 +3,7 @@
 import click
 
 from schematic.manifest.generator import ManifestGenerator
-from schematic.utils.cli_utils import fill_in_from_config
+from schematic.utils.cli_utils import fill_in_from_config, query_dict
 from schematic import CONFIG
 
 CONTEXT_SETTINGS = dict(help_option_names=['--help', '-h'])  # help options
@@ -39,17 +39,18 @@ def get_manifest(title, data_type, jsonld,
     # optional parameters that need to be passed to ManifestGenerator()
     # can be read from config.yml as well
     title = fill_in_from_config(
-        "title", ("manifest", "title"), title
+        "title", title, ("manifest", "title")
     )
     data_type = fill_in_from_config(
-        "data_type", ("manifest", "data_type"), data_type
+        "data_type", data_type, ("manifest", "data_type")
     )
     jsonld = fill_in_from_config(
-        "jsonld", ("model", "input", "location"), jsonld
+        "jsonld", jsonld, ("model", "input", "location")
     )
     json_schema = fill_in_from_config(
-        "json_schema", ("model", "input", "validation_schema"), json_schema
+        "json_schema", json_schema, ("model", "input", "validation_schema")
     )
+
     # create object of type ManifestGenerator
     manifest_generator = ManifestGenerator(title=title,
                                            path_to_json_ld=jsonld,

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -7,7 +7,7 @@ import sys
 from jsonschema import ValidationError
 
 from schematic.models.metadata import MetadataModel
-from schematic.utils.cli_utils import query_dict, fill_in_from_config
+from schematic.utils.cli_utils import get_from_config, fill_in_from_config
 from schematic import CONFIG
 
 logger = logging.getLogger(__name__)
@@ -44,9 +44,9 @@ def submit_manifest(ctx, manifest_path, dataset_id, validate_component):
     """
     Running CLI with manifest validation (optional) and submission options.
     """
-    jsonld = query_dict(CONFIG.DATA, ("model", "input", "location"))
+    jsonld = get_from_config(CONFIG.DATA, ("model", "input", "location"))
 
-    model_file_type = query_dict(CONFIG.DATA, ("model", "input", "file_type"))
+    model_file_type = get_from_config(CONFIG.DATA, ("model", "input", "file_type"))
 
     metadata_model = MetadataModel(inputMModelLocation=jsonld, 
                                    inputMModelLocationType=model_file_type)

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -7,7 +7,7 @@ import sys
 from jsonschema import ValidationError
 
 from schematic.models.metadata import MetadataModel
-from schematic.utils.cli_utils import fill_in_from_config
+from schematic.utils.cli_utils import query_dict, fill_in_from_config
 from schematic import CONFIG
 
 logger = logging.getLogger(__name__)
@@ -44,13 +44,9 @@ def submit_manifest(ctx, manifest_path, dataset_id, validate_component):
     """
     Running CLI with manifest validation (optional) and submission options.
     """
-    jsonld = fill_in_from_config(
-        "jsonld", ("model", "input", "location")
-    )
+    jsonld = query_dict(CONFIG.DATA, ("model", "input", "location"))
 
-    model_file_type = fill_in_from_config(
-        "model_file_type", ("model", "input", "file_type")
-    )
+    model_file_type = query_dict(CONFIG.DATA, ("model", "input", "file_type"))
 
     metadata_model = MetadataModel(inputMModelLocation=jsonld, 
                                    inputMModelLocationType=model_file_type)
@@ -67,4 +63,3 @@ def submit_manifest(ctx, manifest_path, dataset_id, validate_component):
         logger.error(f"Component '{validate_component}' is not present in '{jsonld}', or is invalid.")
     except ValidationError:
         logger.error(f"Validation errors resulted while validating with '{validate_component}'.")
-

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import click
+import click_log
+import logging
+import sys
+from jsonschema import ValidationError
+
+from schematic.models.metadata import MetadataModel
+from schematic.utils.cli_utils import fill_in_from_config
+from schematic import CONFIG
+
+logger = logging.getLogger(__name__)
+click_log.basic_config(logger)
+
+CONTEXT_SETTINGS = dict(help_option_names=['--help', '-h'])  # help options
+
+# invoke_without_command=True -> forces the application not to show aids before losing them with a --h
+@click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
+@click_log.simple_verbosity_option(logger)
+@click.option('-c', '--config', envvar='SCHEMATIC_CONFIG', help='Path to schematic configuration file.')
+@click.pass_context
+def model(ctx, config): # use as `schematic model ...`
+    """
+    Sub-commands for Metadata Model related utilities/methods.
+    """
+    try:
+        logger.debug(f"Loading config file contents in '{config}'")
+        ctx.obj = CONFIG.load_config(config)
+    except ValueError as e:
+        logger.error("'--config' not provided or environment variable not set.")
+        logger.exception(e)
+        sys.exit(1)
+
+
+# prototype based on submit_metadata_manifest()
+@model.command('submit', short_help='Validation (optional) and submission of manifest files.')
+@click_log.simple_verbosity_option(logger)
+@click.option('-mp', '--manifest_path', help='Path to the user-populated manifest file.', required=True)
+@click.option('-d', '--dataset_id', help='SynID of existing dataset on Synapse.', required=True)
+@click.option('-vc', '--validate_component', help='Component to be used for validation', default=None)
+@click.pass_obj
+def submit_manifest(ctx, manifest_path, dataset_id, validate_component):
+    """
+    Running CLI with manifest validation (optional) and submission options.
+    """
+    jsonld = fill_in_from_config(
+        "jsonld", ("model", "input", "location")
+    )
+
+    model_file_type = fill_in_from_config(
+        "model_file_type", ("model", "input", "file_type")
+    )
+
+    metadata_model = MetadataModel(inputMModelLocation=jsonld, 
+                                   inputMModelLocationType=model_file_type)
+
+    try:
+        success = metadata_model.submit_metadata_manifest(manifest_path=manifest_path,
+                                                          dataset_id=dataset_id,
+                                                          validate_component=validate_component)
+
+        if success:
+            logger.info(f"File at '{manifest_path}' was successfully associated "
+                        f"with dataset '{dataset_id}'.")
+    except ValueError:
+        logger.error(f"Component '{validate_component}' is not present in '{jsonld}', or is invalid.")
+    except ValidationError:
+        logger.error(f"Validation errors resulted while validating with '{validate_component}'.")
+

--- a/schematic/schemas/generator.py
+++ b/schematic/schemas/generator.py
@@ -449,6 +449,11 @@ class SchemaGenerator(object):
 
         root_dependencies = self.get_adjacent_nodes_by_relationship(source_node, self.requires_dependency_relationship)
 
+        # if root_dependencies is empty it means that a class with name 'source_node' exists
+        # in the schema, but it is not a valid component
+        if not root_dependencies:
+            raise ValueError(f"'{source_node}' is not a valid component in the schema.")
+
         nodes_to_process += root_dependencies
 
         process_node = nodes_to_process.pop(0)

--- a/schematic/utils/cli_utils.py
+++ b/schematic/utils/cli_utils.py
@@ -39,17 +39,17 @@ def query_dict(
 
 def fill_in_from_config(
     arg_name: str,
-    arg_value: Any,
-    config_keys: Sequence[Any]
+    config_keys: Sequence[Any],
+    arg_value: Any = None
 ) -> Any:
     """Fill in a missing value from a configuration object.
 
     Args:
         arg_name: Name of the argument. Used for logging.
-        arg_value: Value of the argument provided at the
-            command line.
         config_keys: List of keys used to access a nested
             value in `config` corresponding to `arg_name`.
+        arg_value: Value of the argument provided at the
+            command line.
 
     Returns:
         The argument value, either from the calling context

--- a/schematic/utils/cli_utils.py
+++ b/schematic/utils/cli_utils.py
@@ -35,8 +35,29 @@ def query_dict(
             return None
         return dictionary.get(key)
 
+    return reduce(extract, keys, dictionary)
+
+
+def get_from_config(
+    dictionary: Mapping[Any, Any], keys: Sequence[Any]
+) -> Union[Any, None]:
+    """Access a nested configuration value from a yaml
+    configuration file.
+
+    Args:
+        dictionary: A dictionary containing anything.
+        keys: A sequence of values corresponding to keys
+            in `dictionary`.
+
+    Returns:
+        The nested value corresponding to the given series.
+
+    Raises:
+        MissingConfigValueError: When configuration value not
+            found in config.yml file for given key.
+    """
     # get configuration value from config file
-    config_value = reduce(extract, keys, dictionary)
+    config_value = query_dict(dictionary, keys)
 
     # if configuration value not present then raise Exception
     if config_value is None:
@@ -49,8 +70,8 @@ def query_dict(
         f"'{config_value}' is being read from the config file."
     )
 
-    return reduce(extract, keys, dictionary)
-
+    return config_value
+    
 
 def fill_in_from_config(
     arg_name: str,
@@ -79,10 +100,10 @@ def fill_in_from_config(
     if arg_value is not None:
         return arg_value
 
-    # raise Exception if both configuration value not present
+    # raise Exception if both, configuration value not present
     # in config file and CLI argument value is missing
     try:
-        config_value = query_dict(CONFIG.DATA, config_keys)
+        config_value = get_from_config(CONFIG.DATA, config_keys)
     except MissingConfigValueError:
         raise MissingConfigAndArgumentValueError(arg_name, config_keys)
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'jsonschema==3.2.0', 'fastjsonschema==2.14.4', 'orderedset==2.0.1',
         'google-api-python-client==1.7.9', 'google-auth-httplib2==0.0.3', 'google-auth-oauthlib==0.4.0', 
         'pandas', 'pygsheets>=2.0.1', 'inflection==0.3.1', 'synapseclient==2.2.0', 'setuptools>=41.2.0',
-        'pyyaml==5.3.1', 'click>=7.1.2'
+        'pyyaml==5.3.1', 'click>=7.1.2', 'click-log'
     ],
     entry_points={
         'console_scripts': 'schematic = schematic.__main__:main'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ coverage>=4.0.3
 pytest>=4.2.0
 pytest-cov>=2.7.1
 pluggy>=0.7.0
+pytest-mock>=3.5.1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import pytest
 
 from schematic.utils import general
 from schematic.utils import cli_utils
+from schematic.exceptions import MissingConfigValueError, MissingConfigAndArgumentValueError
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -50,6 +51,20 @@ class TestCliUtils:
         assert test_result_invalid is None
 
 
+    def test_get_from_config(self):
+
+        mock_dict = {"k1": {"k2": {"k3": "foobar"}}}
+        mock_keys_valid = ["k1", "k2", "k3"]
+        mock_keys_invalid = ["k1", "k2", "k4"]
+
+        test_result_valid = cli_utils.get_from_config(mock_dict, mock_keys_valid)
+        
+        assert test_result_valid == "foobar"
+
+        with pytest.raises(MissingConfigValueError):
+            cli_utils.get_from_config(mock_dict, mock_keys_invalid)
+                        
+
     def test_fill_in_from_config(self, mocker):
 
         jsonld = "/path/to/one"
@@ -75,7 +90,7 @@ class TestCliUtils:
         assert result2 == "/path/to/one"
         assert result3 == "/path/to/two"
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(MissingConfigAndArgumentValueError):
             cli_utils.fill_in_from_config(
                 "jsonld_none", jsonld_none, mock_keys_invalid
             )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,7 +50,7 @@ class TestCliUtils:
         assert test_result_invalid is None
 
 
-    def test_fill_in_from_config(self):
+    def test_fill_in_from_config(self, mocker):
 
         jsonld = "/path/to/one"
         jsonld_none = None
@@ -58,15 +58,17 @@ class TestCliUtils:
         mock_config = {"model": {"path": "/path/to/two"}}
         mock_keys = ["model", "path"]
         mock_keys_invalid = ["model", "file"]
+        
+        mocker.patch("schematic.CONFIG.DATA", mock_config)
 
         result1 = cli_utils.fill_in_from_config(
-            "jsonld", jsonld, None, mock_keys
+            "jsonld", jsonld, mock_keys
         )
         result2 = cli_utils.fill_in_from_config(
-            "jsonld", jsonld, mock_config, mock_keys
+            "jsonld", jsonld, mock_keys
         )
         result3 = cli_utils.fill_in_from_config(
-            "jsonld_none", jsonld_none, mock_config, mock_keys
+            "jsonld_none", jsonld_none, mock_keys
         )
 
         assert result1 == "/path/to/one"
@@ -75,10 +77,5 @@ class TestCliUtils:
 
         with pytest.raises(AssertionError):
             cli_utils.fill_in_from_config(
-                "jsonld_none", jsonld_none, None, mock_keys
-            )
-
-        with pytest.raises(AssertionError):
-            cli_utils.fill_in_from_config(
-                "jsonld_none", jsonld_none, mock_config, mock_keys_invalid
+                "jsonld_none", jsonld_none, mock_keys_invalid
             )


### PR DESCRIPTION
This PR addresses the issue of providing a way to call `submit_metadata_manifest()` though the CLI. The `submit_metadata_manifest()` method is a wrapper that encapsulates optional validation and submission of user-populated metadata.

To test this new utility, execute the following:

```bash
$ python -m schematic model --config /path/to/config.yml submit --manifest_path /path/to/manifest.csv --dataset_id synID --validate_component some_valid_component
```

_Note: The structure/pattern followed for `submit_metadata_manifest()` isn't the same as `get_manifest()`. After the review, I will adapt the pattern we decide on for `submit_metadata_manifest()` to `get_manifest()` as well._