### PR TITLE
create batch request for Google API to avoid hitting rate limit

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -606,8 +606,8 @@ class ManifestGenerator(object):
 
 
             # generating sheet api request to populate a dropdown or a multi selection UI
-            if len(req_vals) > 10 and not "list" in validation_rules:
-                # if more than 10 values in dropdown use ONE_OF_RANGE type of validation since excel and openoffice
+            if len(req_vals) > 0 and not "list" in validation_rules:
+                # if more than 0 values in dropdown use ONE_OF_RANGE type of validation since excel and openoffice
                 # do not support other kinds of data validation for larger number of items (even if individual items are not that many
                 # excel has a total number of characters limit per dropdown...)
                 validation_body = self._get_column_data_validation_values(spreadsheet_id, req_vals, i, validation_type = "ONE_OF_RANGE")


### PR DESCRIPTION
This PR fixes issue #410. It repeats the code from within the [for loop](https://github.com/Sage-Bionetworks/schematic/blob/develop/schematic/manifest/generator.py#L469-L479) but only in order to create a "request body" so we can issue a single [`batchUpdate()`](https://github.com/Sage-Bionetworks/schematic/blob/develop-rate_limit-fix/schematic/manifest/generator.py#L492) API request. We can now execute the command from within the referenced issue to test, and see it works on large datasets.

Benchmarking results: for the `NF.jsonld` data model to generate a metadata manifest template using existing Synapse annotations, takes about ~10 mins.

Tagging @BrunoGrandePhD and @milen-sage for a code review, and @allaway for a feature review.