### PR TITLE
add --use_schema_label and --use_display_label options to CLI

### DIFF
--- a/schematic/help.py
+++ b/schematic/help.py
@@ -73,8 +73,8 @@ model_commands = {
                 "data filled in your manifest template."
             ),
             "use_schema_label": (
-                "Store attributes using the schema label (True) or store attributes using the display label "
-                "(False). Attribute display names in the schema must not only include characters that are "
+                "Store attributes using the schema label (--use_schema_label, default) or store attributes using the display label "
+                "(--use_display_label). Attribute display names in the schema must not only include characters that are "
                 "not accepted by Synapse. Annotation names may only contain: letters, numbers, '_' and '.'"
             ),
         },

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -72,6 +72,11 @@ model_commands = {
                 "The component or data type from the data model which you can use to validate the "
                 "data filled in your manifest template."
             ),
+            "use_schema_label": (
+                "Store attributes using the schema label (True) or store attributes using the display label "
+                "(False). Attribute display names in the schema must not only include characters that are "
+                "not accepted by Synapse. Annotation names may only contain: letters, numbers, '_' and '.'"
+            ),
         },
         "validate": {
             "short_help": ("Validation of manifest files."),

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -71,7 +71,7 @@ def model(ctx, config):  # use as `schematic model ...`
     help=query_dict(model_commands, ("model", "submit", "use_schema_label")),
 )
 @click.pass_obj
-def submit_manifest(ctx, manifest_path, dataset_id, validate_component):
+def submit_manifest(ctx, manifest_path, dataset_id, validate_component, use_schema_label):
     """
     Running CLI with manifest validation (optional) and submission options.
     """

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -64,8 +64,8 @@ def model(ctx, config):  # use as `schematic model ...`
     help=query_dict(model_commands, ("model", "submit", "validate_component")),
 )
 @click.option(
-    "--use_schema_label/--use_display_label', 
-    '-sl/-dl',
+    "--use_schema_label/--use_display_label", 
+    "-sl/-dl",
     default=True,
     show_default=True,
     help=query_dict(model_commands, ("model", "submit", "use_schema_label")),

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -64,8 +64,8 @@ def model(ctx, config):  # use as `schematic model ...`
     help=query_dict(model_commands, ("model", "submit", "validate_component")),
 )
 @click.option(
-    "-us",
-    "--use_schema_label",
+    "--use_schema_label/--use_display_label', 
+    '-sl/-dl',
     default=True,
     show_default=True,
     help=query_dict(model_commands, ("model", "submit", "use_schema_label")),

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -63,6 +63,11 @@ def model(ctx, config):  # use as `schematic model ...`
     "--validate_component",
     help=query_dict(model_commands, ("model", "submit", "validate_component")),
 )
+@click.option(
+    "-us",
+    "--use_schema_label",
+    help=query_dict(model_commands, ("model", "submit", "use_schema_label")),
+)
 @click.pass_obj
 def submit_manifest(ctx, manifest_path, dataset_id, validate_component):
     """
@@ -81,6 +86,7 @@ def submit_manifest(ctx, manifest_path, dataset_id, validate_component):
             manifest_path=manifest_path,
             dataset_id=dataset_id,
             validate_component=validate_component,
+            use_schema_label=use_schema_label,
         )
 
         if success:

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -67,7 +67,6 @@ def model(ctx, config):  # use as `schematic model ...`
     "--use_schema_label/--use_display_label", 
     "-sl/-dl",
     default=True,
-    show_default=True,
     help=query_dict(model_commands, ("model", "submit", "use_schema_label")),
 )
 @click.pass_obj

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -66,6 +66,8 @@ def model(ctx, config):  # use as `schematic model ...`
 @click.option(
     "-us",
     "--use_schema_label",
+    default=True,
+    show_default=True,
     help=query_dict(model_commands, ("model", "submit", "use_schema_label")),
 )
 @click.pass_obj

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -295,7 +295,7 @@ class MetadataModel(object):
         return mg.populate_manifest_spreadsheet(manifestPath, emptyManifestURL)
 
     def submit_metadata_manifest(
-        self, manifest_path: str, dataset_id: str, validate_component: str = None
+        self, manifest_path: str, dataset_id: str, validate_component: str = None, use_schema_label: bool = True
     ) -> bool:
         """Wrap methods that are responsible for validation of manifests for a given component, and association of the
         same manifest file with a specified dataset.
@@ -349,7 +349,7 @@ class MetadataModel(object):
 
         # no need to perform validation, just submit/associate the metadata manifest file
         syn_store.associateMetadataWithFiles(
-            metadataManifestPath=manifest_path, datasetId=dataset_id
+            metadataManifestPath=manifest_path, datasetId=dataset_id, useSchemaLabel=use_schema_label
         )
 
         logger.debug(


### PR DESCRIPTION
~In progress to add useSchemaLabel to schematic model store CLI function.~

This PR adds `--use_schema_label` (the default) and `--use_display_label` options to `schematic model submit`. Unfortunately, when I tested this function, the eTag seems to sneak through (see #479), but at least this additional flag will make it easier to debug using the CLI.