### PR TITLE
tests for df_utils module

### DIFF
--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 
 def normalize_table(df: pd.DataFrame, primary_key:str) -> pd.DataFrame:
     
@@ -43,7 +44,7 @@ def update_df(existing_df: pd.DataFrame, new_df: pd.DataFrame, idx_key: str) -> 
     # filter to keep only updated values across all columns in the schema
     for col in existing_df.columns:
         if col != idx_key and col != 'ROW_ID' and col != 'ROW_VERSION':
-            existing_col = col + "_existing"
+            # existing_col = col + "_existing"
             new_col = col + "_new"
 
             updated_df[col] = updated_df[new_col]
@@ -60,7 +61,7 @@ def update_df(existing_df: pd.DataFrame, new_df: pd.DataFrame, idx_key: str) -> 
 
 
 def trim_commas_df(df: pd.DataFrame):
-    """Removes empty columns and empty rows from pandas dataframe (manifest data).
+    """Removes empty (trailing) columns and empty rows from pandas dataframe (manifest data).
 
     Args:
         df: pandas dataframe with data from manifest file.
@@ -68,5 +69,9 @@ def trim_commas_df(df: pd.DataFrame):
     Returns:
         df: cleaned-up pandas dataframe.
     """
-    return df.dropna(how='all', axis=1) \
-             .dropna(how='all', axis=0)
+    # remove all columns which have substring "Unnamed" in them
+    df = df.loc[:, ~df.columns.str.contains('^Unnamed')]
+
+    # remove all completely empty rows
+    df = df.dropna(how='all', axis=0)
+    return df

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import numpy as np
 
 def normalize_table(df: pd.DataFrame, primary_key:str) -> pd.DataFrame:
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 
 import logging
 import pytest
+import pandas as pd
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -14,3 +15,13 @@ def mock_creds():
         'creds': 'mock_creds'
     }
     yield mock_creds
+
+
+@pytest.fixture()
+def synapse_manifest():
+    return pd.read_csv("tests/data/mock_manifests/synapse_manifest.csv")
+
+
+@pytest.fixture()
+def local_manifest():
+    return pd.read_csv("tests/data/mock_manifests/local_manifest.csv")

--- a/tests/data/mock_manifests/local_manifest.csv
+++ b/tests/data/mock_manifests/local_manifest.csv
@@ -1,0 +1,10 @@
+Component,Days to Follow Up,Adverse Event,Progression or Recurrence,Barretts Esophagus Goblet Cells Present,BMI,Cause of Response,Comorbidity,Comorbidity Method of Diagnosis,Days to Adverse Event,Days to Comorbidity,Diabetes Treatment Type,Disease Response,DLCO Ref Predictive Percent,ECOG Performance Status,FEV1 FVC Post Bronch Percent,FEV 1 FVC Pre Bronch Percent,FEV1 Ref Post Bronch Percent,FEV1 Ref Pre Bronch Percent,Height,Hepatitis Sustained Virological Response,HPV Positive Type,Karnofsky Performance Status,Menopause Status,Pancreatitis Onset Year,Reflux Treatment Type,Risk Factor,Risk Factor Treatment,Viral Hepatitis Serologies,Weight,Days to Progression,Days to Progression Free,Days to Recurrence,Progression or Recurrence Anatomic Site,Progression or Recurrence Type,entityId,HTAN Participant ID
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22249015,455.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22249915,456.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22687161,457.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22688035,458.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22978930,459.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22978946,460.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22978975,461.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22979177,462.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn21989551,454.0

--- a/tests/data/mock_manifests/synapse_manifest.csv
+++ b/tests/data/mock_manifests/synapse_manifest.csv
@@ -1,0 +1,10 @@
+Component,Days to Follow Up,Adverse Event,Progression or Recurrence,Barretts Esophagus Goblet Cells Present,BMI,Cause of Response,Comorbidity,Comorbidity Method of Diagnosis,Days to Adverse Event,Days to Comorbidity,Diabetes Treatment Type,Disease Response,DLCO Ref Predictive Percent,ECOG Performance Status,FEV1 FVC Post Bronch Percent,FEV 1 FVC Pre Bronch Percent,FEV1 Ref Post Bronch Percent,FEV1 Ref Pre Bronch Percent,Height,Hepatitis Sustained Virological Response,HPV Positive Type,Karnofsky Performance Status,Menopause Status,Pancreatitis Onset Year,Reflux Treatment Type,Risk Factor,Risk Factor Treatment,Viral Hepatitis Serologies,Weight,Days to Progression,Days to Progression Free,Days to Recurrence,Progression or Recurrence Anatomic Site,Progression or Recurrence Type,entityId,HTAN Participant ID
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22249015,455.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22249915,456.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22687161,457.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22688035,458.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22978930,459.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22978946,460.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22978975,461.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn22979177,463.0
+FollowUp,73.0,,Not Reported,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,syn21989551,454.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,18 @@
 import logging
 import pytest
+import json
+import os
+import pandas as pd
+import numpy as np
+
+from pandas.testing import assert_frame_equal
 
 from schematic.utils import general
 from schematic.utils import cli_utils
+from schematic.utils import io_utils
+from schematic.utils import df_utils
 from schematic.exceptions import MissingConfigValueError, MissingConfigAndArgumentValueError
+from schematic import LOADER
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -94,3 +103,155 @@ class TestCliUtils:
             cli_utils.fill_in_from_config(
                 "jsonld_none", jsonld_none, mock_keys_invalid
             )
+
+
+class FakeResponse:
+    status: int
+    data: bytes
+
+    def __init__(self, *, data: bytes):
+        self.data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        pass
+
+    def read(self):
+        self.status = 200 if self.data is not None else 404
+        return self.data
+
+    def close(self):
+        pass
+
+
+class TestIOUtils:
+
+    def test_json_load(self, tmpdir):
+
+        json_file = tmpdir.join("example.json")
+        json_file.write_text(json.dumps([
+            {'k1': 'v1'},
+            {'k2': 'v2'}
+        ]), encoding="utf-8")
+
+        with open(json_file, encoding='utf-8') as f:
+            expected = json.load(f)
+
+        local_result = io_utils.load_json(str(json_file))
+
+        assert local_result == expected
+
+    
+    def test_json_load_online(self, mocker):
+
+        mock_urlopen = mocker.patch("urllib.request.urlopen",
+                                    return_value = FakeResponse(data=json.dumps([
+                                        {'k1': 'v1'}, 
+                                        {'k2': 'v2'}]
+                                    ).encode('utf-8'))
+                                    )
+        
+        url_result = io_utils.load_json("http://example.com")
+        assert url_result == [
+            {'k1': 'v1'},
+            {'k2': 'v2'}
+        ]
+
+        assert mock_urlopen.call_count == 1
+
+    
+    def test_export_json(self, tmpdir):
+
+        json_str = json.dumps([
+            {'k1': 'v1'},
+            {'k2': 'v2'}
+        ])
+
+        export_file = tmpdir.join("export_json_expected.json")
+        io_utils.export_json(json_str, export_file)
+
+        with open(export_file, encoding='utf-8') as f:
+            expected = json.load(f)
+
+        assert expected == json_str
+
+
+    def test_load_default(self):
+        
+        biothings_schema = io_utils.load_default()
+
+        expected_ctx_keys = ['bts', 'rdf', 'rdfs', 'schema', 'xsd']
+        actual_ctx_keys = list(biothings_schema["@context"].keys())
+        assert expected_ctx_keys == actual_ctx_keys
+
+        expected_no_of_keys = 146
+        actual_no_of_keys = len(biothings_schema["@graph"])
+        assert expected_no_of_keys == actual_no_of_keys
+
+
+    def test_load_schema_org(self):
+        
+        schema_org_schema = io_utils.load_schemaorg()
+
+        expected_ctx_keys = ['rdf', 'rdfs', 'xsd']
+        actual_ctx_keys = list(schema_org_schema["@context"].keys())
+        assert expected_ctx_keys == actual_ctx_keys
+
+        expected_no_of_graphs = 6
+        actual_no_of_graphs = len(schema_org_schema["@graph"])
+        assert expected_no_of_graphs == actual_no_of_graphs
+
+        expected_no_of_keys_G1 = 1621
+        actual_no_of_keys_G1 = len(schema_org_schema["@graph"][0]["@graph"])
+        assert expected_no_of_keys_G1 == actual_no_of_keys_G1
+
+        expected_no_of_keys_G2 = 405
+        actual_no_of_keys_G2 = len(schema_org_schema["@graph"][1]["@graph"])
+        assert expected_no_of_keys_G2 == actual_no_of_keys_G2
+
+        expected_no_of_keys_G3 = 7
+        actual_no_of_keys_G3 = len(schema_org_schema["@graph"][2]["@graph"])
+        assert expected_no_of_keys_G3 == actual_no_of_keys_G3
+
+        expected_no_of_keys_G4 = 223
+        actual_no_of_keys_G4 = len(schema_org_schema["@graph"][3]["@graph"])
+        assert expected_no_of_keys_G4 == actual_no_of_keys_G4
+
+        expected_no_of_keys_G5 = 31
+        actual_no_of_keys_G5 = len(schema_org_schema["@graph"][4]["@graph"])
+        assert expected_no_of_keys_G5 == actual_no_of_keys_G5
+
+        expected_no_of_keys_G6 = 27
+        actual_no_of_keys_G6 = len(schema_org_schema["@graph"][5]["@graph"])
+        assert expected_no_of_keys_G6 == actual_no_of_keys_G6
+
+
+class TestDfUtils:
+
+    def test_update_df_col_present(self, synapse_manifest, local_manifest):
+
+        col_pres_res = df_utils.update_df(local_manifest, synapse_manifest, "entityId")
+
+        assert_frame_equal(col_pres_res, synapse_manifest)
+
+    
+    def test_update_df_col_absent(self, synapse_manifest, local_manifest):
+
+        col_abs_res = df_utils.update_df(local_manifest, synapse_manifest, "Col_Not_In_Dfs")
+
+        assert_frame_equal(col_abs_res, local_manifest)
+
+
+    def test_trim_commas_df(self, local_manifest):
+
+        nan_row = pd.DataFrame([[np.nan] * len(local_manifest.columns)], 
+                                columns=local_manifest.columns)
+
+        df_with_nans = local_manifest.append(nan_row, ignore_index=True)
+
+        df_with_nans["Unnamed: 1"] = np.nan
+        trimmed_df = df_utils.trim_commas_df(df_with_nans)
+
+        assert_frame_equal(trimmed_df, local_manifest)


### PR DESCRIPTION
Added tests for utilities in the `df_utils` module. 

_Note_: We need to modify the `normalize_table()` function, since it doesn't seem correct semantically. I didn't write any test cases for it since we need to decide what the behaviour needs to be and since it isn't being used anywhere yet.