### PR TITLE
Enable CI for testing schematic using GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest tests/ --doctest-modules --cov=schematic --cov-report=html
+        pytest tests/ --cov=schematic --cov-report=html
     - name: Upload pytest test results
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r test-requirements.txt
-        pip install -r requirements.txt
-        pip install .
+        python -m pip install -r test-requirements.txt
+        python -m pip install -r requirements.txt
+        python -m pip install .
     # Disabling linting until we agree to turn it on
     # - name: Lint with flake8
     #   run: |
@@ -35,7 +35,8 @@ jobs:
     #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest tests/ --cov=schematic
+        pytest --cov=schematic tests/
+    # Disabling HTML coverage reports for now
     #   run: |
     #     pytest tests/ --cov=schematic --cov-report=html
     # - name: Upload pytest test results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+# Built from:
+# https://docs.github.com/en/actions/guides/building-and-testing-python
+# https://github.com/Sage-Bionetworks/challengeutils/blob/master/.github/workflows/pythonapp.yml
+
+name: Test schematic
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r test-requirements.txt
+        pip install -r requirements.txt
+        pip install .
+    # Disabling linting until we agree to turn it on
+    # - name: Lint with flake8
+    #   run: |
+    #     # stop the build if there are Python syntax errors or undefined names
+    #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest tests/ --doctest-modules --cov=schematic --cov-report=html
+    - name: Upload pytest test results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest-results-${{ matrix.python-version }}
+        path: htmlcov
+      # Use always() to always run this step to publish test results when there are test failures
+      if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,13 @@ jobs:
     #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest tests/ --cov=schematic --cov-report=html
-    - name: Upload pytest test results
-      uses: actions/upload-artifact@v2
-      with:
-        name: pytest-results-${{ matrix.python-version }}
-        path: htmlcov
-      # Use always() to always run this step to publish test results when there are test failures
-      if: ${{ always() }}
+        pytest tests/ --cov=schematic
+    #   run: |
+    #     pytest tests/ --cov=schematic --cov-report=html
+    # - name: Upload pytest test results
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: pytest-results-${{ matrix.python-version }}
+    #     path: htmlcov
+    #   # Use always() to always run this step to publish test results when there are test failures
+    #   if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,14 +35,11 @@ jobs:
     #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest --cov=schematic tests/
-    # Disabling HTML coverage reports for now
-    #   run: |
-    #     pytest tests/ --cov=schematic --cov-report=html
-    # - name: Upload pytest test results
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: pytest-results-${{ matrix.python-version }}
-    #     path: htmlcov
-    #   # Use always() to always run this step to publish test results when there are test failures
-    #   if: ${{ always() }}
+        pytest
+    - name: Upload pytest test results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest-results-${{ matrix.python-version }}
+        path: htmlcov
+      # Use always() to always run this step to publish test results when there are test failures
+      if: ${{ always() }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
+addopts = --verbose --cov-report=term --cov-report=html:htmlcov --cov=schematic/
+testpaths =
+    tests
 filterwarnings =
     ignore::DeprecationWarning


### PR DESCRIPTION
These tests will run on every push and every pull request. PRs will be blocked until all tests pass. I based my CI workflow on @thomasyu888's `challengeutils` [repository](https://github.com/Sage-Bionetworks/challengeutils/blob/master/.github/workflows/pythonapp.yml). (Thanks, Tom!)

I was initially getting 0% coverage on GitHub Actions whereas local tests were giving me sensible results. I think I resolved this by adding the `__init__.py` file in `tests/` based on this [SO post](https://stackoverflow.com/a/60579142). ¯\_(ツ)_/¯

Here's an [example run](https://github.com/Sage-Bionetworks/schematic/actions/runs/510766792). At the bottom of this page, you can find HTML code coverage reports. I've attached an [example here](https://github.com/Sage-Bionetworks/schematic/files/5870404/pytest-results-3.8.zip) (open `index.html` once decompressed). 

For more details, you can expand the "Test with pytest" section in this [specific job](https://github.com/Sage-Bionetworks/schematic/runs/1765971517?check_suite_focus=true) (Python 3.8). Example output included in the Details section below. 

<details>
```
============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /opt/hostedtoolcache/Python/3.8.6/x64/bin/python
cachedir: .pytest_cache
rootdir: /home/runner/work/schematic/schematic, configfile: pytest.ini, testpaths: tests
plugins: mock-3.5.1, cov-2.11.1
collecting ... collected 8 items

tests/test_configuration.py::TestConfiguration::test_load_yaml_valid PASSED [ 12%]
tests/test_configuration.py::TestConfiguration::test_load_yaml_invalid PASSED [ 25%]
tests/test_utils.py::TestGeneral::test_find_duplicates PASSED            [ 37%]
tests/test_utils.py::TestGeneral::test_dict2list_with_dict PASSED        [ 50%]
tests/test_utils.py::TestGeneral::test_dict2list_with_list PASSED        [ 62%]
tests/test_utils.py::TestCliUtils::test_query_dict PASSED                [ 75%]
tests/test_utils.py::TestCliUtils::test_get_from_config PASSED           [ 87%]
tests/test_utils.py::TestCliUtils::test_fill_in_from_config PASSED       [100%]

----------- coverage: platform linux, python 3.8.6-final-0 -----------
Name                                  Stmts   Miss  Cover
---------------------------------------------------------
schematic/__init__.py                     2      0   100%
schematic/__main__.py                    17     17     0%
schematic/configuration.py               64     34    47%
schematic/exceptions.py                  19      4    79%
schematic/loader.py                      41     20    51%
schematic/manifest/__init__.py            1      0   100%
schematic/manifest/commands.py           24     24     0%
schematic/manifest/generator.py         236    207    12%
schematic/models/__init__.py              1      1     0%
schematic/models/commands.py             41     41     0%
schematic/models/metadata.py             87     87     0%
schematic/schemas/__init__.py             3      0   100%
schematic/schemas/curie.py               50     30    40%
schematic/schemas/explorer.py           447    395    12%
schematic/schemas/generator.py          197    168    15%
schematic/schemas/validator.py           79     59    25%
schematic/synapse/__init__.py             1      0   100%
schematic/synapse/store.py              163    140    14%
schematic/utils/__init__.py               8      0   100%
schematic/utils/cli_utils.py             31      1    97%
schematic/utils/csv_utils.py            404    404     0%
schematic/utils/curie_utils.py           37     33    11%
schematic/utils/df_utils.py              23     19    17%
schematic/utils/general.py               17      7    59%
schematic/utils/google_api_utils.py      44     30    32%
schematic/utils/io_utils.py              23     15    35%
schematic/utils/schema_utils.py         151    141     7%
schematic/utils/validate_utils.py        19     12    37%
schematic/utils/viz_utils.py              8      6    25%
schematic/version.py                      1      1     0%
---------------------------------------------------------
TOTAL                                  2239   1896    15%
Coverage HTML written to dir htmlcov


============================== 8 passed in 3.74s ===============================
```
</details>