### PR TITLE
Add strict validation to config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,7 @@ definitions:
 synapse:
   master_fileview: 'syn23643253'
   manifest_folder: 'manifests'
-  manifest_filename: 'synapse_storage_manifest.csv'
+  manifest_filename: 'data/manifests/synapse_storage_manifest.csv'
   token_creds: 'syn23643259'
   service_acct_creds: 'syn25171627'
 
@@ -18,8 +18,10 @@ manifest:
 
 model:
   input:
-    location: 'tests/data/example.model.jsonld'
+    location: 'data/schema_org_schemas/example.jsonld'
     file_type: 'local'
+    validation_schema: 'data/validation_schemas/example_validation_schema.json'
+    log_location: 'data/json_schema_logs/json_schema_log.json'
 
 style:
   google_manifest:
@@ -32,3 +34,4 @@ style:
       green: 1.0
       blue: 0.9019
     master_template_id: '1LYS5qE4nV9jzcYw5sXwCza25slDfRA1CIg3cs-hCdpU'
+    strict_validation: true

--- a/config.yml
+++ b/config.yml
@@ -20,8 +20,6 @@ model:
   input:
     location: 'tests/data/example.model.jsonld'
     file_type: 'local'
-    validation_schema: 'data/validation_schemas/example_validation_schema.json'
-    log_location: 'data/json_schema_logs/json_schema_log.json'
 
 style:
   google_manifest:

--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,7 @@ definitions:
 synapse:
   master_fileview: 'syn23643253'
   manifest_folder: 'manifests'
-  manifest_filename: 'data/manifests/synapse_storage_manifest.csv'
+  manifest_filename: 'synapse_storage_manifest.csv'
   token_creds: 'syn23643259'
   service_acct_creds: 'syn25171627'
 
@@ -18,7 +18,7 @@ manifest:
 
 model:
   input:
-    location: 'data/schema_org_schemas/example.jsonld'
+    location: 'tests/data/example.model.jsonld'
     file_type: 'local'
     validation_schema: 'data/validation_schemas/example_validation_schema.json'
     log_location: 'data/json_schema_logs/json_schema_log.json'

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -249,10 +249,13 @@ class ManifestGenerator(object):
         valid_values,
         column_id,
         validation_type="ONE_OF_LIST",
-        strict=True,
         custom_ui=True,
         input_message="Choose one from dropdown",
     ):
+
+        strict = CONFIG["style"]["google_manifest"].get(
+            "strict_validation",
+            True)
 
         # get valid values w/o google sheet header
         values = [valid_value["userEnteredValue"] for valid_value in valid_values]
@@ -1000,3 +1003,4 @@ class ManifestGenerator(object):
             manifest_fields.append("entityId")
 
         return manifest_fields
+                            

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1003,4 +1003,3 @@ class ManifestGenerator(object):
             manifest_fields.append("entityId")
 
         return manifest_fields
-                            

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -253,9 +253,7 @@ class ManifestGenerator(object):
         input_message="Choose one from dropdown",
     ):
 
-        strict = CONFIG["style"]["google_manifest"].get(
-            "strict_validation",
-            True)
+        strict = CONFIG["style"]["google_manifest"].get("strict_validation", True)
 
         # get valid values w/o google sheet header
         values = [valid_value["userEnteredValue"] for valid_value in valid_values]


### PR DESCRIPTION
Splitting out of #465. 

Closes #341.

This adds the ability to configure the "warn" vs "reject" option in the generated manifest but toggling a boolean in the config file. 