### PR TITLE
trim_commas_df to trim only trailing empty columns

### DIFF
--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 
 def normalize_table(df: pd.DataFrame, primary_key:str) -> pd.DataFrame:
     
@@ -43,7 +44,7 @@ def update_df(existing_df: pd.DataFrame, new_df: pd.DataFrame, idx_key: str) -> 
     # filter to keep only updated values across all columns in the schema
     for col in existing_df.columns:
         if col != idx_key and col != 'ROW_ID' and col != 'ROW_VERSION':
-            existing_col = col + "_existing"
+            # existing_col = col + "_existing"
             new_col = col + "_new"
 
             updated_df[col] = updated_df[new_col]
@@ -60,7 +61,7 @@ def update_df(existing_df: pd.DataFrame, new_df: pd.DataFrame, idx_key: str) -> 
 
 
 def trim_commas_df(df: pd.DataFrame):
-    """Removes empty columns and empty rows from pandas dataframe (manifest data).
+    """Removes empty (trailing) columns and empty rows from pandas dataframe (manifest data).
 
     Args:
         df: pandas dataframe with data from manifest file.
@@ -68,5 +69,9 @@ def trim_commas_df(df: pd.DataFrame):
     Returns:
         df: cleaned-up pandas dataframe.
     """
-    return df.dropna(how='all', axis=1) \
-             .dropna(how='all', axis=0)
+    # remove all columns which have substring "Unnamed" in them
+    df = df.loc[:, ~df.columns.str.contains('^Unnamed')]
+
+    # remove all completely empty rows
+    df = df.dropna(how='all', axis=0)
+    return df

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import numpy as np
 
 def normalize_table(df: pd.DataFrame, primary_key:str) -> pd.DataFrame:
     


### PR DESCRIPTION
A slight modification was necessary for the `trim_commas_df()`. This is the method that was written to address issue #376. When writing tests for the utilities in `df_utils` I realized, `.dropna(how='all', axis=0)` dropped all empty columns and that wasn't desirable behaviour, since our manifests are allowed to have completely empty columns. The manifest that we used to test from issue #376 didn't have any empty columns besides the last/trailing ones, so this issue didn't come up.

I've made a slight modification to the function `trim_commas_df()` to trim out/drop only the those columns which have the substring "Unnamed" in them. As for empty rows, it shouldn't matter where the empty rows are we can remove them freely.