### PR TITLE
Removing unneeded calls to Synapse from synapse store

### DIFF
--- a/schematic/synapse/store.py
+++ b/schematic/synapse/store.py
@@ -174,7 +174,7 @@ class SynapseStorage(object):
             foldersTable = self.storageFileviewTable[(self.storageFileviewTable["contentType"] == "dataset") & (self.storageFileviewTable["projectId"] == projectId)]
             areDatasets = True
         else:
-            foldersTable = self.storageFileviewTable[(self.storageFileviewTable["type"] == "folder") & (self.storageFileviewTable["projectId"] == projectId)]
+            foldersTable = self.storageFileviewTable[(self.storageFileviewTable["type"] == "folder") & (self.storageFileviewTable["parentId"] == projectId)]
 
         # get an array of tuples (folderId, folderName)
         # some folders are part of datasets; others contain datasets
@@ -187,8 +187,7 @@ class SynapseStorage(object):
         folderProperties = ["id", "name"]
         for folder in list(foldersTable[folderProperties].itertuples(index = False, name = None)):
             try:
-                if self.syn.get(folder[0], downloadFile = False).properties["parentId"] == projectId or areDatasets:
-                    datasetList.append(folder)
+                datasetList.append(folder)
             except ValueError:
                 print("The project id {} was not found.".format(projectId))
 

--- a/schematic/synapse/store.py
+++ b/schematic/synapse/store.py
@@ -186,10 +186,7 @@ class SynapseStorage(object):
         datasetList = []
         folderProperties = ["id", "name"]
         for folder in list(foldersTable[folderProperties].itertuples(index = False, name = None)):
-            try:
-                datasetList.append(folder)
-            except ValueError:
-                print("The project id {} was not found.".format(projectId))
+            datasetList.append(folder)
 
         sorted_dataset_list = sorted(datasetList, key=lambda tup: tup[0])
 


### PR DESCRIPTION
The calls resulted in considerable delays for datasets containing a large number of files (~10000).
For example, that causes the dataset dropdown menu to take long time to appear in the DC app (which may also slow down the appearance of the metadata template selection menu).

