### PR TITLE
Tests for methods in utils/validate_utils module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import pandas as pd
 
+from schematic.schemas.explorer import SchemaExplorer
 from schematic.configuration import CONFIG
 
 
@@ -40,6 +41,17 @@ class Helpers:
         fullpath = os.path.join(DATA_DIR, path, *paths)
         return pd.read_csv(fullpath, **kwargs)
 
+    @staticmethod
+    def get_schema_explorer(path, *paths):
+        fullpath = Helpers.get_data_path(path, *paths)
+        
+        if fullpath is None:
+            return SchemaExplorer()
+            
+        se = SchemaExplorer()
+        se.load_schema(fullpath)
+        return se
+            
 
 @pytest.fixture
 def helpers():
@@ -49,13 +61,3 @@ def helpers():
 @pytest.fixture
 def config():
     yield CONFIG
-
-
-@pytest.fixture()
-def synapse_manifest(helpers):
-    yield helpers.get_data_frame("mock_manifests", "synapse_manifest.csv")
-
-
-@pytest.fixture()
-def local_manifest(helpers):
-    yield helpers.get_data_frame("mock_manifests", "local_manifest.csv")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,11 +42,11 @@ class Helpers:
         return pd.read_csv(fullpath, **kwargs)
 
     @staticmethod
-    def get_schema_explorer(path, *paths):
-        fullpath = Helpers.get_data_path(path, *paths)
-        
-        if fullpath is None:
+    def get_schema_explorer(path=None, *paths):
+        if path is None:
             return SchemaExplorer()
+            
+        fullpath = Helpers.get_data_path(path, *paths)
             
         se = SchemaExplorer()
         se.load_schema(fullpath)


### PR DESCRIPTION
This PR adds test cases for methods in the `validate_utils.py` module.

I closed the original PR (#394), which addressed this issue. Resolving the merge conflicts as a result of multiple merges into `develop` was a bit of a hassle (apologies). I've addressed the review comments from PR #394 here.