### PR TITLE
Miscellaneous fixes in schematic repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ SCHEMATIC is an acronym for _Schema Engine for Manifest Ingress and Curation_. T
 * [Clone Project Repository](https://sage-schematic.readthedocs.io/en/develop/README.html#clone-project-repository)
 * [Virtual Environment Setup](https://sage-schematic.readthedocs.io/en/develop/README.html#virtual-environment-setup)
 * [Install Dependencies](https://sage-schematic.readthedocs.io/en/develop/README.html#install-dependencies)
-* [Obtain Credentials File(s)](https://sage-schematic.readthedocs.io/en/develop/README.html#obtain-credentials-file-s)
 * [Fill in Configuration File(s)](https://sage-schematic.readthedocs.io/en/develop/README.html#fill-in-configuration-file-s)
+* [Obtain Credentials File(s)](https://sage-schematic.readthedocs.io/en/develop/README.html#obtain-credentials-file-s)
 
 
 ## Command Line Interface

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,7 +1,7 @@
 Schematic
 =========
 
-1.1. Introduction
+1. Introduction
 -----------------
 
 SCHEMATIC is an acronym for *Schema Engine for Manifest Ingress and
@@ -10,7 +10,7 @@ schema-based, data ingress ecosystem, that is meant to streamline the
 process of metadata annotation and validation for various data
 contributors.
 
-1.2. Installation Requirements and Pre-requisites
+2. Installation Requirements and Pre-requisites
 -------------------------------------------------
 
 Following are the tools or packages that you will need to set up
@@ -37,10 +37,10 @@ right permissions to download credentials files in the following steps.
 Contact your DCC liaison to request for permission to access the
 credentials files.
 
-1.3. Package Setup Instructions
+3. Package Setup Instructions
 -------------------------------
 
-1.3.1. Clone Project Repository
+3.1. Clone Project Repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Since the package isn't available on `PyPI <https://pypi.org/>`__
@@ -51,7 +51,7 @@ from GitHub by running the following command:
 
     git clone --single-branch --branch develop `https://github.com/Sage-Bionetworks/schematic.git`
 
-1.3.2. Virtual Environment Setup
+3.2. Virtual Environment Setup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
@@ -62,7 +62,7 @@ from GitHub by running the following command:
 
     source .venv/bin/activate # activate the `venv` virtual environment
 
-1.3.3. Install Dependencies
+3.3. Install Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After cloning the ``schematic`` project from GitHub and setting up your
@@ -75,32 +75,7 @@ virtual environment:
     poetry build # build source and wheel archives
     pip install dist/schematicpy-0.1.11-py3-none-any.whl  # install wheel file
 
-1.3.4. Obtain Credentials File(s)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code:: bash
-
-    schematic init --config ~/path/to/config.yml --auth [token|serivce_account] 
-
-The ``credentials.json`` file is required when you are using
-`OAuth2 <https://developers.google.com/identity/protocols/oauth2>`__
-to authenticate with the Google APIs.
-
-For details about the steps involved in the `OAuth2 authorization
-flow <https://github.com/Sage-Bionetworks/schematic/blob/develop/schematic/utils/google_api_utils.py#L18>`__,
-refer to the ``Credentials`` section in the
-`docs/details <https://github.com/Sage-Bionetworks/schematic/blob/develop/docs/details.md#credentials>`__
-document.
-
-Use the ``schematic_service_account_creds.json`` file for the service
-account mode of authentication (*for Google services/APIs*).
-
-Note: The ``Selection Options`` dropdown which allows the user to select
-multiple values in a cell during manifest annotation `does not
-work <https://developers.google.com/apps-script/api/concepts>`__ with
-the service account mode of authentication.
-
-1.3.5. Fill in Configuration File(s)
+3.4. Fill in Configuration File(s)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 There are two main configuration files that need to be edited –
@@ -148,10 +123,35 @@ section.
 Note: You can get your Synapse API key by: *logging into Synapse* >
 *Settings* > *Synapse API Key* > *Show API Key*.
 
-1.3.6. Command Line Interface
+3.5. Obtain Credentials File(s)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: bash
+
+    schematic init --config ~/path/to/config.yml --auth [token|serivce_account] 
+
+The ``credentials.json`` file is required when you are using
+`OAuth2 <https://developers.google.com/identity/protocols/oauth2>`__
+to authenticate with the Google APIs.
+
+For details about the steps involved in the `OAuth2 authorization
+flow <https://github.com/Sage-Bionetworks/schematic/blob/develop/schematic/utils/google_api_utils.py#L18>`__,
+refer to the ``Credentials`` section in the
+`docs/details <https://github.com/Sage-Bionetworks/schematic/blob/develop/docs/details.md#credentials>`__
+document.
+
+Use the ``schematic_service_account_creds.json`` file for the service
+account mode of authentication (*for Google services/APIs*).
+
+Note: The ``Selection Options`` dropdown which allows the user to select
+multiple values in a cell during manifest annotation `does not
+work <https://developers.google.com/apps-script/api/concepts>`__ with
+the service account mode of authentication.
+
+4. Command Line Interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1.3.6.1. Schematic Initialization
+4.1. Schematic Initialization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Initialize `schematic` for use with the `init` command by selecting the 
@@ -161,7 +161,7 @@ mode of authentication of your choice:
 
     schematic init --config ~/path/to/config.yml
 
-1.3.6.2. Metadata Manifest Generation
+4.2. Metadata Manifest Generation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To generate a metadata manifest template based on a data type that is
@@ -171,7 +171,7 @@ present in your data model:
 
     schematic manifest --config ~/path/to/config.yml get
 
-1.3.6.3. Metadata Manifest Validation
+4.3. Metadata Manifest Validation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To simply validate the data filled in the manifest generated from the 
@@ -181,7 +181,7 @@ above step:
 
     schematic model --config validate --manifest_path ~/path/to/manifest.csv
 
-1.3.6.4. Metadata Manifest Validation and Submission
+4.4. Metadata Manifest Validation and Submission
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To submit (and optionally validate) your filled metadata manifest file:
@@ -198,7 +198,7 @@ Note: To view a full list of all the arguments that can be supplied to
 the command line interfaces, add a ``--help`` option at the end of each
 of the commands.
 
-1.4. Contributing
+5. Contributing
 -----------------
 
 Interested in contributing? Awesome! We follow the typical `GitHub
@@ -211,7 +211,7 @@ Started <https://github.com/Sage-Bionetworks/schematic/blob/develop/CONTRIBUTION
 section in our `contributing
 guide <https://github.com/Sage-Bionetworks/schematic/blob/develop/CONTRIBUTION.md>`__.
 
-1.5. Contributors
+6. Contributors
 -----------------
 
 Active contributors and maintainers:

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -149,10 +149,10 @@ work <https://developers.google.com/apps-script/api/concepts>`__ with
 the service account mode of authentication.
 
 4. Command Line Interface
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 4.1. Schematic Initialization
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------
 
 Initialize `schematic` for use with the `init` command by selecting the 
 mode of authentication of your choice:
@@ -162,7 +162,7 @@ mode of authentication of your choice:
     schematic init --config ~/path/to/config.yml
 
 4.2. Metadata Manifest Generation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------
 
 To generate a metadata manifest template based on a data type that is
 present in your data model:
@@ -172,7 +172,7 @@ present in your data model:
     schematic manifest --config ~/path/to/config.yml get
 
 4.3. Metadata Manifest Validation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------
 
 To simply validate the data filled in the manifest generated from the 
 above step:
@@ -182,7 +182,7 @@ above step:
     schematic model --config validate --manifest_path ~/path/to/manifest.csv
 
 4.4. Metadata Manifest Validation and Submission
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------------------------
 
 To submit (and optionally validate) your filled metadata manifest file:
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -152,7 +152,7 @@ the service account mode of authentication.
 -------------------------------
 
 4.1. Schematic Initialization
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Initialize `schematic` for use with the `init` command by selecting the 
 mode of authentication of your choice:
@@ -162,7 +162,7 @@ mode of authentication of your choice:
     schematic init --config ~/path/to/config.yml
 
 4.2. Metadata Manifest Generation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To generate a metadata manifest template based on a data type that is
 present in your data model:
@@ -172,7 +172,7 @@ present in your data model:
     schematic manifest --config ~/path/to/config.yml get
 
 4.3. Metadata Manifest Validation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To simply validate the data filled in the manifest generated from the 
 above step:
@@ -182,7 +182,7 @@ above step:
     schematic model --config validate --manifest_path ~/path/to/manifest.csv
 
 4.4. Metadata Manifest Validation and Submission
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To submit (and optionally validate) your filled metadata manifest file:
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -152,7 +152,7 @@ the service account mode of authentication.
 -------------------------------
 
 4.1. Schematic Initialization
-----------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Initialize `schematic` for use with the `init` command by selecting the 
 mode of authentication of your choice:
@@ -162,7 +162,7 @@ mode of authentication of your choice:
     schematic init --config ~/path/to/config.yml
 
 4.2. Metadata Manifest Generation
-------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To generate a metadata manifest template based on a data type that is
 present in your data model:
@@ -172,7 +172,7 @@ present in your data model:
     schematic manifest --config ~/path/to/config.yml get
 
 4.3. Metadata Manifest Validation
----------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To simply validate the data filled in the manifest generated from the 
 above step:
@@ -182,7 +182,7 @@ above step:
     schematic model --config validate --manifest_path ~/path/to/manifest.csv
 
 4.4. Metadata Manifest Validation and Submission
------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To submit (and optionally validate) your filled metadata manifest file:
 

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -30,8 +30,8 @@ manifest_commands = {
                 "in that folder, then it will be pulled with the existing annotations for further annotation/modification. "
                 ),
             "sheet_url": (
-                "Takes `True` or `False` as argument values. If `True` then it will produce a Googlesheets URL/link "
-                "to the metadata manifest file. If `False`, then it will produce a pandas dataframe for the same."
+                "This is a boolean flag. If flag is provided when command line utility is executed, result will be a link/URL "
+                "to the metadata manifest file. If not it will produce a pandas dataframe for the same."
                 ),
             "output_csv": (
                 "Path to where the CSV manifest template should be stored."
@@ -39,6 +39,10 @@ manifest_commands = {
             "use_annotations": (
                 "Takes `True` or `False` as argument values. If `True` then it will prepopulate template with existing annotations "
                 "associated with dataset files. If `False` it will skip populating template with Synapse annotations."
+                ),
+            "oauth": (
+                "This is a boolean flag. If flag is provided when command line utility is executed, OAuth will be used to "
+                "authenticate your Google credentials. If not service account mode of authentication will be used."
                 ),
             "json_schema": (
                 "Specify the path to the JSON Validation Schema for this argument. "

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -47,7 +47,7 @@ def manifest(ctx, config): # use as `schematic manifest ...`
 @click.option('-dt', '--data_type', help=query_dict(manifest_commands, ("manifest", "get", "data_type")))
 @click.option('-p', '--jsonld', help=query_dict(manifest_commands, ("manifest", "get", "jsonld")))
 @click.option('-d', '--dataset_id', help=query_dict(manifest_commands, ("manifest", "get", "dataset_id")))
-@click.option('-s', '--sheet_url', type=bool, help=query_dict(manifest_commands, ("manifest", "get", "sheet_url")))
+@click.option('-s', '--sheet_url', is_flag=True, help=query_dict(manifest_commands, ("manifest", "get", "sheet_url")))
 @click.option('-o', '--output_csv', help=query_dict(manifest_commands, ("manifest", "get", "output_csv")))
 @click.option('-a', '--use_annotations', is_flag=True, help=query_dict(manifest_commands, ("manifest", "get", "use_annotations")))
 @click.option('-j', '--json_schema', help=query_dict(manifest_commands, ("manifest", "get", "json_schema")))

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -50,10 +50,11 @@ def manifest(ctx, config): # use as `schematic manifest ...`
 @click.option('-s', '--sheet_url', is_flag=True, help=query_dict(manifest_commands, ("manifest", "get", "sheet_url")))
 @click.option('-o', '--output_csv', help=query_dict(manifest_commands, ("manifest", "get", "output_csv")))
 @click.option('-a', '--use_annotations', is_flag=True, help=query_dict(manifest_commands, ("manifest", "get", "use_annotations")))
+@click.option('-a', '--oauth', is_flag=True, help=query_dict(manifest_commands, ("manifest", "get", "oauth")))
 @click.option('-j', '--json_schema', help=query_dict(manifest_commands, ("manifest", "get", "json_schema")))
 @click.pass_obj
 def get_manifest(ctx, title, data_type, jsonld, dataset_id, sheet_url,
-                 output_csv, use_annotations, json_schema):
+                 output_csv, use_annotations, oauth, json_schema):
     """
     Running CLI with manifest generation options.
     """
@@ -80,6 +81,7 @@ def get_manifest(ctx, title, data_type, jsonld, dataset_id, sheet_url,
         path_to_json_ld=jsonld,
         title=title,
         root=data_type,
+        oauth=oauth,
         use_annotations=use_annotations,
     )
 

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -9,7 +9,7 @@ import pygsheets as ps
 import json
 
 from schematic.schemas.generator import SchemaGenerator
-from schematic.utils.google_api_utils import build_credentials, execute_google_api_requests
+from schematic.utils.google_api_utils import build_credentials, execute_google_api_requests, build_service_account_creds
 from schematic.utils.df_utils import update_df
 from schematic.store.synapse import SynapseStorage
 
@@ -24,14 +24,20 @@ class ManifestGenerator(object):
                 title: str = None, # manifest sheet title
                 root: str = None,
                 additional_metadata: Dict = None,
+                oauth: bool = True,
                 use_annotations: bool = False,
                 ) -> None:
 
         """TODO: read in a config file instead of hardcoding paths to credential files...
         """
 
-        # make a call to the build_credentials() function
-        services_creds = build_credentials()
+        if oauth:
+            # if user wants to use OAuth for Google authentication
+            # use credentials.json and create token.pickle file
+            services_creds = build_credentials()
+        else:
+            # if not oauth then use service account credentials
+            services_creds = build_service_account_creds()
 
         # google service for Sheet API
         self.sheet_service = services_creds["sheet_service"]

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -80,7 +80,7 @@ def download_creds_file(auth: str = "token") -> None:
         raise ValueError(f"'{auth}' is not a valid authentication method. Please "
                           "enter one of 'token' or 'service_account'.")
 
-    syn = synapseclient.Synapse()
+    syn = synapseclient.Synapse(configPath=CONFIG.SYNAPSE_CONFIG_PATH)
     syn.login(silent=True)
 
     if auth == "token":


### PR DESCRIPTION
A few miscellaneous fixes that are addressed in this PR:

Note: Some of these problems/issues were identified when going through the `schematic` setup process with @rrchai and @alyssa-acebedo.

1. [`--sheet_url`](https://github.com/Sage-Bionetworks/schematic/blob/develop-misc-fixes/schematic/manifest/commands.py#L50) optional argument has been converted to a boolean flag.

2. Point `synapseclient.Synapse()` call to `.synapseConfig` file. See this [diff](https://github.com/Sage-Bionetworks/schematic/compare/develop-misc-fixes?expand=1#diff-8873f6d90e1568d0d48726fe2b9c7e253ef6a84fd55aaadd9df9bd0bde8d27caR83).

3. Allow users to use one of the two options: `oauth` or `service_account`. [`--oauth`](https://github.com/Sage-Bionetworks/schematic/blob/develop-misc-fixes/schematic/manifest/commands.py#L53) has been added as a boolean flag that can be turned on and off. "On" would instruct schematic to use `oauth` and "Off" would instruct the app to use `service_account`.

4. Updated main [README](https://github.com/Sage-Bionetworks/schematic/tree/develop-misc-fixes) and [RTD docs](https://sage-schematic.readthedocs.io/en/develop-misc-fixes/index.html) with section numbers and order of execution of steps.

Apologies for the many formatting commits.