### PR TITLE
trim_commas_df to remove only trailing empty columns

### DIFF
--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -60,11 +60,15 @@ def update_df(existing_df: pd.DataFrame, new_df: pd.DataFrame, idx_key: str) -> 
 
 
 def trim_commas_df(df: pd.DataFrame):
-    """Removes empty columns and empty rows from pandas dataframe (manifest data).
+    """Removes empty (trailing) columns and empty rows from pandas dataframe (manifest data).
     Args:
         df: pandas dataframe with data from manifest file.
     Returns:
         df: cleaned-up pandas dataframe.
     """
-    return df.dropna(how='all', axis=1) \
-             .dropna(how='all', axis=0) 
+    # remove all columns which have substring "Unnamed" in them
+    df = df.loc[:, ~df.columns.str.contains('^Unnamed')]
+
+    # remove all completely empty rows
+    df = df.dropna(how='all', axis=0)
+    return df


### PR DESCRIPTION
A replica of PR #389 (PR'd into `develop` branch).