### PR TITLE
tests for io_utils functions

### DIFF
--- a/schematic/utils/io_utils.py
+++ b/schematic/utils/io_utils.py
@@ -11,7 +11,7 @@ def load_json(file_path):
     """
     if file_path.startswith("http"):
         with urllib.request.urlopen(file_path) as url:
-            data = json.loads(url.read().decode())
+            data = json.loads(url.read())
             return data
     # handle file path
     else:

--- a/schematic/utils/io_utils.py
+++ b/schematic/utils/io_utils.py
@@ -11,7 +11,7 @@ def load_json(file_path):
     """
     if file_path.startswith("http"):
         with urllib.request.urlopen(file_path) as url:
-            data = json.loads(url.read())
+            data = json.loads(url.read().decode('utf-8'))
             return data
     # handle file path
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -145,7 +145,7 @@ class TestIOUtils:
                                     return_value = FakeResponse(data=json.dumps([
                                         {'k1': 'v1'}, 
                                         {'k2': 'v2'}]
-                                    ))
+                                    ).encode('utf-8'))
                                     )
         
         url_result = io_utils.load_json("http://example.com")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -173,13 +173,8 @@ class TestIOUtils:
         assert expected == json_str
 
 
-    def test_load_default(self, mocker):
+    def test_load_default(self):
         
-        biothings_schema_path = "tests/data/etc/data_models/biothings.model.jsonld"
-
-        mocker.patch("schematic.LOADER.filename",
-                    return_value=os.path.normpath(biothings_schema_path))
-
         biothings_schema = io_utils.load_default()
 
         expected_ctx_keys = ['bts', 'rdf', 'rdfs', 'schema', 'xsd']
@@ -191,13 +186,8 @@ class TestIOUtils:
         assert expected_no_of_keys == actual_no_of_keys
 
 
-    def test_load_schema_org(self, mocker):
+    def test_load_schema_org(self):
         
-        schema_org_schema_path = "tests/data/etc/data_models/schema_org.model.jsonld"
-
-        mocker.patch("schematic.LOADER.filename",
-                    return_value=os.path.normpath(schema_org_schema_path))
-
         schema_org_schema = io_utils.load_schemaorg()
 
         expected_ctx_keys = ['rdf', 'rdfs', 'xsd']


### PR DESCRIPTION
This PR adds tests for the utilities in `schematic.utils.io_utils`.

Note: Removing the `.decode()` from `load_json()` function because there's no need to decode an object that has already been decoded (into a `str`).