### PR TITLE
Remove completely empty columns/rows from manifest dataframe

### DIFF
--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -13,6 +13,7 @@ from schematic.schemas.explorer import SchemaExplorer
 from schematic.manifest.generator import ManifestGenerator
 from schematic.schemas.generator import SchemaGenerator
 from schematic.synapse.store import SynapseStorage
+from schematic.utils.df_utils import trim_commas_df
 
 class MetadataModel(object):
     """Metadata model wrapper around schema.org specification graph.
@@ -175,19 +176,16 @@ class MetadataModel(object):
         errors = []
  
         # get annotations from manifest (array of json annotations corresponding to manifest rows)
-        manifest = pd.read_csv(manifestPath).fillna("")
-
-
-        """ 
-        check if each of the provided annotation columns has validation rule 'list'
-        if so, assume annotation for this column are comma separated list of multi-value annotations
-        convert multi-valued annotations to list
-        """
+        manifest = pd.read_csv(manifestPath)    # read manifest csv file as is from manifest path
+        manifest = trim_commas_df(manifest).fillna("")  # apply cleaning logic as part of pre-processing step
+ 
+        # check if each of the provided annotation columns has validation rule 'list'
+        # if so, assume annotation for this column are comma separated list of multi-value annotations
+        # convert multi-valued annotations to list
         for col in manifest.columns:
             
             # remove trailing/leading whitespaces from manifest
             manifest.applymap(lambda x: x.strip() if isinstance(x, str) else x)
-
 
             # convert manifest values to string
             # TODO: when validation handles annotation types as validation rules 
@@ -283,4 +281,3 @@ class MetadataModel(object):
         print("Validation was not performed on manifest file before association.")
         
         return True
-        

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -57,3 +57,16 @@ def update_df(existing_df: pd.DataFrame, new_df: pd.DataFrame, idx_key: str) -> 
     updated_df = updated_df[existing_df.columns]
 
     return updated_df
+
+
+def trim_commas_df(df: pd.DataFrame):
+    """Removes empty columns and empty rows from pandas dataframe (manifest data).
+
+    Args:
+        df: pandas dataframe with data from manifest file.
+
+    Returns:
+        df: cleaned-up pandas dataframe.
+    """
+    return df.dropna(how='all', axis=1) \
+             .dropna(how='all', axis=0)


### PR DESCRIPTION
Added utility function `trim_commas_df ` (to `df_utils`) to remove completely empty columns and rows from a manifest file. This is an important pre-processing step (method) which can be run on the metadata (manifest) dataframe before we use it for further processing.

Note: This is a fix to resolve issue #376. I've also tested this new backend with an instance of the DC App, and it works. It doesn't "time out" like the previous behaviour.

I'm thinking if I should push an update to the `main` branch as well, so @xdoan can integrate the fix? I'll create a branch called `main-trailiing-commas-fix`. @xdoan can test with that branch and see if the DC App works properly. If yes, then we can merge to `main` as well. 