### PR TITLE
init command added to CLI catalogue

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,13 +3,14 @@ definitions:
   synapse_config: ".synapseConfig"
   creds_path: "credentials.json"
   token_pickle: "token.pickle"
-  service_acct_creds: "quickstart-1560359685924-198a7114b6b5.json"
+  service_acct_creds: "schematic_service_account_creds.json"
 
 synapse:
-  master_fileview: 'syn23643253'
+  master_fileview: 'syn20446927'
   manifest_folder: 'manifests'
   manifest_filename: 'data/manifests/synapse_storage_manifest.csv'
-  api_creds: 'syn23643259'
+  token_creds: 'syn23643259'
+  service_acct_creds: 'syn24214983'
 
 manifest:
   title: 'Patient_Manifest'

--- a/config.yml
+++ b/config.yml
@@ -6,11 +6,11 @@ definitions:
   service_acct_creds: "schematic_service_account_creds.json"
 
 synapse:
-  master_fileview: 'syn20446927'
+  master_fileview: 'syn23643253'
   manifest_folder: 'manifests'
   manifest_filename: 'data/manifests/synapse_storage_manifest.csv'
   token_creds: 'syn23643259'
-  service_acct_creds: 'syn24214983'
+  service_acct_creds: 'syn25171627'
 
 manifest:
   title: 'Patient_Manifest'

--- a/schematic/__init__.py
+++ b/schematic/__init__.py
@@ -1,7 +1,14 @@
+import sys
 import logging
+
+import click
+import click_log
 
 from schematic.configuration import CONFIG
 from schematic.loader import LOADER
+from schematic.utils.google_api_utils import download_creds_file, generate_token
+from schematic.utils.cli_utils import query_dict
+from schematic.help import init_command
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'
                             ' - %(message)s'),
@@ -9,7 +16,36 @@ logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'
 
 
 # Suppress INFO-level logging from some dependencies
-logging.getLogger('keyring').setLevel(logging.ERROR)
-logging.getLogger('rdflib').setLevel(logging.ERROR)
+logging.getLogger("keyring").setLevel(logging.ERROR)
+logging.getLogger("rdflib").setLevel(logging.ERROR)
 
-logger = logging.getLogger('schematic')
+logger = logging.getLogger(__name__)
+click_log.basic_config(logger)
+
+
+@click.command("init", short_help=query_dict(init_command, ("init", "short_help")))
+@click_log.simple_verbosity_option(logger)
+@click.option("-a", "--auth", default="token", 
+              type=click.Choice(["token", "service_account"], case_sensitive=False), 
+              help=query_dict(init_command, ("init", "auth")))
+@click.option("-c", "--config", required=True, 
+              help=query_dict(init_command, ("init", "config")))
+def init(auth, config):
+    """Initialize mode of authentication for schematic.
+    """
+    try:
+        logger.debug(f"Loading config file contents in '{config}'")
+        obj = CONFIG.load_config(config)
+    except ValueError as e:
+        logger.error("'--config' not provided or environment variable not set.")
+        logger.exception(e)
+        sys.exit(1)
+    
+    # download crdentials file based on selected mode of authentication
+    download_creds_file(auth)
+
+    # if authentication method is token-based
+    # then create 'token.pickle' file from 'credentials.json' file
+    if auth == "token":
+        generate_token()
+        

--- a/schematic/__main__.py
+++ b/schematic/__main__.py
@@ -7,6 +7,7 @@ import click_log
 from schematic.manifest.commands import manifest as manifest_cli    # get manifest commands
 from schematic.models.commands import model as model_cli    # submit manifest commands
 from schematic.schemas.commands import schema as schema_cli # schema conversion commands
+from schematic import init as init_cli  # schematic initialization commands
 
 logger = logging.getLogger()
 click_log.basic_config(logger)
@@ -25,6 +26,7 @@ def main():
     logger.debug("Existing sub-commands need to be used with schematic.")
 
 
+main.add_command(init_cli)  # add init commands
 main.add_command(manifest_cli) # add manifest commands
 main.add_command(model_cli) # add model commands
 main.add_command(schema_cli) # add schema commands

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -102,8 +102,8 @@ init_command = {
             "Initialize mode of authentication for schematic."
         ),
         "auth": (
-            "Specify the mode of authentication you want to use. You can use one of "
-            "either 'token' or 'service_account'. The default mode of authentication "
+            "Specify the mode of authentication you want to use for Google accounts. "
+            "You can use one of either 'token' or 'service_account'. The default mode of authentication "
             "is 'token' which uses OAuth."
         ),
         "config": (

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -93,3 +93,21 @@ schema_commands = {
         }
     }
 }
+
+
+# `schematic init` command description
+init_command = {
+    "init": {
+        "short_help": (
+            "Initialize mode of authentication for schematic."
+        ),
+        "auth": (
+            "Specify the mode of authentication you want to use. You can use one of "
+            "either 'token' or 'service_account'. The default mode of authentication "
+            "is 'token' which uses OAuth."
+        ),
+        "config": (
+            "Specify the path to the `config.yml` using this option. This is a required argument."
+        )
+    }
+}

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -5,10 +5,13 @@ import logging
 
 import pygsheets as ps
 
+from typing import Dict, Any
+
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 from google.oauth2 import service_account
+from google.oauth2.credentials import Credentials
 from schematic import CONFIG
 
 logger = logging.getLogger(__name__)
@@ -17,9 +20,9 @@ logger = logging.getLogger(__name__)
 # If modifying these scopes, delete the file token.pickle.
 SCOPES = ['https://www.googleapis.com/auth/spreadsheets', 'https://www.googleapis.com/auth/drive']
 
+
 # it will create 'token.pickle' based on credentials.json
-# TODO: replace by pygsheets calls?
-def build_credentials() -> dict:
+def generate_token() -> Credentials:
     creds = None
     # The file token.pickle stores the user's access and refresh tokens,
     # and is created automatically when the authorization flow completes for the first time.
@@ -38,6 +41,13 @@ def build_credentials() -> dict:
         with open(CONFIG.TOKEN_PICKLE, 'wb') as token:
             pickle.dump(creds, token)
 
+    return creds
+
+
+# TODO: replace by pygsheets calls?
+def build_credentials() -> Dict[str, Any]:
+    creds = generate_token()
+
     # get a Google Sheet API service
     sheet_service = build('sheets', 'v4', credentials=creds)
     # get a Google Drive API service
@@ -49,7 +59,8 @@ def build_credentials() -> dict:
         'creds': creds
     }
 
-def build_service_account_creds():
+
+def build_service_account_creds() -> Dict[str, Any]:
     credentials = service_account.Credentials.from_service_account_file(CONFIG.SERVICE_ACCT_CREDS, scopes=SCOPES)
 
     # get a Google Sheet API service
@@ -63,21 +74,50 @@ def build_service_account_creds():
         'creds': credentials
     }
 
-def download_creds_file():
-    if not os.path.exists(CONFIG.CREDS_PATH):
 
-        logging.info("Retrieving Google API credentials from Synapse...")
-        # synapse ID of the 'credentials.json' file, which we need in
-        # order to establish communication with gAPIs/services
-        API_CREDS = CONFIG["synapse"]["api_creds"]
-        syn = synapseclient.Synapse()
-        syn.login()
-        # Download in parent directory of CREDS_PATH to
-        # ensure same file system for os.rename()
-        creds_dir = os.path.dirname(CONFIG.CREDS_PATH)
-        creds_file = syn.get(API_CREDS, downloadLocation = creds_dir)
-        os.rename(creds_file.path, CONFIG.CREDS_PATH)
-        logging.info("Downloaded Google API credentials file.")
+def download_creds_file(auth: str = "token") -> None:
+    if auth is None:
+        raise ValueError(f"'{auth}' is not a valid authentication method. Please "
+                          "enter one of 'token' or 'service_account'.")
+
+    syn = synapseclient.Synapse()
+    syn.login(silent=True)
+
+    if auth == "token":
+        if not os.path.exists(CONFIG.CREDS_PATH):
+            # synapse ID of the 'credentials.json' file
+            API_CREDS = CONFIG["synapse"]["token_creds"]
+
+            # Download in parent directory of CREDS_PATH to
+            # ensure same file system for os.rename()
+            creds_dir = os.path.dirname(CONFIG.CREDS_PATH)
+
+            creds_file = syn.get(API_CREDS, downloadLocation = creds_dir)
+            os.rename(creds_file.path, CONFIG.CREDS_PATH)
+
+            logger.info("The credentials file has been downloaded "
+                       f"to '{CONFIG.CREDS_PATH}'")
+                       
+    elif auth == "service_account":
+        if not os.path.exists(CONFIG.SERVICE_ACCT_CREDS):
+            # synapse ID of the 'schematic_service_account_creds.json' file
+            API_CREDS = CONFIG["synapse"]["service_acct_creds"]
+
+            # Download in parent directory of SERVICE_ACCT_CREDS to
+            # ensure same file system for os.rename()
+            creds_dir = os.path.dirname(CONFIG.SERVICE_ACCT_CREDS)
+
+            creds_file = syn.get(API_CREDS, downloadLocation = creds_dir)
+            os.rename(creds_file.path, CONFIG.SERVICE_ACCT_CREDS)
+
+            logger.info("The credentials file has been downloaded "
+                       f"to '{CONFIG.SERVICE_ACCT_CREDS}'")
+    
+    else:
+        logger.warning(f"The mode of authentication you selected '{auth}' is "
+                        "not supported. Please use one of either 'token' or "
+                        "'service_account'.")
+
 
 def execute_google_api_requests(service, requests_body, **kwargs):
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ class TestSchemaCli:
         output_path = helpers.get_data_path("simple.model.jsonld")
 
         result = runner.invoke(schema,
-                               ["convert", rfc_csv_path,
+                               ["convert", data_model_csv_path,
                                 "--output_jsonld", output_path])
 
         assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,9 @@ import pytest
 
 from click.testing import CliRunner
 
+# from schematic import init
 from schematic.schemas.commands import schema
+from schematic.utils.google_api_utils import download_creds_file
 
 
 @pytest.fixture
@@ -14,20 +16,20 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
-class SchemaCli:
+class TestSchemaCli:
 
     def test_schema_convert_cli(self, runner, config_path, helpers):
 
         rfc_csv_path = helpers.get_data_path("simple.model.csv")
 
-        result = runner.invoke(schema, 
-                               ["--config", config_path, 
-                               "convert", rfc_csv_path])
-
-        assert result.exit_code == 0
-
         output_path = helpers.get_data_path("simple.model.jsonld")
 
+        result = runner.invoke(schema, 
+                               ["convert", rfc_csv_path,
+                                "--output_jsonld", output_path])
+
+        assert result.exit_code == 0
+        
         expected_substr = (
                           "The Data Model was created and saved to "
                           f"'{output_path}' location."


### PR DESCRIPTION
Note: This PR should be reviewed/merged before PR #429.

This PR adds a new command line utility to our existing list of CLI tools: `schematic init`.

The idea to add the `init` command was based on recommendations by @BrunoGrandePhD (Thanks Bruno), in PR #392. The `init` command takes the following arguments:`--auth` and `--config`. Using the `--auth` optional argument you can control what mode of authentication you want to use, i.e., either `OAuth` or `Service Account`, and you can specify how the files are to be configured using `config.yml`. By doing this you would essentially be eliminating the [`Obtain Credentials File(s)`](https://github.com/Sage-Bionetworks/schematic/tree/develop#134-obtain-credentials-files) step from the setup process.

I didn't want to delay pushing this code, so I haven't added tests for this CLI. I will address that in a future PR.