### PR TITLE
Assume empty column might be present

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -744,7 +744,11 @@ class ManifestGenerator(object):
         wb = sh[0]
 
         # get column headers and read it into a dataframe
-        manifest_df = wb.get_as_df(hasHeader=True).drop(columns="")
+        manifest_df = wb.get_as_df(hasHeader=True)
+
+        # An empty column is sometimes included
+        if "" in manifest_df:
+            manifest_df.drop(columns=[""], inplace=True)
 
         return manifest_df
 


### PR DESCRIPTION
Thanks to tests done for NF (in #361), I realized that the empty column isn't always there. Not sure why, but this quick fix gets rid of that assumption. Otherwise, you run into an error about an index not existing. 