### PR TITLE
Order of arguments being passed to ManifestGenerator call

### DIFF
--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -76,8 +76,8 @@ def get_manifest(ctx, title, data_type, jsonld, dataset_id, sheet_url,
 
     # create object of type ManifestGenerator
     manifest_generator = ManifestGenerator(
-        title=title,
         path_to_json_ld=jsonld,
+        title=title,
         root=data_type,
         use_annotations=use_annotations,
     )

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -123,7 +123,10 @@ class MetadataModel(object):
         if filenames:
             additionalMetadata["Filename"] = filenames
 
-        mg = ManifestGenerator(self.inputMModelLocation, title, rootNode, additionalMetadata)
+        mg = ManifestGenerator(path_to_json_ld=self.inputMModelLocation, 
+                               title=title, 
+                               root=rootNode, 
+                               additional_metadata=additionalMetadata)
 
         if jsonSchema:
             return mg.get_manifest(json_schema=jsonSchema)
@@ -250,7 +253,9 @@ class MetadataModel(object):
         Raises:
             ValueError: rootNode not found in metadata model.
         """
-        mg = ManifestGenerator(title, self.inputMModelLocation, rootNode)
+        mg = ManifestGenerator(path_to_json_ld=self.inputMModelLocation, 
+                               title=title, 
+                               root=rootNode)
 
         emptyManifestURL = mg.get_manifest()
 

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -123,7 +123,7 @@ class MetadataModel(object):
         if filenames:
             additionalMetadata["Filename"] = filenames
 
-        mg = ManifestGenerator(title, self.inputMModelLocation, rootNode, additionalMetadata)
+        mg = ManifestGenerator(self.inputMModelLocation, title, rootNode, additionalMetadata)
 
         if jsonSchema:
             return mg.get_manifest(json_schema=jsonSchema)


### PR DESCRIPTION
This was the reason why I wasn't able to get the current version of the code in `develop` to work with the Data Curator App. The Data Curator App makes a call to [`getModelManifest()`](https://github.com/Sage-Bionetworks/schematic/blob/develop/schematic/models/metadata.py#L108), and the order of the arguments being passed to `ManifestGenerator()` was not correct.

The `path_to_jsonld` argument needs to be passed first, if you look at the [`ManifestGenerator()`](https://github.com/Sage-Bionetworks/schematic/blob/develop/schematic/manifest/generator.py#L21) constructor. 