### PR TITLE
Getting component dependencies as a graph

### DIFF
--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -155,14 +155,16 @@ class MetadataModel(object):
 
         return mg.get_manifest(sheet_url=sheetUrl)
 
-    def get_component_requirements(self, source_component: str, as_graph: bool = False) -> List:
+    def get_component_requirements(
+        self, source_component: str, as_graph: bool = False
+    ) -> List:
         """Given a source model component (see https://w3id.org/biolink/vocab/category for definnition of component), return all components required by it.
         Useful to construct requirement dependencies not only between specific attributes but also between categories/components of attributes;
         Can be utilized to track metadata completion progress across multiple categories of attributes.
 
         Args:
             source_component: an attribute label indicating the source component.
-            as_graph: if False return component requirements as a list; if True return component requirements as a dependency graph (i.e. a DAG) 
+            as_graph: if False return component requirements as a list; if True return component requirements as a dependency graph (i.e. a DAG)
 
         Returns:
             A list of required components associated with the source component.
@@ -173,7 +175,9 @@ class MetadataModel(object):
 
         # retreive components as graph
         if as_graph:
-            req_components_graph = self.sg.get_component_requirements_graph(source_component)
+            req_components_graph = self.sg.get_component_requirements_graph(
+                source_component
+            )
 
             # serialize component dependencies DAG to a edge list of node tuples
             req_components = list(req_components_graph.edges())
@@ -181,7 +185,6 @@ class MetadataModel(object):
             return req_components
 
         return req_components
-
 
     # TODO: abstract validation in its own module
     def validateModelManifest(

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -171,13 +171,14 @@ class MetadataModel(object):
         # get required components for the input/source component
         req_components = self.sg.get_component_requirements(source_component)
 
-        if not as_graph:
-            return req_components
-        else:
+        # retreive components as graph
+        if as_graph:
             req_components_graph = self.sg.get_component_requirements_graph(source_component)
 
             # serialize component dependencies DAG to a edge list of node tuples
             req_components = list(req_components_graph.edges())
+
+            return req_components
 
         return req_components
 

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -155,25 +155,32 @@ class MetadataModel(object):
 
         return mg.get_manifest(sheet_url=sheetUrl)
 
-    def get_component_requirements(self, source_component: str) -> List[str]:
+    def get_component_requirements(self, source_component: str, as_graph: bool = False) -> List:
         """Given a source model component (see https://w3id.org/biolink/vocab/category for definnition of component), return all components required by it.
         Useful to construct requirement dependencies not only between specific attributes but also between categories/components of attributes;
         Can be utilized to track metadata completion progress across multiple categories of attributes.
 
         Args:
             source_component: an attribute label indicating the source component.
+            as_graph: if False return component requirements as a list; if True return component requirements as a dependency graph (i.e. a DAG) 
 
         Returns:
             A list of required components associated with the source component.
         """
-        # get metadata model schema graph
-        # mm_graph = self.se.get_nx_schema()
 
         # get required components for the input/source component
         req_components = self.sg.get_component_requirements(source_component)
-        # req_components = get_component_requirements(mm_graph, source_component)
+
+        if not as_graph:
+            return req_components
+        else:
+            req_components_graph = self.sg.get_component_requirements_graph(source_component)
+
+            # serialize component dependencies DAG to a edge list of node tuples
+            req_components = list(req_components_graph.edges())
 
         return req_components
+
 
     # TODO: abstract validation in its own module
     def validateModelManifest(

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -93,7 +93,7 @@ class SchemaExplorer:
         source_node: str,
         relationship: str,
         connected: bool = True,
-        ordered: bool = False,
+        ordered: bool = False
     ) -> List[str]:
         """Get all nodes that are descendants of a given source node, based on a specific type of edge / relationship type.
 

--- a/schematic/schemas/generator.py
+++ b/schematic/schemas/generator.py
@@ -106,6 +106,7 @@ class SchemaGenerator(object):
         self, graph: nx.MultiDiGraph, relationship: str
     ) -> nx.DiGraph:
         """Get a subgraph containing all edges of a given type (aka relationship).
+        TODO: possibly move method to SchemaExplorer and refactor downstream code to call from SchemaExplorer
 
         Args:
             graph: input multi digraph (aka hypergraph)
@@ -123,6 +124,8 @@ class SchemaGenerator(object):
 
         relationship_subgraph = nx.DiGraph()
         relationship_subgraph.add_edges_from(rel_edges)
+
+        return relationship_subgraph
 
     def get_descendants_by_edge_type(
         self,
@@ -160,6 +163,27 @@ class SchemaGenerator(object):
         )
 
         return req_components
+
+    def get_component_requirements_graph(self, source_component: str) -> nx.DiGraph:
+        """Get all components that are associated with a given source component and are required by it; return the components as a dependency graph (i.e. a DAG).
+
+        Args:
+            source_component: source component for which we need to find all required downstream components.
+
+        Returns:
+            A subgraph of the schema graph induced on nodes that are descendants from the source component and are related to the source through a specific component relationship.
+        """
+
+        # get a list of required component nodes
+        req_components = self.get_component_requirements(source_component)
+
+        # get the schema graph
+        mm_graph = self.se.get_nx_schema()
+
+        # get the subgraph induced on required component nodes
+        req_components_graph = self.get_subgraph_by_edge_type(mm_graph, self.requires_component_relationship)
+
+        return req_components_graph
 
     def get_node_dependencies(
         self, source_node: str, display_names: bool = True, schema_ordered: bool = True

--- a/schematic/schemas/generator.py
+++ b/schematic/schemas/generator.py
@@ -118,7 +118,7 @@ class SchemaGenerator(object):
 
         # prune the metadata model graph so as to include only those edges that match the relationship type
         rel_edges = []
-        for (u, v, key, c) in graph.edges(data=True, keys=True):
+        for (u, v, key, c) in graph.out_edges(data=True, keys=True):
             if key == relationship:
                 rel_edges.append((u, v))
 
@@ -176,12 +176,12 @@ class SchemaGenerator(object):
 
         # get a list of required component nodes
         req_components = self.get_component_requirements(source_component)
-
+        
         # get the schema graph
         mm_graph = self.se.get_nx_schema()
 
         # get the subgraph induced on required component nodes
-        req_components_graph = self.get_subgraph_by_edge_type(mm_graph, self.requires_component_relationship)
+        req_components_graph = self.get_subgraph_by_edge_type(mm_graph, self.requires_component_relationship).subgraph(req_components)
 
         return req_components_graph
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -24,8 +24,8 @@ class TestMetadataModel:
     def test_get_component_requirements(self, metadata_model):
             
         source_component = "BulkRNA-seqAssay"
-        as_graph = True
+        as_graph = False
         
         output = metadata_model.get_component_requirements(source_component, as_graph = as_graph)
-        print(output)
+        
         assert type(output) is list

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,9 +1,9 @@
 import os
 import logging
+
 import pytest
 
 from schematic.models.metadata import MetadataModel
-from schematic.schemas.generator import SchemaGenerator
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -21,7 +21,11 @@ def metadata_model(helpers):
 
 
 class TestMetadataModel:
-    @pytest.mark.parameterize("as_graph", [True, False], ids=["as_graph, as_list"])
+    # TODO: currently, there are no DependsOn Component relationships
+    # in the example data model. Create a dummy relationship between Biospecimen
+    # and Patient using tempfiles and assert list of values rather than data types
+    
+    @pytest.mark.parametrize("as_graph", [True, False], ids=["as_graph", "as_list"])
     def test_get_component_requirements(self, metadata_model, as_graph):
 
         source_component = "BulkRNA-seqAssay"
@@ -29,5 +33,5 @@ class TestMetadataModel:
         output = metadata_model.get_component_requirements(
             source_component, as_graph=as_graph
         )
-
+        
         assert type(output) is list

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,31 @@
+import os
+import logging
+import pytest
+
+from schematic.models.metadata import MetadataModel
+from schematic.schemas.generator import SchemaGenerator
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+@pytest.fixture
+def metadata_model(helpers):
+
+        mm = MetadataModel(
+            helpers.get_data_path("example.model.jsonld"),
+            "local"
+        )
+
+        yield mm
+
+
+class TestMetadataModel:
+
+    def test_get_component_requirements(self, metadata_model):
+            
+        source_component = "BulkRNA-seqAssay"
+        as_graph = True
+        
+        output = metadata_model.get_component_requirements(source_component, as_graph = as_graph)
+        print(output)
+        assert type(output) is list

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -8,24 +8,26 @@ from schematic.schemas.generator import SchemaGenerator
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
+
 @pytest.fixture
 def metadata_model(helpers):
 
-        mm = MetadataModel(
-            helpers.get_data_path("example.model.jsonld"),
-            "local"
-        )
+    metadata_model = MetadataModel(
+        inputMModelLocation=helpers.get_data_path("example.model.jsonld"),
+        inputMModelLocationType="local",
+    )
 
-        yield mm
+    yield metadata_model
 
 
 class TestMetadataModel:
+    @pytest.mark.parameterize("as_graph", [True, False], ids=["as_graph, as_list"])
+    def test_get_component_requirements(self, metadata_model, as_graph):
 
-    def test_get_component_requirements(self, metadata_model):
-            
         source_component = "BulkRNA-seqAssay"
-        as_graph = True
-        
-        output = metadata_model.get_component_requirements(source_component, as_graph = as_graph)
-        
+
+        output = metadata_model.get_component_requirements(
+            source_component, as_graph=as_graph
+        )
+
         assert type(output) is list

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -24,7 +24,7 @@ class TestMetadataModel:
     def test_get_component_requirements(self, metadata_model):
             
         source_component = "BulkRNA-seqAssay"
-        as_graph = False
+        as_graph = True
         
         output = metadata_model.get_component_requirements(source_component, as_graph = as_graph)
         


### PR DESCRIPTION
get_component_requirements in models/metadata.py now has an argument allowing returning the component requirements graph (i.e. set as_graph to true). Added test to test_metadata.py. 

@rrchai you can call get_component_requirements from MetadataModel w/ input source component (e.g. selected template type in the DCA) and should get a tuple of edges (a directed graph to load in R).

