### PR TITLE
test_fill_in_from_config() test to accommodate changes to fill_in_from_config() implementation

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ coverage>=4.0.3
 pytest>=4.2.0
 pytest-cov>=2.7.1
 pluggy>=0.7.0
+pytest-mock>=3.5.1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,13 +62,13 @@ class TestCliUtils:
         mocker.patch("schematic.CONFIG.DATA", mock_config)
 
         result1 = cli_utils.fill_in_from_config(
-            "jsonld", mock_keys, jsonld
+            "jsonld", jsonld, mock_keys
         )
         result2 = cli_utils.fill_in_from_config(
-            "jsonld", mock_keys, jsonld
+            "jsonld", jsonld, mock_keys
         )
         result3 = cli_utils.fill_in_from_config(
-            "jsonld_none", mock_keys, jsonld_none
+            "jsonld_none", jsonld_none, mock_keys
         )
 
         assert result1 == "/path/to/one"
@@ -77,5 +77,5 @@ class TestCliUtils:
 
         with pytest.raises(AssertionError):
             cli_utils.fill_in_from_config(
-                "jsonld_none", mock_keys_invalid, jsonld_none
+                "jsonld_none", jsonld_none, mock_keys_invalid
             )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,7 +50,7 @@ class TestCliUtils:
         assert test_result_invalid is None
 
 
-    def test_fill_in_from_config(self):
+    def test_fill_in_from_config(self, mocker):
 
         jsonld = "/path/to/one"
         jsonld_none = None
@@ -58,15 +58,17 @@ class TestCliUtils:
         mock_config = {"model": {"path": "/path/to/two"}}
         mock_keys = ["model", "path"]
         mock_keys_invalid = ["model", "file"]
+        
+        mocker.patch("schematic.CONFIG.DATA", mock_config)
 
         result1 = cli_utils.fill_in_from_config(
-            "jsonld", jsonld, None, mock_keys
+            "jsonld", mock_keys, jsonld
         )
         result2 = cli_utils.fill_in_from_config(
-            "jsonld", jsonld, mock_config, mock_keys
+            "jsonld", mock_keys, jsonld
         )
         result3 = cli_utils.fill_in_from_config(
-            "jsonld_none", jsonld_none, mock_config, mock_keys
+            "jsonld_none", mock_keys, jsonld_none
         )
 
         assert result1 == "/path/to/one"
@@ -75,10 +77,5 @@ class TestCliUtils:
 
         with pytest.raises(AssertionError):
             cli_utils.fill_in_from_config(
-                "jsonld_none", jsonld_none, None, mock_keys
-            )
-
-        with pytest.raises(AssertionError):
-            cli_utils.fill_in_from_config(
-                "jsonld_none", jsonld_none, mock_config, mock_keys_invalid
+                "jsonld_none", mock_keys_invalid, jsonld_none
             )


### PR DESCRIPTION
`CONFIG.DATA` had to be mocked in order to make sure `fill_in_from_config()` works correctly.

Note: The test on L#76 is the same as the test on L#69, right @BrunoGrandePhD?