### PR TITLE
Escape formulae in annotations (fixes #457)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,7 @@ pygsheets = "^2.0.4"
 PyYAML = "^5.4.1"
 rdflib = "^5.0.0"
 setuptools = "^52.0.0"
-synapseclient = "2.3.0"  # Update once Data Curator App supports OAuth tokens
-                         # And once schematic handles booleans (see #458)
+synapseclient = "~2.3"  # ~ (not ^) until Data Curator App supports OAuth tokens
 toml = "^0.10.2"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ pygsheets = "^2.0.4"
 PyYAML = "^5.4.1"
 rdflib = "^5.0.0"
 setuptools = "^52.0.0"
-synapseclient = "~2.3"  # ~ (not ^) until Data Curator App supports OAuth tokens
+synapseclient = "2.3.0"  # Update once Data Curator App supports OAuth tokens
+                         # And once schematic handles booleans (see #458)
 toml = "^0.10.2"
 
 

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -748,6 +748,7 @@ class ManifestGenerator(object):
 
         # open google sheets and extract first sheet
         sh = gc.open_by_url(manifest_url)
+        sh.default_parse = False
         wb = sh[0]
 
         # update spreadsheet with given manifest starting at top-left cell

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -748,11 +748,13 @@ class ManifestGenerator(object):
 
         # open google sheets and extract first sheet
         sh = gc.open_by_url(manifest_url)
-        sh.default_parse = False
         wb = sh[0]
 
+        # The following line sets `valueInputOption = "RAW"` in pygsheets
+        sh.default_parse = False
+
         # update spreadsheet with given manifest starting at top-left cell
-        wb.set_dataframe(manifest_df, (1,1), escape_formulae=True)
+        wb.set_dataframe(manifest_df, (1,1))
 
         # set permissions so that anyone with the link can edit
         sh.share("", role = "writer", type = "anyone")

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -751,7 +751,7 @@ class ManifestGenerator(object):
         wb = sh[0]
 
         # update spreadsheet with given manifest starting at top-left cell
-        wb.set_dataframe(manifest_df, (1,1))
+        wb.set_dataframe(manifest_df, (1,1), escape_formulae=True)
 
         # set permissions so that anyone with the link can edit
         sh.share("", role = "writer", type = "anyone")


### PR DESCRIPTION
This **might** be one of those easy one-line fixes. 

@allaway: Can you check if this PR addresses the problem you faced in #457? You should be able to install this PR's version of schematic with the following command: 

```
python -m pip install git+https://github.com/Sage-Bionetworks/schematic.git@bgrande/issue-457/escape-annotation-values
```