### PR TITLE
Restrict annotation retrieval to files and folders

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -488,23 +488,33 @@ class SynapseStorage(BaseStorage):
         Returns:
             dict: Annotations as comma-separated strings.
         """
-        # Retrieve Synapse annotations using _getRawAnnotations()
-        # to get etag, which isn't provided by get_annotations()
-        syn_annotations = self.syn._getRawAnnotations(fileId)
 
-        # Convert all values into comma-separated lists of strings
-        annotations_unordered = from_synapse_annotations(syn_annotations)
-        annotations = OrderedDict()
-        for key, vals in annotations_unordered.items():
-            annotations[key] = ", ".join(str(v) for v in vals)
+        # Get entity metadata, including annotations
+        entity = self.syn.get(fileId, downloadFile=False)
+        is_file = entity.concreteType.endswith(".FileEntity")
+        is_folder = entity.concreteType.endswith(".Folder")
+        annotations_raw = entity.annotations
+
+        # Skip anything that isn't a file or folder
+        if not (is_file or is_folder):
+            return None
+
+        # Extract annotations from their lists and stringify. For example:
+        # {'YearofBirth': [1980], 'author': ['bruno', 'milen', 'sujay']}
+        annotations = dict()
+        for key, vals in annotations_raw.items():
+            if isinstance(vals, list) and len(vals) == 1:
+                annotations[key] = str(vals[0])
+            else:
+                annotations[key] = ", ".join(str(v) for v in vals)
 
         # Add the file entity ID and eTag, which weren't lists
-        assert fileId == syn_annotations["id"], (
+        assert fileId == entity.id, (
             "For some reason, the Synapse ID in the response doesn't match"
             "the Synapse ID sent in the request (via synapseclient)."
         )
         annotations["entityId"] = fileId
-        annotations["eTag"] = syn_annotations["etag"]
+        annotations["eTag"] = entity.etag
 
         return annotations
 
@@ -526,7 +536,10 @@ class SynapseStorage(BaseStorage):
         # Step 2: Get annotations for each file from Step 1
         annotations_list = [self.getFileAnnotations(i) for i, _ in dataset_files]
 
-        # Step 3: Create data frame from list of annotations
+        # Step 3: Remove any annotations for non-file/folders
+        annotations_list = filter(None, annotations_list)
+
+        # Step 4: Create data frame from list of annotations
         table = pd.DataFrame.from_records(annotations_list)
 
         # Missing values are filled in with empty strings for Google Sheets

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -490,10 +490,16 @@ class SynapseStorage(BaseStorage):
         """
 
         # Get entity metadata, including annotations
-        entity = self.syn.get(fileId, downloadFile=False)
-        is_file = entity.concreteType.endswith(".FileEntity")
-        is_folder = entity.concreteType.endswith(".Folder")
-        annotations_raw = entity.annotations
+        try:
+            entity = self.syn.get(fileId, downloadFile=False)
+            is_file = entity.concreteType.endswith(".FileEntity")
+            is_folder = entity.concreteType.endswith(".Folder")
+            annotations_raw = entity.annotations
+        except SynapseHTTPError:
+            # If an error occurs with retrieving entity, skip it
+            # This could be caused by a temporary file view that
+            # was deleted since its ID was retrieved
+            is_file, is_folder = False, False
 
         # Skip anything that isn't a file or folder
         if not (is_file or is_folder):


### PR DESCRIPTION
With the new code that uses folder-bound file views, this update is required to restrict the annotations retrieval to files and folders. Specifically, this would cause issues when running the test suite, which didn't expect a fourth entity (a temporary file view) in the test dataset folder. 

Briefly, I'm using `syn.get(..., downloadFile=False)` instead of `syn._getAnnotations()` so that I can simultaneously retrieve the annotations and the entity type. This way, I can ignore anything that isn't a file or folder. This should make the test suite more robust. 

I also added a permanent folder-bound [file view](https://www.synapse.org/#!Synapse:syn24226514) to our main test dataset to make sure that this new functionality (_i.e._ to ignore them) works. 