### PR TITLE
Jupyter notebook that validates manifest files

### DIFF
--- a/notebooks/files/invalid_patient_manifest.csv
+++ b/notebooks/files/invalid_patient_manifest.csv
@@ -1,0 +1,2 @@
+Patient ID,Sex,Year of Birth,Diagnosis,Component,Cancer Type,Family History
+HTAN_1,Male,1996,Healthy,,,

--- a/notebooks/files/valid_patient_manifest.csv
+++ b/notebooks/files/valid_patient_manifest.csv
@@ -1,0 +1,2 @@
+Patient ID,Sex,Year of Birth,Diagnosis,Component,Cancer Type,Family History
+HTAN_1,Male,abc,Healthy,Patient,,

--- a/notebooks/manifest_validation.ipynb
+++ b/notebooks/manifest_validation.ipynb
@@ -56,6 +56,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6fa8f5c3",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f80a89e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# MetadataModel class contains validateModelManifest() method\n",
+    "from schematic.models.metadata import MetadataModel\n",
+    "\n",
+    "# initialize object of MetadataModel class\n",
+    "metadata_model = MetadataModel(\n",
+    "    inputMModelLocation=\"../tests/data/example.model.jsonld\", \n",
+    "    inputMModelLocationType=\"local\"\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "eb759f36",
@@ -71,15 +94,6 @@
     }
    ],
    "source": [
-    "# MetadataModel class contains validateModelManifest() method\n",
-    "from schematic.models.metadata import MetadataModel\n",
-    "\n",
-    "# initialize object of MetadataModel class\n",
-    "metadata_model = MetadataModel(\n",
-    "    inputMModelLocation=\"../tests/data/example.model.jsonld\", \n",
-    "    inputMModelLocationType=\"local\"\n",
-    ")\n",
-    "\n",
     "# provide valid manifest file path\n",
     "errors = metadata_model.validateModelManifest(\n",
     "    manifestPath=\"files/valid_patient_manifest.csv\", rootNode=\"Patient\"\n",
@@ -87,6 +101,18 @@
     "\n",
     "# empty list since we're validating a valid manifest\n",
     "print(errors)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "054b3aeb",
+   "metadata": {},
+   "source": [
+    "### Case 2\n",
+    "\n",
+    "#### We are providing an _invalid_ manifest file to the validation method. So instead of returning an empty list like above, the method should return a list with each comma separated value signifying the following respectively:\n",
+    "\n",
+    "\\[ _row number_, _column name_, _description of correction_, _correction suggested_ \\]"
    ]
   },
   {

--- a/notebooks/manifest_validation.ipynb
+++ b/notebooks/manifest_validation.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ef2407a3",
    "metadata": {},
    "source": [
     "#### 1. Set SCHEMATIC_CONFIG environment variable to point to config.yml"
@@ -11,7 +10,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "f83b4039",
    "metadata": {},
    "outputs": [
     {
@@ -29,7 +27,6 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "f41f42b2",
    "metadata": {},
    "outputs": [
     {
@@ -49,7 +46,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15d1638c",
    "metadata": {},
    "source": [
     "#### 2. Call `validateModelManifest()` method from `MetadataModel` class to validate manifest"
@@ -57,14 +53,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6fa8f5c3",
    "metadata": {},
-   "source": []
+   "source": [
+    "### Case 1"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f80a89e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +77,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "eb759f36",
    "metadata": {},
    "outputs": [
     {
@@ -105,7 +100,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "054b3aeb",
    "metadata": {},
    "source": [
     "### Case 2\n",
@@ -118,7 +112,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "e230dfd0",
    "metadata": {},
    "outputs": [
     {

--- a/notebooks/manifest_validation.ipynb
+++ b/notebooks/manifest_validation.ipynb
@@ -1,0 +1,145 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ef2407a3",
+   "metadata": {},
+   "source": [
+    "#### 1. Set SCHEMATIC_CONFIG environment variable to point to config.yml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f83b4039",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: SCHEMATIC_CONFIG=/Users/spatil/Desktop/schematic/config.yml\n"
+     ]
+    }
+   ],
+   "source": [
+    "%env SCHEMATIC_CONFIG=/Users/spatil/Desktop/schematic/config.yml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f41f42b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/spatil/Desktop/schematic/config.yml\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "# check if `SCHEMATIC_CONFIG` variable has been set to correct path\n",
+    "print(os.environ['SCHEMATIC_CONFIG'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15d1638c",
+   "metadata": {},
+   "source": [
+    "#### 2. Call `validateModelManifest()` method from `MetadataModel` class to validate manifest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eb759f36",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading config YAML file specified in 'SCHEMATIC_CONFIG' environment variable: /Users/spatil/Desktop/schematic/config.yml\n",
+      "[]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# MetadataModel class contains validateModelManifest() method\n",
+    "from schematic.models.metadata import MetadataModel\n",
+    "\n",
+    "# initialize object of MetadataModel class\n",
+    "metadata_model = MetadataModel(\n",
+    "    inputMModelLocation=\"../tests/data/example.model.jsonld\", \n",
+    "    inputMModelLocationType=\"local\"\n",
+    ")\n",
+    "\n",
+    "# provide valid manifest file path\n",
+    "errors = metadata_model.validateModelManifest(\n",
+    "    manifestPath=\"files/valid_patient_manifest.csv\", rootNode=\"Patient\"\n",
+    ")\n",
+    "\n",
+    "# empty list since we're validating a valid manifest\n",
+    "print(errors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e230dfd0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR: [2021-07-19 13:10:27] root - The 'Component' column value(s) [''] do not match the selected template type 'Patient'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[2, 'Component', \"Component value provided is: '', whereas the Template Type is: 'Patient'\", ('', 'Patient')]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# provide invalid manifest file path\n",
+    "errors = metadata_model.validateModelManifest(\n",
+    "    manifestPath=\"files/invalid_patient_manifest.csv\", rootNode=\"Patient\"\n",
+    ")\n",
+    "\n",
+    "# list pointing out what errors exist in the provided manifest\n",
+    "print(errors)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": ".venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR logically follows PR #497, and demonstrates the second stage of the data curation lifecycle, i.e., manifest validation. Both the use cases, when the manifest is valid and when the manifest is invalid have been illustrated.