### PR TITLE
Update logger to allow list validation rule without valid values specified.

### DIFF
--- a/schematic/schemas/df_parser.py
+++ b/schematic/schemas/df_parser.py
@@ -999,9 +999,8 @@ def create_nx_schema_objects(
                     validation_rules=property_info["validation_rules"],
                 )
                 se.edit_schema_object_nx(property_val_rule_edit)
-
-            logger.debug(val + "validation rules added")
-
+            logger.debug(attribute["Attribute"] + " validation rules added")
+        
         # get dependencies for this attribute, if any are specified
         requires_dependencies = attribute["DependsOn"]
         if not pd.isnull(requires_dependencies):


### PR DESCRIPTION
Previously there was an error if you worked in the DEBUG level of logging, if you specified a list validation rule without also adding valid values. This was because it was assumed these would be used in conjunction, and the logging message relied on a specific variable. This PR changes the message so its still useful, but does not rely on this variable.