### PR TITLE
REST API endpoint that calls get_manifest()

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -6,3 +6,9 @@ To start a local Flask server and test your endpoints:
 source .venv/bin/activate
 python run_api.py
 ```
+
+Access the Swagger UI docs at this location:
+
+```bash
+http://localhost:3001/v1/ui/
+```

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,8 @@
+## Setup
+
+To start a local Flask server and test your endpoints:
+
+```bash
+source .venv/bin/activate
+python run_api.py
+```

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -4,23 +4,18 @@ import connexion
 
 from schematic import CONFIG
 
-# path to `config.yml` file as constant
-CONFIG_PATH = os.path.abspath(os.path.join(__file__, "../../config.yml"))
-
 
 def create_app():
     connexionapp = connexion.FlaskApp(__name__, specification_dir="openapi/")
     connexionapp.add_api("api.yaml")
+
+    # get the underlying Flask app instance
     app = connexionapp.app
 
-    # Configure schematic and do the error handling
-    # check if file exists at the path created, i.e., CONFIG_PATH
-    if os.path.isfile(CONFIG_PATH):
-        CONFIG.load_config(CONFIG_PATH)
-    else:
-        FileNotFoundError(
-            f"No configuration file was found at this path: {CONFIG_PATH}"
-        )
+    # path to config.yml file saved as a Flask config variable
+    app.config["SCHEMATIC_CONFIG"] = os.path.abspath(
+        os.path.join(__file__, "../../config.yml")
+    )
 
     # Configure flask app
     # app.config[] = schematic[]

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,9 @@
+import connexion
+
+
+def create_app():
+    connexionapp = connexion.FlaskApp(__name__, specification_dir="openapi/")
+    connexionapp.add_api("api.yaml")
+    app = connexionapp.app
+
+    return app

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,4 +1,11 @@
+import os
+
 import connexion
+
+from schematic import CONFIG
+
+# path to `config.yml` file as constant
+CONFIG_PATH = os.path.abspath(os.path.join(__file__, "../../config.yml"))
 
 
 def create_app():
@@ -6,9 +13,14 @@ def create_app():
     connexionapp.add_api("api.yaml")
     app = connexionapp.app
 
-    # Configure schematic & do the error handling
-    # Call schematic.load_config()
-    # keys = schematic get_config()
+    # Configure schematic and do the error handling
+    # check if file exists at the path created, i.e., CONFIG_PATH
+    if os.path.isfile(CONFIG_PATH):
+        CONFIG.load_config(CONFIG_PATH)
+    else:
+        FileNotFoundError(
+            f"No configuration file was found at this path: {CONFIG_PATH}"
+        )
 
     # Configure flask app
     # app.config[] = schematic[]
@@ -25,4 +37,4 @@ def create_app():
 # def route_code():
 #     import flask_schematic as sc
 #     sc.method1()
-# 
+#

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -6,4 +6,23 @@ def create_app():
     connexionapp.add_api("api.yaml")
     app = connexionapp.app
 
+    # Configure schematic & do the error handling
+    # Call schematic.load_config()
+    # keys = schematic get_config()
+
+    # Configure flask app
+    # app.config[] = schematic[]
+    # app.config[] = schematic[]
+    # app.config[] = schematic[]
+
+    # Initialize extension schematic
+    # import MyExtension
+    # myext = MyExtension()
+    # myext.init_app(app)
+
     return app
+
+# def route_code():
+#     import flask_schematic as sc
+#     sc.method1()
+# 

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.0
+info:
+  title: Schematic Rest API
+  version: 0.1.0
+  description: Schematic endpoints
+
+servers:
+  - url: /v1
+
+paths:
+  /manifest/generate:
+    get:
+      summary: >-
+        Endpoints to expose annotation, validation and submission
+        functionalities from schematic
+      description: Endpoint to create dynamically create metadata manifest files
+      parameters:
+        - in: query
+          name: title
+          schema:
+            type: string
+            default: Test_Manifest
+          description: Title of manifest to be created
+          required: false
+        - in: query
+          name: data_type
+          schema:
+            type: string
+            nullable: true
+          description: Data type/component from data model
+          required: true
+        - in: query
+          name: oauth
+          schema:
+            type: boolean
+            default: true
+          description: >-
+            Boolean parameter that decides whether to use token or service
+            account mode of authentication
+          required: false
+        - in: query
+          name: use_annotations
+          schema:
+            type: boolean
+            default: false
+          description: Automatically populate manifest from Synapse annotations
+          required: false
+        - in: query
+          name: dataset_id
+          schema:
+            type: string
+            nullable: true
+          description: Synapse Id of annotated or unannotated dataset
+          required: true
+      operationId: api.routes.get_manifest_route
+      responses:
+        '200':
+          description: Sucess
+          content:
+            application/json:
+              schema:
+                type: string

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -63,9 +63,12 @@ paths:
           required: true
       operationId: api.routes.get_manifest_route
       responses:
-        '200':
-          description: Success. Googlesheet link created.
+        '201':
+          description: Googlesheet link created.
           content:
             application/json:
               schema:
                 type: string
+          summary: Create link to manifest file
+      tags:
+        - Manifest Operations

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -69,6 +69,5 @@ paths:
             application/json:
               schema:
                 type: string
-          summary: Create link to manifest file
       tags:
         - Manifest Operations

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -1,8 +1,10 @@
 openapi: 3.0.0
 info:
-  title: Schematic Rest API
+  title: Schematic REST API
   version: 0.1.0
-  description: Schematic endpoints
+  description: >-
+    This service exposes core functionalities from schematic as REST API
+    endpoints
 
 servers:
   - url: /v1
@@ -20,13 +22,15 @@ paths:
           schema:
             type: string
           description: Data Model URL
+          example: >-
+            https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld
           required: true
         - in: query
           name: title
           schema:
             type: string
-            default: Test_Manifest
           description: Title of Manifest
+          example: Patient Metadata Manifest
           required: false
         - in: query
           name: data_type
@@ -34,6 +38,7 @@ paths:
             type: string
             nullable: true
           description: Data Model Component
+          example: Patient
           required: true
         - in: query
           name: oauth
@@ -58,8 +63,8 @@ paths:
           required: true
       operationId: api.routes.get_manifest_route
       responses:
-        "200":
-          description: Sucess
+        '200':
+          description: Success. Googlesheet link created.
           content:
             application/json:
               schema:

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -16,45 +16,49 @@ paths:
       description: Endpoint to create dynamically create metadata manifest files
       parameters:
         - in: query
+          name: schema_url
+          schema:
+            type: string
+          description: Data Model URL
+          required: true
+        - in: query
           name: title
           schema:
             type: string
             default: Test_Manifest
-          description: Title of manifest to be created
+          description: Title of Manifest
           required: false
         - in: query
           name: data_type
           schema:
             type: string
             nullable: true
-          description: Data type/component from data model
+          description: Data Model Component
           required: true
         - in: query
           name: oauth
           schema:
             type: boolean
             default: true
-          description: >-
-            Boolean parameter that decides whether to use token or service
-            account mode of authentication
+          description: OAuth or Service Account
           required: false
         - in: query
           name: use_annotations
           schema:
             type: boolean
             default: false
-          description: Automatically populate manifest from Synapse annotations
+          description: To Use Annotations
           required: false
         - in: query
           name: dataset_id
           schema:
             type: string
             nullable: true
-          description: Synapse Id of annotated or unannotated dataset
+          description: Dataset SynID
           required: true
       operationId: api.routes.get_manifest_route
       responses:
-        '200':
+        "200":
           description: Sucess
           content:
             application/json:

--- a/api/routes.py
+++ b/api/routes.py
@@ -16,11 +16,16 @@ from schematic.manifest.generator import ManifestGenerator
 #     # Do stuff after your route executes
 #     pass
 
+CONFIG_PATH = os.path.join(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)), "config.yml"
+)
+
 # @before_request
 def get_manifest_route(title, oauth, use_annotations):
-    CONFIG.load_config("./config.yml")
+    CONFIG.load_config(CONFIG_PATH)
     jsonld = get_from_config(CONFIG.DATA, ("model", "input", "location"))
 
+    # TODO: move schematic config parameters into FlaskApp config object
     # current_app.config['model']
     # current_app.config['input']
     # current_app.config['location']
@@ -37,9 +42,9 @@ def get_manifest_route(title, oauth, use_annotations):
         use_annotations=use_annotations,
     )
 
+    dataset_id = connexion.request.args["dataset_id"]
+
     # call get_manifest() on manifest_generator
-    result = manifest_generator.get_manifest(
-        sheet_url=True, dataset_id=connexion.request.args["dataset_id"]
-    )
+    result = manifest_generator.get_manifest(sheet_url=True, dataset_id=dataset_id)
 
     return result

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,0 +1,32 @@
+import os
+
+import connexion
+
+from schematic import CONFIG
+
+from schematic.utils.cli_utils import get_from_config
+from schematic.manifest.generator import ManifestGenerator
+
+
+def get_manifest_route(title, oauth, use_annotations):
+    CONFIG.load_config("./config.yml")
+
+    jsonld = get_from_config(CONFIG.DATA, ("model", "input", "location"))
+
+    data_type = connexion.request.args["data_type"]
+
+    # create object of type ManifestGenerator
+    manifest_generator = ManifestGenerator(
+        path_to_json_ld=jsonld,
+        title=title,
+        root=data_type,
+        oauth=oauth,
+        use_annotations=use_annotations,
+    )
+
+    # call get_manifest() on manifest_generator
+    result = manifest_generator.get_manifest(
+        sheet_url=True, dataset_id=connexion.request.args["dataset_id"]
+    )
+
+    return result

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,6 +1,7 @@
 import os
 
 import connexion
+from flask import current_app, request, g
 
 from schematic import CONFIG
 
@@ -8,11 +9,23 @@ from schematic.utils.cli_utils import get_from_config
 from schematic.manifest.generator import ManifestGenerator
 
 
+# def before_request(var1, var2):
+#     # Do stuff before your route executes
+#     pass
+# def after_request(var1, var2):
+#     # Do stuff after your route executes
+#     pass
+
+# @before_request
 def get_manifest_route(title, oauth, use_annotations):
     CONFIG.load_config("./config.yml")
-
     jsonld = get_from_config(CONFIG.DATA, ("model", "input", "location"))
 
+    # current_app.config['model']
+    # current_app.config['input']
+    # current_app.config['location']
+
+    # request.data[]
     data_type = connexion.request.args["data_type"]
 
     # create object of type ManifestGenerator

--- a/api/routes.py
+++ b/api/routes.py
@@ -6,9 +6,6 @@ import urllib.request
 import connexion
 from flask import current_app, request, g
 
-from schematic import CONFIG
-
-from schematic.utils.cli_utils import get_from_config
 from schematic.manifest.generator import ManifestGenerator
 
 
@@ -19,15 +16,8 @@ from schematic.manifest.generator import ManifestGenerator
 #     # Do stuff after your route executes
 #     pass
 
-# path to `config.yml` file as constant
-CONFIG_PATH = os.path.join(
-    os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)), "config.yml"
-)
-
 # @before_request
 def get_manifest_route(schema_url, title, oauth, use_annotations):
-    CONFIG.load_config(CONFIG_PATH)
-
     # retrieve a JSON-LD via URL and store it in a temporary location
     with urllib.request.urlopen(schema_url) as response:
         with tempfile.NamedTemporaryFile(delete=False, suffix=".jsonld") as tmp_file:
@@ -36,7 +26,7 @@ def get_manifest_route(schema_url, title, oauth, use_annotations):
     # get path to temporary JSON-LD file
     jsonld = tmp_file.name
 
-    # TODO: move schematic config parameters into FlaskApp config object
+    # Move schematic config parameters into FlaskApp config object if any
     # current_app.config['model']
     # current_app.config['input']
     # current_app.config['location']

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,10 +23,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 
 [[package]]
 name = "black"
@@ -37,14 +37,14 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-regex = ">=2020.1.8"
-mypy-extensions = ">=0.4.3"
-typed-ast = ">=1.4.0"
-toml = ">=0.10.1"
-typing-extensions = ">=3.7.4"
-pathspec = ">=0.6,<1"
-click = ">=7.1.2"
 appdirs = "*"
+click = ">=7.1.2"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.6,<1"
+regex = ">=2020.1.8"
+toml = ">=0.10.1"
+typed-ast = ">=1.4.0"
+typing-extensions = ">=3.7.4"
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -105,12 +105,47 @@ python-versions = "*"
 click = "*"
 
 [[package]]
+name = "clickclick"
+version = "20.10.2"
+description = "Click utility functions"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+click = ">=4.0"
+PyYAML = ">=3.11"
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "connexion"
+version = "2.7.0"
+description = "Connexion - API first applications with OpenAPI/Swagger and Flask"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+clickclick = ">=1.2"
+flask = ">=1.0.4"
+inflection = ">=0.3.1"
+jsonschema = ">=2.5.1"
+openapi-spec-validator = ">=0.2.4"
+PyYAML = ">=5.1"
+requests = ">=2.9.1"
+
+[package.extras]
+aiohttp = ["aiohttp (>=2.3.10)", "aiohttp-jinja2 (>=0.14.0)"]
+flask = ["flask (>=1.0.4)"]
+swagger-ui = ["swagger-ui-bundle (>=0.0.2)"]
+tests = ["decorator", "pytest", "pytest-cov", "testfixtures", "flask (>=1.0.4)", "swagger-ui-bundle (>=0.0.2)", "aiohttp (>=2.3.10)", "aiohttp-jinja2 (>=0.14.0)", "pytest-aiohttp", "aiohttp-remotes"]
 
 [[package]]
 name = "coverage"
@@ -135,11 +170,11 @@ python-versions = ">=3.6"
 cffi = ">=1.12"
 
 [package.extras]
-pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
@@ -187,6 +222,24 @@ pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
+name = "flask"
+version = "2.0.1"
+description = "A simple framework for building complex web applications."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = ">=7.1.2"
+itsdangerous = ">=2.0"
+Jinja2 = ">=3.0"
+Werkzeug = ">=2.0"
+
+[package.extras]
+async = ["asgiref (>=3.2)"]
+dotenv = ["python-dotenv"]
+
+[[package]]
 name = "google-api-core"
 version = "1.26.3"
 description = "Google API client core library"
@@ -195,13 +248,13 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [package.dependencies]
+google-auth = ">=1.21.1,<2.0dev"
 googleapis-common-protos = ">=1.6.0,<2.0dev"
-protobuf = ">=3.12.0"
-six = ">=1.13.0"
 packaging = ">=14.3"
+protobuf = ">=3.12.0"
 pytz = "*"
 requests = ">=2.18.0,<3.0.0dev"
-google-auth = ">=1.21.1,<2.0dev"
+six = ">=1.13.0"
 
 [package.extras]
 grpc = ["grpcio (>=1.29.0,<2.0dev)"]
@@ -217,11 +270,11 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
 [package.dependencies]
-six = ">=1.13.0,<2dev"
-google-auth-httplib2 = ">=0.0.3"
 google-api-core = ">=1.21.0,<2dev"
-httplib2 = ">=0.15.0,<1dev"
 google-auth = ">=1.16.0"
+google-auth-httplib2 = ">=0.0.3"
+httplib2 = ">=0.15.0,<1dev"
+six = ">=1.13.0,<2dev"
 uritemplate = ">=3.0.0,<4dev"
 
 [[package]]
@@ -233,14 +286,14 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [package.dependencies]
-six = ">=1.9.0"
-pyasn1-modules = ">=0.2.1"
 cachetools = ">=2.0.0,<5.0"
+pyasn1-modules = ">=0.2.1"
 rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
+six = ">=1.9.0"
 
 [package.extras]
-pyopenssl = ["pyopenssl (>=20.0.0)"]
 aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)"]
+pyopenssl = ["pyopenssl (>=20.0.0)"]
 reauth = ["pyu2f (>=0.1.5)"]
 
 [[package]]
@@ -252,9 +305,9 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
-six = "*"
-httplib2 = ">=0.9.1"
 google-auth = "*"
+httplib2 = ">=0.9.1"
+six = "*"
 
 [[package]]
 name = "google-auth-oauthlib"
@@ -265,8 +318,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-requests-oauthlib = ">=0.7.0"
 google-auth = ">=1.0.0"
+requests-oauthlib = ">=0.7.0"
 
 [package.extras]
 tool = ["click (>=6.0.0)"]
@@ -294,9 +347,9 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [package.extras]
-test = ["mock (>=3)", "pytest (>=4)", "pytest-mock (>=2)", "pytest-cov"]
-docs = ["sphinx (>=1.8)", "sphinx-rtd-theme"]
 dev = ["tox (>=3)", "flake8", "pep8-naming", "wheel", "twine"]
+docs = ["sphinx (>=1.8)", "sphinx-rtd-theme"]
+test = ["mock (>=3)", "pytest (>=4)", "pytest-mock (>=2)", "pytest-cov"]
 
 [[package]]
 name = "httplib2"
@@ -360,6 +413,28 @@ python-versions = "*"
 six = "*"
 
 [[package]]
+name = "itsdangerous"
+version = "2.0.1"
+description = "Safely pass data to untrusted environments and back."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "jinja2"
+version = "3.0.1"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
 name = "jsonschema"
 version = "3.2.0"
 description = "An implementation of JSON Schema validation for Python"
@@ -368,14 +443,14 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
+attrs = ">=17.4.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 pyrsistent = ">=0.14.0"
 six = ">=1.11.0"
-attrs = ">=17.4.0"
 
 [package.extras]
-format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
 format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
+format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
 
 [[package]]
 name = "keyring"
@@ -410,6 +485,14 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5)", "pytest-sugar (>=0.9.1)", "collective.checkdocs", "pytest-flake8", "backports.unittest-mock", "keyring[test] (>=10.3.1)", "fs (>=0.5,<2)", "gdata", "python-keyczar", "pycrypto"]
 
 [[package]]
+name = "markupsafe"
+version = "2.0.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
@@ -438,16 +521,16 @@ decorator = ">=4.3,<5"
 
 [package.extras]
 all = ["numpy", "scipy", "pandas", "matplotlib", "pygraphviz", "pydot", "pyyaml", "lxml", "pytest"]
-lxml = ["lxml"]
-pydot = ["pydot"]
-numpy = ["numpy"]
-pyyaml = ["pyyaml"]
-matplotlib = ["matplotlib"]
-scipy = ["scipy"]
-pytest = ["pytest"]
-pygraphviz = ["pygraphviz"]
-pandas = ["pandas"]
 gdal = ["gdal"]
+lxml = ["lxml"]
+matplotlib = ["matplotlib"]
+numpy = ["numpy"]
+pandas = ["pandas"]
+pydot = ["pydot"]
+pygraphviz = ["pygraphviz"]
+pytest = ["pytest"]
+pyyaml = ["pyyaml"]
+scipy = ["scipy"]
 
 [[package]]
 name = "numpy"
@@ -466,11 +549,11 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
-pyasn1-modules = ">=0.0.5"
-six = ">=1.6.1"
-pyasn1 = ">=0.1.7"
 httplib2 = ">=0.9.1"
+pyasn1 = ">=0.1.7"
+pyasn1-modules = ">=0.0.5"
 rsa = ">=3.1.4"
+six = ">=1.6.1"
 
 [[package]]
 name = "oauthlib"
@@ -481,9 +564,45 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
+rsa = ["cryptography"]
 signals = ["blinker"]
 signedtoken = ["cryptography", "pyjwt (>=1.0.0)"]
-rsa = ["cryptography"]
+
+[[package]]
+name = "openapi-schema-validator"
+version = "0.1.5"
+description = "OpenAPI schema validation for Python"
+category = "main"
+optional = false
+python-versions = ">= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*, != 3.4.*"
+
+[package.dependencies]
+isodate = "*"
+jsonschema = ">=3.0.0"
+six = "*"
+
+[package.extras]
+isodate = ["isodate"]
+rfc3339_validator = ["rfc3339-validator"]
+strict_rfc3339 = ["strict-rfc3339"]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.3.1"
+description = "OpenAPI 2.0 (aka Swagger) and OpenAPI 3.0 spec validator"
+category = "main"
+optional = false
+python-versions = ">= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*, != 3.4.*"
+
+[package.dependencies]
+jsonschema = "*"
+openapi-schema-validator = "*"
+PyYAML = ">=5.1"
+six = "*"
+
+[package.extras]
+dev = ["pre-commit"]
+requests = ["requests"]
 
 [[package]]
 name = "packaging"
@@ -505,9 +624,9 @@ optional = false
 python-versions = ">=3.7.1"
 
 [package.dependencies]
+numpy = ">=1.16.5"
 python-dateutil = ">=2.7.3"
 pytz = ">=2017.3"
-numpy = ">=1.16.5"
 
 [package.extras]
 test = ["pytest (>=5.0.1)", "pytest-xdist", "hypothesis (>=3.58)"]
@@ -605,8 +724,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
-google-auth-oauthlib = "*"
 google-api-python-client = ">=1.5.5"
+google-auth-oauthlib = "*"
 
 [package.extras]
 pandas = ["pandas (>=0.14.0)"]
@@ -636,15 +755,15 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-packaging = "*"
-py = ">=1.8.2"
-iniconfig = "*"
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-attrs = ">=19.2.0"
-toml = "*"
-pluggy = ">=0.12,<1.0.0a1"
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<1.0.0a1"
+py = ">=1.8.2"
+toml = "*"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
@@ -658,8 +777,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-pytest = ">=4.6"
 coverage = ">=5.2.1"
+pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
@@ -733,15 +852,15 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
+isodate = "*"
 pyparsing = "*"
 six = "*"
-isodate = "*"
 
 [package.extras]
 docs = ["sphinx (<3)", "sphinxcontrib-apidoc"]
-tests = ["html5lib", "networkx", "nose", "doctest-ignore-unicode"]
 html = ["html5lib"]
 sparql = ["requests"]
+tests = ["html5lib", "networkx", "nose", "doctest-ignore-unicode"]
 
 [[package]]
 name = "regex"
@@ -760,9 +879,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-idna = ">=2.5,<3"
 certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<5"
+idna = ">=2.5,<3"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
@@ -827,16 +946,16 @@ python-versions = ">=3.6.*"
 
 [package.dependencies]
 deprecated = ">=1.2.4,<2.0"
-requests = ">=2.22.0,<3.0"
 keyring = "12.0.2"
 "keyrings.alt" = {version = "3.1", markers = "sys_platform == \"linux\""}
+requests = ">=2.22.0,<3.0"
 
 [package.extras]
 boto3 = ["boto3 (>=1.7.0,<2.0)"]
 docs = ["sphinx (>=3.0,<4.0)", "sphinx-argparse (>=0.2,<0.3)"]
-tests = ["pytest (>=5.0.0,<7.0)", "pytest-mock (>=3.0,<4.0)", "flake8 (>=3.7.0,<4.0)"]
-pysftp = ["pysftp (>=0.2.8,<0.3)"]
 pandas = ["pandas (>=0.25.0,<2.0)"]
+pysftp = ["pysftp (>=0.2.8,<0.3)"]
+tests = ["pytest (>=5.0.0,<7.0)", "pytest-mock (>=3.0,<4.0)", "flake8 (>=3.7.0,<4.0)"]
 
 [[package]]
 name = "toml"
@@ -879,9 +998,20 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 brotli = ["brotlipy (>=0.6.0)"]
+
+[[package]]
+name = "werkzeug"
+version = "2.0.1"
+description = "The comprehensive WSGI web application library."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+watchdog = ["watchdog"]
 
 [[package]]
 name = "wrapt"
@@ -906,7 +1036,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "08a00bb1cd318502c183e79a7b8e5a13a3f64de7b8d753ccda8a0b2c34a2122c"
+content-hash = "692982a88332023f9ce5767b8354675cb29809f24d89402cd603340e10c35284"
 
 [metadata.files]
 appdirs = [
@@ -949,24 +1079,36 @@ cffi = [
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55"},
     {file = "cffi-1.14.5-cp36-cp36m-win32.whl", hash = "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53"},
     {file = "cffi-1.14.5-cp36-cp36m-win_amd64.whl", hash = "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813"},
     {file = "cffi-1.14.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc"},
     {file = "cffi-1.14.5-cp37-cp37m-win32.whl", hash = "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62"},
     {file = "cffi-1.14.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4"},
     {file = "cffi-1.14.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76"},
     {file = "cffi-1.14.5-cp38-cp38-win32.whl", hash = "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e"},
     {file = "cffi-1.14.5-cp38-cp38-win_amd64.whl", hash = "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396"},
     {file = "cffi-1.14.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7"},
     {file = "cffi-1.14.5-cp39-cp39-win32.whl", hash = "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396"},
     {file = "cffi-1.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d"},
     {file = "cffi-1.14.5.tar.gz", hash = "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"},
@@ -983,9 +1125,17 @@ click-log = [
     {file = "click-log-0.3.2.tar.gz", hash = "sha256:16fd1ca3fc6b16c98cea63acf1ab474ea8e676849dc669d86afafb0ed7003124"},
     {file = "click_log-0.3.2-py2.py3-none-any.whl", hash = "sha256:eee14dc37cdf3072158570f00406572f9e03e414accdccfccd4c538df9ae322c"},
 ]
+clickclick = [
+    {file = "clickclick-20.10.2-py2.py3-none-any.whl", hash = "sha256:c8f33e6d9ec83f68416dd2136a7950125bd256ec39ccc9a85c6e280a16be2bb5"},
+    {file = "clickclick-20.10.2.tar.gz", hash = "sha256:4efb13e62353e34c5eef7ed6582c4920b418d7dedc86d819e22ee089ba01802c"},
+]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+connexion = [
+    {file = "connexion-2.7.0-py2.py3-none-any.whl", hash = "sha256:5439e9659a89c4380d93a07acfbf3380d70be4130574de8881e5f0dfec7ad0e2"},
+    {file = "connexion-2.7.0.tar.gz", hash = "sha256:1ccfac57d4bb7adf4295ba6f5e48f5a1f66057df6a0713417766c9b5235182ee"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
@@ -1071,6 +1221,10 @@ flake8 = [
     {file = "flake8-3.9.1-py2.py3-none-any.whl", hash = "sha256:3b9f848952dddccf635be78098ca75010f073bfe14d2c6bda867154bea728d2a"},
     {file = "flake8-3.9.1.tar.gz", hash = "sha256:1aa8990be1e689d96c745c5682b687ea49f2e05a443aff1f8251092b0014e378"},
 ]
+flask = [
+    {file = "Flask-2.0.1-py3-none-any.whl", hash = "sha256:a6209ca15eb63fc9385f38e452704113d679511d9574d09b2cf9183ae7d20dc9"},
+    {file = "Flask-2.0.1.tar.gz", hash = "sha256:1c4c257b1892aec1398784c63791cbaa43062f1f7aeb555c4da961b20ee68f55"},
+]
 google-api-core = [
     {file = "google-api-core-1.26.3.tar.gz", hash = "sha256:b914345c7ea23861162693a27703bab804a55504f7e6e9abcaff174d80df32ac"},
     {file = "google_api_core-1.26.3-py2.py3-none-any.whl", hash = "sha256:099762d4b4018cd536bcf85136bf337957da438807572db52f21dc61251be089"},
@@ -1123,6 +1277,14 @@ isodate = [
     {file = "isodate-0.6.0-py2.py3-none-any.whl", hash = "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"},
     {file = "isodate-0.6.0.tar.gz", hash = "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8"},
 ]
+itsdangerous = [
+    {file = "itsdangerous-2.0.1-py3-none-any.whl", hash = "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c"},
+    {file = "itsdangerous-2.0.1.tar.gz", hash = "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"},
+]
+jinja2 = [
+    {file = "Jinja2-3.0.1-py3-none-any.whl", hash = "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4"},
+    {file = "Jinja2-3.0.1.tar.gz", hash = "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"},
+]
 jsonschema = [
     {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
     {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
@@ -1134,6 +1296,42 @@ keyring = [
 "keyrings.alt" = [
     {file = "keyrings.alt-3.1-py2.py3-none-any.whl", hash = "sha256:6a00fa799baf1385cf9620bd01bcc815aa56e6970342a567bcfea0c4d21abe5f"},
     {file = "keyrings.alt-3.1.tar.gz", hash = "sha256:b59c86b67b9027a86e841a49efc41025bcc3b1b0308629617b66b7011e52db5a"},
+]
+markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
+    {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
@@ -1179,6 +1377,16 @@ oauth2client = [
 oauthlib = [
     {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
     {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
+]
+openapi-schema-validator = [
+    {file = "openapi-schema-validator-0.1.5.tar.gz", hash = "sha256:a4b2712020284cee880b4c55faa513fbc2f8f07f365deda6098f8ab943c9f0df"},
+    {file = "openapi_schema_validator-0.1.5-py2-none-any.whl", hash = "sha256:215b516d0942f4e8e2446cf3f7d4ff2ed71d102ebddcc30526d8a3f706ab1df6"},
+    {file = "openapi_schema_validator-0.1.5-py3-none-any.whl", hash = "sha256:b65d6c2242620bfe76d4c749b61cd9657e4528895a8f4fb6f916085b508ebd24"},
+]
+openapi-spec-validator = [
+    {file = "openapi-spec-validator-0.3.1.tar.gz", hash = "sha256:3d70e6592754799f7e77a45b98c6a91706bdd309a425169d17d8e92173e198a2"},
+    {file = "openapi_spec_validator-0.3.1-py2-none-any.whl", hash = "sha256:0a7da925bad4576f4518f77302c0b1990adb2fbcbe7d63fb4ed0de894cad8bdd"},
+    {file = "openapi_spec_validator-0.3.1-py3-none-any.whl", hash = "sha256:ba28b06e63274f2bc6de995a07fb572c657e534425b5baf68d9f7911efe6929f"},
 ]
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
@@ -1467,6 +1675,10 @@ uritemplate = [
 urllib3 = [
     {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
     {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
+]
+werkzeug = [
+    {file = "Werkzeug-2.0.1-py3-none-any.whl", hash = "sha256:6c1ec500dcdba0baa27600f6a22f6333d8b662d22027ff9f6202e3367413caa8"},
+    {file = "Werkzeug-2.0.1.tar.gz", hash = "sha256:1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ rdflib = "^5.0.0"
 setuptools = "^52.0.0"
 synapseclient = "~2.3"  # ~ (not ^) until Data Curator App supports OAuth tokens
 toml = "^0.10.2"
+Flask = "^2.0.1"
+connexion = "^2.7.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/run_api.py
+++ b/run_api.py
@@ -1,0 +1,7 @@
+# import our application
+# Run our application
+from api import create_app
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(port=3001, debug=True)

--- a/run_api.py
+++ b/run_api.py
@@ -1,7 +1,0 @@
-# import our application
-# Run our application
-from api import create_app
-
-if __name__ == '__main__':
-    app = create_app()
-    app.run(port=3001, debug=True)


### PR DESCRIPTION
This PR seeks to add the first REST API endpoint for the schematic package.

Brief description of some of the new files that are being added to the repo as part of this PR:
- `api/openapi/api.yaml`: openAPI specification of endpoint in YAML file
- `routes.py`: makes call to the `connexion` library to associate the parameters from the API spec. to the argument of the `ManifestGenerator.__init__()` method as well as the `get_manifest()` method.
- `run_api.py`: contains the driver code to start up the HTTP server

An example endpoint that you can execute to test that the REST API server works:

```
http://localhost:3001/v1/manifest/generate?schema_url=https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld&data_type=FollowUp&dataset_id=&title=FollowUp_Manifest
```

To view the Swagger interface:

```
http://localhost:3001/v1/ui
```

A few things that still need to be addressed in this PR:

- [x] Add examples and custom responses to API endpoint, i.e., clearly define the structure of the endpoint
- [x] Move schematic config parameters into FlaskApp config object

CC: @milen-sage @BrunoGrandePhD @hweej 