### PR TITLE
replace print statements with logging - synapse/store

### DIFF
--- a/schematic/exceptions.py
+++ b/schematic/exceptions.py
@@ -53,3 +53,28 @@ class MissingConfigAndArgumentValueError(Exception):
 
     def __str__(self):
         return f"{self.message}"
+
+
+class AccessCredentialsError(Exception):
+    """Exception raised when provided access credentials cannot be resolved.
+    
+    Args:
+        project: Platform/project (e.g., synID of a project)
+        message: custom/pre-defined error message to be returned.
+
+    Returns:
+        message.
+    """
+
+    def __init__(self, project: str, message: str = None) -> str:
+        if message is not None:
+            self.message = message
+        else:
+            self.message = (
+                f"Your access to '{project}'' could not be resolved. "
+                "Please check your credentials and try again."
+            )
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"{self.message}"

--- a/schematic/exceptions.py
+++ b/schematic/exceptions.py
@@ -11,15 +11,16 @@ class MissingConfigValueError(Exception):
         message.
     """
     def __init__(self, config_keys: Sequence[Any], message: str = None) -> str:
-        if message is not None:
+        config_keys_str = ' > '.join(config_keys)
+        self.message = (
+            "The configuration value corresponding to the argument "
+            f"({config_keys_str}) doesn't exist. "
+            "Please provide a value in the configuration file."
+        )
+
+        if message:
             self.message = message
-        else:
-            config_keys_str = ' > '.join(config_keys)
-            self.message = (
-                "The configuration value corresponding to the argument "
-                f"({config_keys_str}) doesn't exist. "
-                "Please provide a value in the configuration file."
-            )
+
         super().__init__(self.message)
 
     def __str__(self):
@@ -39,16 +40,17 @@ class MissingConfigAndArgumentValueError(Exception):
     """
     def __init__(self, arg_name: str, 
                 config_keys: Sequence[Any], message: str = None) -> str:
-        if message is not None:
+        config_keys_str = ' > '.join(config_keys)
+        self.message = (
+            f"The value corresponding to the CLI argument '--{arg_name}'"
+            " doesn't exist. "
+            "Please provide a value for either the CLI argument or "
+            f"({config_keys_str}) in the configuration file."
+        )
+
+        if message:
             self.message = message
-        else:
-            config_keys_str = ' > '.join(config_keys)
-            self.message = (
-                f"The value corresponding to the CLI argument '--{arg_name}'"
-                " doesn't exist. "
-                "Please provide a value for either the CLI argument or "
-                f"({config_keys_str}) in the configuration file."
-            )
+            
         super().__init__(self.message)
 
     def __str__(self):
@@ -67,13 +69,14 @@ class AccessCredentialsError(Exception):
     """
 
     def __init__(self, project: str, message: str = None) -> str:
-        if message is not None:
+        self.message = (
+            f"Your access to '{project}'' could not be resolved. "
+            "Please check your credentials and try again."
+        )
+
+        if message:
             self.message = message
-        else:
-            self.message = (
-                f"Your access to '{project}'' could not be resolved. "
-                "Please check your credentials and try again."
-            )
+            
         super().__init__(self.message)
 
     def __str__(self):


### PR DESCRIPTION
This PR works to replace the `print` statements in the `synapse/store` module with `logging` statements.

_Note_: I'm planning to address issue #317 in a series of multiple PRs, where I'll refactor schematic, module-by-module. This is the first of those PRs.

I've also been meaning to make this addition to the `config.yml` file:

```
manifest:
  synapse:
    title: 'Patient_Manifest'
    data_type: 'Patient'
  local:
    path: '/path/to/local/manifest'
```

Just a note, we can consider this if we want to allow users to configure the path to the local manifest. But I guess we can talk more about it when working on issue #335.