### PR TITLE
Remove `strict=False` from `_get_column_data_validation_values()` call

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -642,7 +642,6 @@ class ManifestGenerator(object):
                     spreadsheet_id,
                     req_vals,
                     i,
-                    strict=False,
                     custom_ui=False,
                     input_message="",
                     validation_type="ONE_OF_RANGE",


### PR DESCRIPTION
This PR seeks to remove an argument that snuck into the `develop` branch when we were working on some other PRs to address the addition of logic to enforce `strict` validation of Googlesheets.

It's necessary that we merge this PR at the earliest, because when we build and install the app with `poetry` and try to run the manifest generation command, it doesn't work.