### PR TITLE
update store.py

### DIFF
--- a/schematic/synapse/store.py
+++ b/schematic/synapse/store.py
@@ -356,7 +356,7 @@ class SynapseStorage(object):
         return df, results
 
 
-    def associateMetadataWithFiles(self, metadataManifestPath: str, datasetId: str) -> str:
+    def associateMetadataWithFiles(self, metadataManifestPath: str, datasetId: str, useSchemaLabel:bool=True) -> str:
         """Associate metadata with files in a storage dataset already on Synapse. 
         Upload metadataManifest in the storage dataset folder on Synapse as well. Return synapseId of the uploaded manifest file.
         
@@ -365,8 +365,9 @@ class SynapseStorage(object):
             The manifest should include a column entityId containing synapse IDs of files/entities to be associated with metadata, if that is applicable to the dataset type. 
             Some datasets, e.g. clinical data, do not contain file id's, but data is stored in a table: one row per item. 
             In this case, the system creates a file on Synapse for each row in the table (e.g. patient, biospecimen) and associates the columnset data as metadata/annotations to his file. 
-                
             datasetId: synapse ID of folder containing the dataset
+            useSchemaLabel: Default is True - use the schema label. If False, uses the display label from the schema. Attribute display names in the schema must not only include characters that are not accepted by Synapse. Annotation names may only contain: letters, numbers, '_' and '.'.
+
             
         Returns: synapse Id of the uploaded manifest.
         
@@ -434,7 +435,10 @@ class SynapseStorage(object):
             #  prepare metadata for Synapse storage (resolve display name into a name that Synapse annotations support (e.g no spaces)
             metadataSyn = {}
             for k, v in row.to_dict().items():
-                keySyn = se.get_class_label_from_display_name(str(k))
+                if useSchemaLabel:
+                    keySyn = se.get_class_label_from_display_name(str(k))
+                else:
+                    keySyn = str(k)
 
                 metadataSyn[keySyn] = v
 


### PR DESCRIPTION
Re: #397 add useSchemaLabel param to store.associateMetadataWithFiles

This was a simpler change than I anticipated...let me know if I've missed something.  I tested this with both `useSchemaLabel = T` and `useSchemaLabel = F` on the NF staging instance of the curation app, and it worked fine, but would appreciate another test to make sure I didn't do anything weird. 

Discovered during testing: `schematic` uploads nan values for optional blank annotations, which can cause some issues when updating a manifest - will file an issue if it doesn't already exist. Based on my testing, I don't believe this issue is caused by this change. 