### PR TITLE
mismatched 'Component' type and selected template type

### DIFF
--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -179,6 +179,14 @@ class MetadataModel(object):
         manifest = pd.read_csv(manifestPath)    # read manifest csv file as is from manifest path
         manifest = trim_commas_df(manifest).fillna("")  # apply cleaning logic as part of pre-processing step
  
+        # handler for mismatched components/data types
+        # throw TypeError if the value(s) in the "Component" column differ from the selected template type
+        if ('Component' in manifest.columns) and (
+            (len(manifest['Component'].unique()) > 1) or (manifest['Component'].unique()[0] != rootNode)
+            ):
+            raise TypeError(f"The 'Component' column value(s) {manifest['Component'].unique()} do not match the "
+                            f"selected template type '{rootNode}'.")
+
         # check if each of the provided annotation columns has validation rule 'list'
         # if so, assume annotation for this column are comma separated list of multi-value annotations
         # convert multi-valued annotations to list

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -199,8 +199,11 @@ class MetadataModel(object):
                 errors.append([
                     index + 2,
                     'Component',
-                    'Component value(s) does not match selected template type',
-                    component
+                    f"Component value provided is: '{component}', whereas the Template Type is: '{rootNode}'",
+
+                    # tuple of the component in the manifest and selected template type
+                    # check: R/Reticulate cannnot handle dicts? So returning tuple
+                    (component, rootNode)
                 ])
                 
             return errors
@@ -307,3 +310,8 @@ class MetadataModel(object):
         print("Validation was not performed on manifest file before association.")
         
         return True
+
+if __name__ == "__main__":
+    metadata_model = MetadataModel("./data/schema_org_schemas/HTAN.jsonld", "local")
+    res = metadata_model.validateModelManifest("./data/manifests/synapse_storage_manifest_followup.csv", "FollowUp")
+    print(res)

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -307,8 +307,3 @@ class MetadataModel(object):
         print("Validation was not performed on manifest file before association.")
         
         return True
-
-if __name__ == "__main__":
-    metadata_model = MetadataModel("./data/schema_org_schemas/HTAN.jsonld", "local")
-    res = metadata_model.validateModelManifest("./data/manifests/synapse_storage_manifest_followup.csv", "FollowUp")
-    print(res)


### PR DESCRIPTION
This PR seeks to address [issue #61](https://github.com/Sage-Bionetworks/data_curator/issues/61) on the DC App repo.

So there are two cases to handle [here](https://github.com/Sage-Bionetworks/schematic/compare/develop...spatil/dc-issue-61-fix?expand=1#diff-2d85c23b757cbcca2e561765d45e496cb6af65062b560d092559374b68089889R186-R188):
- if there are more than one Component(s) in the manifest that the user wants to validate (and/or submit)
- if the component value in the submitted manifest does not match the selected template type (`rootNode`)

The first "version" I wrote, simply throws a `TypeError`. See [this commit](https://github.com/Sage-Bionetworks/schematic/commit/a7ed54ce841d27117d7c3f028a304c36c1feccda). In which case the DC App cannot read what the `validateModelManifest()` returns.

The second "version" returns errors in the same format as `validateModelManifest()`'s original return type. See [this commit](https://github.com/Sage-Bionetworks/schematic/commit/a3572d9c06543500f39b25ae4bf569c5311d1e52).

Do let me know what behaviour would be preferable @milen-sage and @xdoan.