### PR TITLE
Integrate CSV to JSON-LD parser into schematic core modules

### DIFF
--- a/schematic/__main__.py
+++ b/schematic/__main__.py
@@ -6,6 +6,7 @@ import click_log
 
 from schematic.manifest.commands import manifest as manifest_cli    # get manifest commands
 from schematic.models.commands import model as model_cli    # submit manifest commands
+from schematic.schemas.commands import schema as schema_cli # schema conversion commands
 
 logger = logging.getLogger()
 click_log.basic_config(logger)
@@ -26,6 +27,7 @@ def main():
 
 main.add_command(manifest_cli) # add manifest commands
 main.add_command(model_cli) # add model commands
+main.add_command(schema_cli) # add schema commands
 
 
 if __name__ == '__main__':

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -23,7 +23,7 @@ manifest_commands = {
                 ),
             "jsonld": (
                 "Specify the path to the JSON-LD data model (schema) using this option. You can either explicitly pass the "
-                "schema here or provide a valie for the `(model > input > location)` key."
+                "schema here or provide a value for the `(model > input > location)` key."
                 ),
             "dataset_id": (
                 "Specify the synID of a dataset folder on Synapse. If there is an exisiting manifest already present "
@@ -72,6 +72,27 @@ model_commands = {
                 "The component or data type from the data model which you can use to validate the "
                 "data filled in your manifest template."
                 )
+        }
+    }
+}
+
+
+# `schematic schema` related sub-commands description
+schema_commands = {
+    "schema": {
+        "config": (
+            "Specify the path to the `config.yml` using this option. This is a required argument."
+            ),
+        "convert": {
+            "short_help": (
+                "Convert specification from CSV (based on RFC) to JSON-LD data model."
+            ),
+            "base_schema": (
+                "Path to base data model. BioThings data model is loaded by default."
+            ),
+            "output_jsonld": (
+                "Path to where the generated JSON-LD file needs to be outputted."
+            )
         }
     }
 }

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -82,7 +82,7 @@ schema_commands = {
     "schema": {
         "convert": {
             "short_help": (
-                "Convert specification from CSV (based on RFC) to JSON-LD data model."
+                "Convert specification from CSV data model to JSON-LD data model."
             ),
             "base_schema": (
                 "Path to base data model. BioThings data model is loaded by default."

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -80,9 +80,6 @@ model_commands = {
 # `schematic schema` related sub-commands description
 schema_commands = {
     "schema": {
-        "config": (
-            "Specify the path to the `config.yml` using this option. This is a required argument."
-            ),
         "convert": {
             "short_help": (
                 "Convert specification from CSV (based on RFC) to JSON-LD data model."

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -9,7 +9,6 @@ import re
 from schematic.schemas.df_parser import _convert_rfc_to_data_model
 from schematic.utils.cli_utils import query_dict
 from schematic.help import schema_commands
-from schematic import CONFIG
 
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
@@ -18,26 +17,16 @@ CONTEXT_SETTINGS = dict(help_option_names=['--help', '-h'])  # help options
 
 # invoke_without_command=True -> forces the application not to show aids before losing them with a --h
 @click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
-@click_log.simple_verbosity_option(logger)
-@click.option('-c', '--config', type=click.Path(exists=True), 
-              envvar='SCHEMATIC_CONFIG', help=query_dict(schema_commands, ("schema", "config")))
-@click.pass_context
-def schema(ctx, config): # use as `schematic model ...`
+def schema(): # use as `schematic model ...`
     """
-    Sub-commands for Metadata Model related utilities/methods.
+    Sub-commands for Schema related utilities/methods.
     """
-    try:
-        logger.debug(f"Loading config file contents in '{config}'")
-        ctx.obj = CONFIG.load_config(config)
-    except ValueError as e:
-        logger.error("'--config' not provided or environment variable not set.")
-        logger.exception(e)
-        sys.exit(1)
+    pass
 
 
 # prototype based on submit_metadata_manifest()
 @schema.command('convert', options_metavar="<options>", 
-                short_help=query_dict(schema_commands, ("schema", "config")))
+                short_help=query_dict(schema_commands, ("schema", "convert", "short_help")))
 @click_log.simple_verbosity_option(logger)
 @click.argument("schema_csv", type=click.Path(exists=True), 
                 metavar="<RFC_CSV>", 
@@ -48,8 +37,7 @@ def schema(ctx, config): # use as `schematic model ...`
 @click.option("--output_jsonld", "-o", type=click.Path(exists=True), 
               metavar="<OUTPUT_PATH>", 
               help=query_dict(schema_commands, ("schema", "convert", "output_jsonld")))
-@click.pass_obj
-def submit_manifest(ctx, schema_csv, base_schema, output_jsonld):
+def submit_manifest(schema_csv, base_schema, output_jsonld):
     """
     Running CLI to convert data model specification in CSV format to 
     data model in JSON-LD format.

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -37,7 +37,7 @@ def schema(): # use as `schematic model ...`
 @click.option("--output_jsonld", "-o", type=click.Path(exists=True), 
               metavar="<OUTPUT_PATH>", 
               help=query_dict(schema_commands, ("schema", "convert", "output_jsonld")))
-def convert_rfc_to_data_model(schema_csv, base_schema, output_jsonld):
+def convert(schema_csv, base_schema, output_jsonld):
     """
     Running CLI to convert data model specification in CSV format to 
     data model in JSON-LD format.

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -6,7 +6,7 @@ import logging
 import sys
 import re
 
-from schematic.schemas.df_parser import _convert_rfc_to_data_model
+from schematic.schemas.df_parser import _convert_csv_to_data_model
 from schematic.utils.cli_utils import query_dict
 from schematic.help import schema_commands
 
@@ -29,7 +29,7 @@ def schema(): # use as `schematic model ...`
                 short_help=query_dict(schema_commands, ("schema", "convert", "short_help")))
 @click_log.simple_verbosity_option(logger)
 @click.argument("schema_csv", type=click.Path(exists=True), 
-                metavar="<RFC_CSV>", 
+                metavar="<DATA_MODEL_CSV>", 
                 nargs=1)
 @click.option("--base_schema", "-b", type=click.Path(exists=True), 
               metavar="<JSON-LD_SCHEMA>", 
@@ -43,7 +43,7 @@ def convert(schema_csv, base_schema, output_jsonld):
     data model in JSON-LD format.
     """
     # convert RFC to Data Model
-    base_se = _convert_rfc_to_data_model(schema_csv, base_schema)
+    base_se = _convert_csv_to_data_model(schema_csv, base_schema)
 
     # output JSON-LD file alongside CSV file by default
     if output_jsonld is None:

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import click
+import click_log
+import logging
+import sys
+import re
+
+from schematic.schemas.df_parser import _convert_rfc_to_data_model
+from schematic.utils.cli_utils import query_dict
+from schematic.help import schema_commands
+from schematic import CONFIG
+
+logger = logging.getLogger(__name__)
+click_log.basic_config(logger)
+
+CONTEXT_SETTINGS = dict(help_option_names=['--help', '-h'])  # help options
+
+# invoke_without_command=True -> forces the application not to show aids before losing them with a --h
+@click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
+@click_log.simple_verbosity_option(logger)
+@click.option('-c', '--config', type=click.Path(exists=True), 
+              envvar='SCHEMATIC_CONFIG', help=query_dict(schema_commands, ("schema", "config")))
+@click.pass_context
+def schema(ctx, config): # use as `schematic model ...`
+    """
+    Sub-commands for Metadata Model related utilities/methods.
+    """
+    try:
+        logger.debug(f"Loading config file contents in '{config}'")
+        ctx.obj = CONFIG.load_config(config)
+    except ValueError as e:
+        logger.error("'--config' not provided or environment variable not set.")
+        logger.exception(e)
+        sys.exit(1)
+
+
+# prototype based on submit_metadata_manifest()
+@schema.command('convert', options_metavar="<options>", 
+                short_help=query_dict(schema_commands, ("schema", "config")))
+@click_log.simple_verbosity_option(logger)
+@click.argument("schema_csv", type=click.Path(exists=True), 
+                metavar="<RFC_CSV>", 
+                nargs=1)
+@click.option("--base_schema", "-b", type=click.Path(exists=True), 
+              metavar="<JSON-LD_SCHEMA>", 
+              help=query_dict(schema_commands, ("schema", "convert", "base_schema")))
+@click.option("--output_jsonld", "-o", type=click.Path(exists=True), 
+              metavar="<OUTPUT_PATH>", 
+              help=query_dict(schema_commands, ("schema", "convert", "output_jsonld")))
+@click.pass_obj
+def submit_manifest(ctx, schema_csv, base_schema, output_jsonld):
+    """
+    Running CLI to convert data model specification in CSV format to 
+    data model in JSON-LD format.
+    """
+    # convert RFC to Data Model
+    base_se = _convert_rfc_to_data_model(schema_csv, base_schema)
+
+    # output JSON-LD file alongside CSV file by default
+    if output_jsonld is None:
+        csv_no_ext = re.sub("[.]csv$", "", schema_csv)
+        output_jsonld = csv_no_ext + ".jsonld"
+
+        logger.info("By default, the JSON-LD output will be stored alongside the first "
+                    f"input CSV file. In this case, it will appear here: '{output_jsonld}'. "
+                    "You can use the `--output_jsonld` argument to specify another file path.")
+                    
+    # saving updated schema.org schema
+    base_se.export_schema(output_jsonld)
+    click.echo(f"The Data Model was created and saved to '{output_jsonld}' location.")

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -37,7 +37,7 @@ def schema(): # use as `schematic model ...`
 @click.option("--output_jsonld", "-o", type=click.Path(exists=True), 
               metavar="<OUTPUT_PATH>", 
               help=query_dict(schema_commands, ("schema", "convert", "output_jsonld")))
-def submit_manifest(schema_csv, base_schema, output_jsonld):
+def convert_rfc_to_data_model(schema_csv, base_schema, output_jsonld):
     """
     Running CLI to convert data model specification in CSV format to 
     data model in JSON-LD format.

--- a/schematic/schemas/df_parser.py
+++ b/schematic/schemas/df_parser.py
@@ -982,9 +982,9 @@ def _get_base_schema_path(base_schema: str = None) -> str:
     return base_schema_path
 
 
-def _convert_rfc_to_data_model(schema_csv: str, 
+def _convert_csv_to_data_model(schema_csv: str, 
                                base_schema: str = None) -> SchemaExplorer:
-    """Convert provided RFC spec. in CSV format to data model in JSON-LD format.
+    """Convert provided CSV spec. in CSV format to data model in JSON-LD format.
 
     Args:
         schema_csv: Path to CSV file containing data to be translated to 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,3 +61,9 @@ def helpers():
 @pytest.fixture
 def config():
     yield CONFIG
+
+
+@pytest.fixture
+def config_path():
+    yield CONFIG_PATH
+    

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,11 +18,11 @@ class SchemaCli:
 
     def test_schema_convert_cli(self, runner, config_path, helpers):
 
-        rfc_csv_path = helpers.get_data_path("simple.model.csv")
+        data_model_csv_path = helpers.get_data_path("simple.model.csv")
 
         result = runner.invoke(schema, 
                                ["--config", config_path, 
-                               "convert", rfc_csv_path])
+                               "convert", data_model_csv_path])
 
         assert result.exit_code == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,37 @@
+import os
+
+import pytest
+
+from click.testing import CliRunner
+
+from schematic.schemas.commands import schema
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Fixture for invoking command-line interfaces."""
+
+    return CliRunner()
+
+
+class SchemaCli:
+
+    def test_schema_convert_cli(self, runner, config_path, helpers):
+
+        rfc_csv_path = helpers.get_data_path("simple.model.csv")
+
+        result = runner.invoke(schema, 
+                               ["--config", config_path, 
+                               "convert", rfc_csv_path])
+
+        assert result.exit_code == 0
+
+        output_path = helpers.get_data_path("simple.model.jsonld")
+
+        expected_substr = (
+                          "The Data Model was created and saved to "
+                          f"'{output_path}' location."
+                        )
+
+        assert expected_substr in result.output
+        


### PR DESCRIPTION
Based on the approach in issue #407, I decided to skip 3. and 4. since it was making the application unnecessarily verbose.

To test the CLI bundled with this PR:

`poetry run schematic schema --config ~/path/to/config.yml convert --help`