### PR TITLE
Retrieving information about manifests associated with all datasets in a project

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -364,7 +364,7 @@ class SynapseStorage(BaseStorage):
         return manifest_id
 
 
-    def getAllManifests(self, projectId: str) -> List[str]:
+    def getProjectManifests(self, projectId: str) -> List[str]:
         """Gets all metadata manifest files across all datasets in a specified project.
 
         Returns: A list of datasets per project; metadata manifest Synapse ID for each dataset; and the corresponding schema component of the manifest

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -363,46 +363,66 @@ class SynapseStorage(BaseStorage):
 
         return manifest_id
 
-    def getAllManifests(self) -> List[str]:
-        """Gets all metadata manifest files across all datasets in projects a user has access to.
 
-        Returns: A list of projects, datasets per project and metadata manifest Synapse ID for each dataset
+    def getAllManifests(self, projectId: str) -> List[str]:
+        """Gets all metadata manifest files across all datasets in a specified project.
+
+        Returns: A list of datasets per project; metadata manifest Synapse ID for each dataset; and the corresponding schema component of the manifest
                  as a list of tuples, one for each manifest:
                     [
                         (
-                            (projectId, projectName),
                             (datasetId, dataName),
-                            (manifestId, manifestName)
+                            (manifestId, manifestName),
+                            (componentSchemaLabel, componentSchemaLabel) TODO: # get component name from schema
                         ),
                         ...
                     ]
 
         TODO: Return manifest URI instead of Synapse ID for interoperability with other implementations of a store interface
-        TODO: Use fileview instead of iterating through projects and datasets
-        TODO: GetDatasetManifest() return type has changed to return only manifest synapse ID. Fetch
-              manifestName from config.yml and create tuple
         """
 
-        projects = self.getStorageProjects()
 
         manifests = []
-        for projectId, projectName in projects:
 
-            datasets = self.getStorageDatasetsInProject(projectId)
+        datasets = self.getStorageDatasetsInProject(projectId)
 
-            for (datasetId, datasetName) in datasets:
+        for (datasetId, datasetName) in datasets:
+            # encode information about the manifest in a simple list (so that R clients can unpack it)
+            # eventually can serialize differently
 
-                # encode information about the manifest in a simple list (so that R clients can unpack it)
-                # eventually can serialize differently
-                manifest = (
-                    (projectId, projectName),
+            manifest = (
                     (datasetId, datasetName),
-                    self.getDatasetManifest(datasetId),
-                )
-
-                manifests.append(manifest)
+                    ("", ""),
+                    ("", "")
+            )
+            
+            manifest_info = self.getDatasetManifest(datasetId, downloadFile = True)
+            if manifest_info:
+                manifest_id = manifest_info["properties"]["id"]
+                manifest_name = manifest_info["properties"]["name"]
+                manifest_path = manifest_info["path"]
+                
+                manifest_df = pd.read_csv(manifest_path)
+            
+                if "Component" in manifest_df and  not manifest_df["Component"].empty:
+                    manifest_component = manifest_df["Component"][0]         
+        
+                    manifest = (
+                        (datasetId, datasetName),
+                        (manifest_id, manifest_name),
+                        (manifest_component, manifest_component)
+                    )
+                else:
+                    manifest = (
+                        (datasetId, datasetName),
+                        (manifest_id, manifest_name),
+                        ("", "")
+                    )
+            
+            manifests.append(manifest)
 
         return manifests
+
 
     def get_synapse_table(self, synapse_id: str) -> Tuple[pd.DataFrame, CsvFileTable]:
         """Download synapse table as a pd dataframe; return table schema and etags as results too


### PR DESCRIPTION
Adding a function retrieving all synapse IDs of manifests associated with a project, in addition to listing the data model component associated with each manifest, if applicable.

 @rrchai this may be of use for your work on the metadata dashboard. Note the return list of the function: 
- if no manifest is present in a dataset folder, the manifest ID is empty string
- if a manifest is present, but not Component is specified in the manifest columns, the component name is an empty string. (This is possible for manifests in general, but shouldn't happen given the HTAN data model, for instance.) 