### PR TITLE
Develop rdb central manifest

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -351,6 +351,17 @@ docs = ["sphinx (>=1.8)", "sphinx-rtd-theme"]
 test = ["mock (>=3)", "pytest (>=4)", "pytest-mock (>=2)", "pytest-cov"]
 
 [[package]]
+name = "greenlet"
+version = "1.1.1"
+description = "Lightweight in-process concurrent programming"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+
+[package.extras]
+docs = ["sphinx"]
+
+[[package]]
 name = "httplib2"
 version = "0.19.1"
 description = "A comprehensive HTTP client library."
@@ -506,6 +517,14 @@ description = "Experimental type system extensions for programs checked with the
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "mysqlclient"
+version = "2.0.3"
+description = "Python interface to MySQL"
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "networkx"
@@ -696,6 +715,17 @@ description = "C parser in Python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pydot"
+version = "1.4.2"
+description = "Python interface to Graphviz's Dot"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pyparsing = ">=2.1.4"
 
 [[package]]
 name = "pyflakes"
@@ -928,6 +958,76 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "sqlalchemy"
+version = "1.4.22"
+description = "Database Abstraction Library"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+
+[package.dependencies]
+greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+aiomysql = ["greenlet (!=0.4.17)", "aiomysql"]
+aiosqlite = ["greenlet (!=0.4.17)", "aiosqlite"]
+asyncio = ["greenlet (!=0.4.17)"]
+mariadb_connector = ["mariadb (>=1.0.1)"]
+mssql = ["pyodbc"]
+mssql_pymssql = ["pymssql"]
+mssql_pyodbc = ["pyodbc"]
+mypy = ["sqlalchemy2-stubs", "mypy (>=0.800)"]
+mysql = ["mysqlclient (>=1.4.0,<2)", "mysqlclient (>=1.4.0)"]
+mysql_connector = ["mysqlconnector"]
+oracle = ["cx_oracle (>=7,<8)", "cx_oracle (>=7)"]
+postgresql = ["psycopg2 (>=2.7)"]
+postgresql_asyncpg = ["greenlet (!=0.4.17)", "asyncpg"]
+postgresql_pg8000 = ["pg8000 (>=1.16.6)"]
+postgresql_psycopg2binary = ["psycopg2-binary"]
+postgresql_psycopg2cffi = ["psycopg2cffi"]
+pymysql = ["pymysql (<1)", "pymysql"]
+sqlcipher = ["sqlcipher3-binary"]
+
+[[package]]
+name = "sqlalchemy-schemadisplay"
+version = "1.3"
+description = "Turn SQLAlchemy DB Model into a graph"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pydot = "*"
+
+[[package]]
+name = "sqlalchemy-utils"
+version = "0.37.8"
+description = "Various utility functions for SQLAlchemy."
+category = "main"
+optional = false
+python-versions = "~=3.4"
+
+[package.dependencies]
+six = "*"
+SQLAlchemy = ">=1.0"
+
+[package.extras]
+anyjson = ["anyjson (>=0.3.3)"]
+arrow = ["arrow (>=0.3.4)"]
+babel = ["Babel (>=1.3)"]
+color = ["colour (>=0.0.4)"]
+encrypted = ["cryptography (>=0.6)"]
+intervals = ["intervals (>=0.7.1)"]
+password = ["passlib (>=1.6,<2.0)"]
+pendulum = ["pendulum (>=2.0.5)"]
+phone = ["phonenumbers (>=5.9.2)"]
+test = ["pytest (>=2.7.1)", "Pygments (>=1.2)", "Jinja2 (>=2.3)", "docutils (>=0.10)", "flexmock (>=0.9.7)", "mock (==2.0.0)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pg8000 (>=1.12.4)", "pytz (>=2014.2)", "python-dateutil (>=2.6)", "pymysql", "flake8 (>=2.4.0)", "isort (>=4.2.2)", "pyodbc", "backports.zoneinfo"]
+test_all = ["Babel (>=1.3)", "Jinja2 (>=2.3)", "Pygments (>=1.2)", "anyjson (>=0.3.3)", "arrow (>=0.3.4)", "colour (>=0.0.4)", "cryptography (>=0.6)", "docutils (>=0.10)", "flake8 (>=2.4.0)", "flexmock (>=0.9.7)", "furl (>=0.4.1)", "intervals (>=0.7.1)", "isort (>=4.2.2)", "mock (==2.0.0)", "passlib (>=1.6,<2.0)", "pendulum (>=2.0.5)", "pg8000 (>=1.12.4)", "phonenumbers (>=5.9.2)", "psycopg2 (>=2.5.1)", "psycopg2cffi (>=2.8.1)", "pymysql", "pyodbc", "pytest (>=2.7.1)", "python-dateutil", "python-dateutil (>=2.6)", "pytz (>=2014.2)", "backports.zoneinfo"]
+timezone = ["python-dateutil"]
+url = ["furl (>=0.4.1)"]
+
+[[package]]
 name = "swagger-ui-bundle"
 version = "0.0.8"
 description = "swagger_ui_bundle - swagger-ui files in a pip package"
@@ -1039,7 +1139,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "6ec96f77494f2d51890bd52abb66875ea16165511992b4ea98703e6e99b92576"
+content-hash = "b68c8b025647d213fd147fdec7352304bf1afe549dc9375cbcba1500d932b940"
 
 [metadata.files]
 appdirs = [
@@ -1200,8 +1300,10 @@ cryptography = [
     {file = "cryptography-3.4.7-cp36-abi3-win_amd64.whl", hash = "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
+    {file = "cryptography-3.4.7-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3"},
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
 ]
 deprecated = [
@@ -1248,6 +1350,58 @@ graphviz = [
     {file = "graphviz-0.16-py2.py3-none-any.whl", hash = "sha256:3cad5517c961090dfc679df6402a57de62d97703e2880a1a46147bb0dc1639eb"},
     {file = "graphviz-0.16.zip", hash = "sha256:d2d25af1c199cad567ce4806f0449cb74eb30cf451fd7597251e1da099ac6e57"},
 ]
+greenlet = [
+    {file = "greenlet-1.1.1-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:476ba9435afaead4382fbab8f1882f75e3fb2285c35c9285abb3dd30237f9142"},
+    {file = "greenlet-1.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:44556302c0ab376e37939fd0058e1f0db2e769580d340fb03b01678d1ff25f68"},
+    {file = "greenlet-1.1.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:40abb7fec4f6294225d2b5464bb6d9552050ded14a7516588d6f010e7e366dcc"},
+    {file = "greenlet-1.1.1-cp27-cp27m-win32.whl", hash = "sha256:a11b6199a0b9dc868990456a2667167d0ba096c5224f6258e452bfbe5a9742c5"},
+    {file = "greenlet-1.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e22a82d2b416d9227a500c6860cf13e74060cf10e7daf6695cbf4e6a94e0eee4"},
+    {file = "greenlet-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bad269e442f1b7ffa3fa8820b3c3aa66f02a9f9455b5ba2db5a6f9eea96f56de"},
+    {file = "greenlet-1.1.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:8ddb38fb6ad96c2ef7468ff73ba5c6876b63b664eebb2c919c224261ae5e8378"},
+    {file = "greenlet-1.1.1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:84782c80a433d87530ae3f4b9ed58d4a57317d9918dfcc6a59115fa2d8731f2c"},
+    {file = "greenlet-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac991947ca6533ada4ce7095f0e28fe25d5b2f3266ad5b983ed4201e61596acf"},
+    {file = "greenlet-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5317701c7ce167205c0569c10abc4bd01c7f4cf93f642c39f2ce975fa9b78a3c"},
+    {file = "greenlet-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4870b018ca685ff573edd56b93f00a122f279640732bb52ce3a62b73ee5c4a92"},
+    {file = "greenlet-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:990e0f5e64bcbc6bdbd03774ecb72496224d13b664aa03afd1f9b171a3269272"},
+    {file = "greenlet-1.1.1-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:a414f8e14aa7bacfe1578f17c11d977e637d25383b6210587c29210af995ef04"},
+    {file = "greenlet-1.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:e02780da03f84a671bb4205c5968c120f18df081236d7b5462b380fd4f0b497b"},
+    {file = "greenlet-1.1.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:dfcb5a4056e161307d103bc013478892cfd919f1262c2bb8703220adcb986362"},
+    {file = "greenlet-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:655ab836324a473d4cd8cf231a2d6f283ed71ed77037679da554e38e606a7117"},
+    {file = "greenlet-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:6ce9d0784c3c79f3e5c5c9c9517bbb6c7e8aa12372a5ea95197b8a99402aa0e6"},
+    {file = "greenlet-1.1.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:3fc6a447735749d651d8919da49aab03c434a300e9f0af1c886d560405840fd1"},
+    {file = "greenlet-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8039f5fe8030c43cd1732d9a234fdcbf4916fcc32e21745ca62e75023e4d4649"},
+    {file = "greenlet-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fddfb31aa2ac550b938d952bca8a87f1db0f8dc930ffa14ce05b5c08d27e7fd1"},
+    {file = "greenlet-1.1.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b97a807437b81f90f85022a9dcfd527deea38368a3979ccb49d93c9198b2c722"},
+    {file = "greenlet-1.1.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cf31e894dabb077a35bbe6963285d4515a387ff657bd25b0530c7168e48f167f"},
+    {file = "greenlet-1.1.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4eae94de9924bbb4d24960185363e614b1b62ff797c23dc3c8a7c75bbb8d187e"},
+    {file = "greenlet-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:c1862f9f1031b1dee3ff00f1027fcd098ffc82120f43041fe67804b464bbd8a7"},
+    {file = "greenlet-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:9b02e6039eafd75e029d8c58b7b1f3e450ca563ef1fe21c7e3e40b9936c8d03e"},
+    {file = "greenlet-1.1.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:84488516639c3c5e5c0e52f311fff94ebc45b56788c2a3bfe9cf8e75670f4de3"},
+    {file = "greenlet-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3f8fc59bc5d64fa41f58b0029794f474223693fd00016b29f4e176b3ee2cfd9f"},
+    {file = "greenlet-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3e594015a2349ec6dcceda9aca29da8dc89e85b56825b7d1f138a3f6bb79dd4c"},
+    {file = "greenlet-1.1.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e41f72f225192d5d4df81dad2974a8943b0f2d664a2a5cfccdf5a01506f5523c"},
+    {file = "greenlet-1.1.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:75ff270fd05125dce3303e9216ccddc541a9e072d4fc764a9276d44dee87242b"},
+    {file = "greenlet-1.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cde7ee190196cbdc078511f4df0be367af85636b84d8be32230f4871b960687"},
+    {file = "greenlet-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:f253dad38605486a4590f9368ecbace95865fea0f2b66615d121ac91fd1a1563"},
+    {file = "greenlet-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a91ee268f059583176c2c8b012a9fce7e49ca6b333a12bbc2dd01fc1a9783885"},
+    {file = "greenlet-1.1.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:34e6675167a238bede724ee60fe0550709e95adaff6a36bcc97006c365290384"},
+    {file = "greenlet-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:bf3725d79b1ceb19e83fb1aed44095518c0fcff88fba06a76c0891cfd1f36837"},
+    {file = "greenlet-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:5c3b735ccf8fc8048664ee415f8af5a3a018cc92010a0d7195395059b4b39b7d"},
+    {file = "greenlet-1.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2002a59453858c7f3404690ae80f10c924a39f45f6095f18a985a1234c37334"},
+    {file = "greenlet-1.1.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:04e1849c88aa56584d4a0a6e36af5ec7cc37993fdc1fda72b56aa1394a92ded3"},
+    {file = "greenlet-1.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8d4ed48eed7414ccb2aaaecbc733ed2a84c299714eae3f0f48db085342d5629"},
+    {file = "greenlet-1.1.1-cp38-cp38-win32.whl", hash = "sha256:2f89d74b4f423e756a018832cd7a0a571e0a31b9ca59323b77ce5f15a437629b"},
+    {file = "greenlet-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:d15cb6f8706678dc47fb4e4f8b339937b04eda48a0af1cca95f180db552e7663"},
+    {file = "greenlet-1.1.1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b050dbb96216db273b56f0e5960959c2b4cb679fe1e58a0c3906fa0a60c00662"},
+    {file = "greenlet-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e0696525500bc8aa12eae654095d2260db4dc95d5c35af2b486eae1bf914ccd"},
+    {file = "greenlet-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:07e6d88242e09b399682b39f8dfa1e7e6eca66b305de1ff74ed9eb1a7d8e539c"},
+    {file = "greenlet-1.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98b491976ed656be9445b79bc57ed21decf08a01aaaf5fdabf07c98c108111f6"},
+    {file = "greenlet-1.1.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e72db813c28906cdc59bd0da7c325d9b82aa0b0543014059c34c8c4ad20e16"},
+    {file = "greenlet-1.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:090126004c8ab9cd0787e2acf63d79e80ab41a18f57d6448225bbfcba475034f"},
+    {file = "greenlet-1.1.1-cp39-cp39-win32.whl", hash = "sha256:1796f2c283faab2b71c67e9b9aefb3f201fdfbee5cb55001f5ffce9125f63a45"},
+    {file = "greenlet-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:4adaf53ace289ced90797d92d767d37e7cdc29f13bd3830c3f0a561277a4ae83"},
+    {file = "greenlet-1.1.1.tar.gz", hash = "sha256:c0f22774cd8294078bdf7392ac73cf00bfa1e5e0ed644bd064fdabc5f2a2f481"},
+]
 httplib2 = [
     {file = "httplib2-0.19.1-py3-none-any.whl", hash = "sha256:2ad195faf9faf079723f6714926e9a9061f694d07724b846658ce08d40f522b4"},
     {file = "httplib2-0.19.1.tar.gz", hash = "sha256:0b12617eeca7433d4c396a100eaecfa4b08ee99aa881e6df6e257a7aad5d533d"},
@@ -1293,12 +1447,22 @@ keyring = [
     {file = "keyrings.alt-3.1.tar.gz", hash = "sha256:b59c86b67b9027a86e841a49efc41025bcc3b1b0308629617b66b7011e52db5a"},
 ]
 markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1307,14 +1471,21 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1324,6 +1495,9 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1335,6 +1509,13 @@ mccabe = [
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+mysqlclient = [
+    {file = "mysqlclient-2.0.3-cp36-cp36m-win_amd64.whl", hash = "sha256:3381ca1a4f37ff1155fcfde20836b46416d66531add8843f6aa6d968982731c3"},
+    {file = "mysqlclient-2.0.3-cp37-cp37m-win_amd64.whl", hash = "sha256:0ac0dd759c4ca02c35a9fedc24bc982cf75171651e8187c2495ec957a87dfff7"},
+    {file = "mysqlclient-2.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:71c4b330cf2313bbda0307fc858cc9055e64493ba9bf28454d25cf8b3ee8d7f5"},
+    {file = "mysqlclient-2.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:fc575093cf81b6605bed84653e48b277318b880dc9becf42dd47fa11ffd3e2b6"},
+    {file = "mysqlclient-2.0.3.tar.gz", hash = "sha256:f6ebea7c008f155baeefe16c56cd3ee6239f7a5a9ae42396c2f1860f08a7c432"},
 ]
 networkx = [
     {file = "networkx-2.6.2-py3-none-any.whl", hash = "sha256:5fcb7004be69e8fbdf07dcb502efa5c77cadcaad6982164134eeb9721f826c2e"},
@@ -1491,6 +1672,10 @@ pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
+pydot = [
+    {file = "pydot-1.4.2-py2.py3-none-any.whl", hash = "sha256:66c98190c65b8d2e2382a441b4c0edfdb4f4c025ef9cb9874de478fb0793a451"},
+    {file = "pydot-1.4.2.tar.gz", hash = "sha256:248081a39bcb56784deb018977e428605c1c758f10897a339fce1dd728ff007d"},
+]
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
@@ -1598,6 +1783,10 @@ regex = [
     {file = "regex-2021.7.6-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:b85ac458354165405c8a84725de7bbd07b00d9f72c31a60ffbf96bb38d3e25fa"},
     {file = "regex-2021.7.6-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:3f5716923d3d0bfb27048242a6e0f14eecdb2e2a7fac47eda1d055288595f222"},
     {file = "regex-2021.7.6-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5983c19d0beb6af88cb4d47afb92d96751fb3fa1784d8785b1cdf14c6519407"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf1d2d183abc7faa101ebe0b8d04fd19cb9138820abc8589083035c9440b8ca6"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1947e7de155063e1c495c50590229fb98720d4c383af5031bbcb413db33fa1be"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:17d8a3f99b18d87ac54a449b836d485cc8c195bb6f5e4379c84c8519045facc9"},
+    {file = "regex-2021.7.6-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d30895ec80cc80358392841add9dde81ea1d54a4949049269115e6b0555d0498"},
     {file = "regex-2021.7.6-cp36-cp36m-win32.whl", hash = "sha256:c92831dac113a6e0ab28bc98f33781383fe294df1a2c3dfd1e850114da35fd5b"},
     {file = "regex-2021.7.6-cp36-cp36m-win_amd64.whl", hash = "sha256:791aa1b300e5b6e5d597c37c346fb4d66422178566bbb426dd87eaae475053fb"},
     {file = "regex-2021.7.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:59506c6e8bd9306cd8a41511e32d16d5d1194110b8cfe5a11d102d8b63cf945d"},
@@ -1608,6 +1797,10 @@ regex = [
     {file = "regex-2021.7.6-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:173bc44ff95bc1e96398c38f3629d86fa72e539c79900283afa895694229fe6a"},
     {file = "regex-2021.7.6-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:15dddb19823f5147e7517bb12635b3c82e6f2a3a6b696cc3e321522e8b9308ad"},
     {file = "regex-2021.7.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ddeabc7652024803666ea09f32dd1ed40a0579b6fbb2a213eba590683025895"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8244c681018423a0d1784bc6b9af33bdf55f2ab8acb1f3cd9dd83d90e0813253"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a4c742089faf0e51469c6a1ad7e3d3d21afae54a16a6cead85209dfe0a1ce65"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:914e626dc8e75fe4fc9b7214763f141d9f40165d00dfe680b104fa1b24063bbf"},
+    {file = "regex-2021.7.6-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3fabb19c82ecf39832a3f5060dfea9a7ab270ef156039a1143a29a83a09a62de"},
     {file = "regex-2021.7.6-cp37-cp37m-win32.whl", hash = "sha256:f080248b3e029d052bf74a897b9d74cfb7643537fbde97fe8225a6467fb559b5"},
     {file = "regex-2021.7.6-cp37-cp37m-win_amd64.whl", hash = "sha256:d8bbce0c96462dbceaa7ac4a7dfbbee92745b801b24bce10a98d2f2b1ea9432f"},
     {file = "regex-2021.7.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:edd1a68f79b89b0c57339bce297ad5d5ffcc6ae7e1afdb10f1947706ed066c9c"},
@@ -1618,6 +1811,10 @@ regex = [
     {file = "regex-2021.7.6-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:bc84fb254a875a9f66616ed4538542fb7965db6356f3df571d783f7c8d256edd"},
     {file = "regex-2021.7.6-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:598c0a79b4b851b922f504f9f39a863d83ebdfff787261a5ed061c21e67dd761"},
     {file = "regex-2021.7.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:875c355360d0f8d3d827e462b29ea7682bf52327d500a4f837e934e9e4656068"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dfc0957c4a4b91eff5ad036088769e600a25774256cd0e1154378591ce573f08"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:efb4af05fa4d2fc29766bf516f1f5098d6b5c3ed846fde980c18bf8646ad3979"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7423aca7cc30a6228ccdcf2ea76f12923d652c5c7c6dc1959a0b004e308f39fb"},
+    {file = "regex-2021.7.6-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bb9834c1e77493efd7343b8e38950dee9797d2d6f2d5fd91c008dfaef64684b9"},
     {file = "regex-2021.7.6-cp38-cp38-win32.whl", hash = "sha256:e586f448df2bbc37dfadccdb7ccd125c62b4348cb90c10840d695592aa1b29e0"},
     {file = "regex-2021.7.6-cp38-cp38-win_amd64.whl", hash = "sha256:2fe5e71e11a54e3355fa272137d521a40aace5d937d08b494bed4529964c19c4"},
     {file = "regex-2021.7.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6110bab7eab6566492618540c70edd4d2a18f40ca1d51d704f1d81c52d245026"},
@@ -1628,6 +1825,10 @@ regex = [
     {file = "regex-2021.7.6-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:2bceeb491b38225b1fee4517107b8491ba54fba77cf22a12e996d96a3c55613d"},
     {file = "regex-2021.7.6-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:f98dc35ab9a749276f1a4a38ab3e0e2ba1662ce710f6530f5b0a6656f1c32b58"},
     {file = "regex-2021.7.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:319eb2a8d0888fa6f1d9177705f341bc9455a2c8aca130016e52c7fe8d6c37a3"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:598ee917dbe961dcf827217bf2466bb86e4ee5a8559705af57cbabb3489dd37e"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:56fc7045a1999a8d9dd1896715bc5c802dfec5b9b60e883d2cbdecb42adedea4"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8363ac90ea63c3dd0872dfdb695f38aff3334bfa5712cffb238bd3ffef300e3"},
+    {file = "regex-2021.7.6-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:716a6db91b3641f566531ffcc03ceec00b2447f0db9942b3c6ea5d2827ad6be3"},
     {file = "regex-2021.7.6-cp39-cp39-win32.whl", hash = "sha256:eaf58b9e30e0e546cdc3ac06cf9165a1ca5b3de8221e9df679416ca667972035"},
     {file = "regex-2021.7.6-cp39-cp39-win_amd64.whl", hash = "sha256:4c9c3155fe74269f61e27617529b7f09552fbb12e44b1189cebbdb24294e6e1c"},
     {file = "regex-2021.7.6.tar.gz", hash = "sha256:8394e266005f2d8c6f0bc6780001f7afa3ef81a7a2111fa35058ded6fce79e4d"},
@@ -1651,6 +1852,46 @@ secretstorage = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+sqlalchemy = [
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:488608953385d6c127d2dcbc4b11f8d7f2f30b89f6bd27c01b042253d985cc2f"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:5d856cc50fd26fc8dd04892ed5a5a3d7eeb914fea2c2e484183e2d84c14926e0"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-win32.whl", hash = "sha256:a00d9c6d3a8afe1d1681cd8a5266d2f0ed684b0b44bada2ca82403b9e8b25d39"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27m-win_amd64.whl", hash = "sha256:5908ea6c652a050d768580d01219c98c071e71910ab8e7b42c02af4010608397"},
+    {file = "SQLAlchemy-1.4.22-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b7fb937c720847879c7402fe300cfdb2aeff22349fa4ea3651bca4e2d6555939"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:9bfe882d5a1bbde0245dca0bd48da0976bd6634cf2041d2fdf0417c5463e40e5"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eedd76f135461cf237534a6dc0d1e0f6bb88a1dc193678fab48a11d223462da5"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6a16c7c4452293da5143afa3056680db2d187b380b3ef4d470d4e29885720de3"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44d23ea797a5e0be71bc5454b9ae99158ea0edc79e2393c6e9a2354de88329c0"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-win32.whl", hash = "sha256:a5e14cb0c0a4ac095395f24575a0e7ab5d1be27f5f9347f1762f21505e3ba9f1"},
+    {file = "SQLAlchemy-1.4.22-cp36-cp36m-win_amd64.whl", hash = "sha256:bc34a007e604091ca3a4a057525efc4cefd2b7fe970f44d20b9cfa109ab1bddb"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:756f5d2f5b92d27450167247fb574b09c4cd192a3f8c2e493b3e518a204ee543"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fcbb4b4756b250ed19adc5e28c005b8ed56fdb5c21efa24c6822c0575b4964d"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:09dbb4bc01a734ccddbf188deb2a69aede4b3c153a72b6d5c6900be7fb2945b1"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f028ef6a1d828bc754852a022b2160e036202ac8658a6c7d34875aafd14a9a15"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-win32.whl", hash = "sha256:68393d3fd31469845b6ba11f5b4209edbea0b58506be0e077aafbf9aa2e21e11"},
+    {file = "SQLAlchemy-1.4.22-cp37-cp37m-win_amd64.whl", hash = "sha256:891927a49b2363a4199763a9d436d97b0b42c65922a4ea09025600b81a00d17e"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:fd2102a8f8a659522719ed73865dff3d3cc76eb0833039dc473e0ad3041d04be"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4014978de28163cd8027434916a92d0f5bb1a3a38dff5e8bf8bff4d9372a9117"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f814d80844969b0d22ea63663da4de5ca1c434cfbae226188901e5d368792c17"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d09a760b0a045b4d799102ae7965b5491ccf102123f14b2a8cc6c01d1021a2d9"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-win32.whl", hash = "sha256:26daa429f039e29b1e523bf763bfab17490556b974c77b5ca7acb545b9230e9a"},
+    {file = "SQLAlchemy-1.4.22-cp38-cp38-win_amd64.whl", hash = "sha256:12bac5fa1a6ea870bdccb96fe01610641dd44ebe001ed91ef7fcd980e9702db5"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:39b5d36ab71f73c068cdcf70c38075511de73616e6c7fdd112d6268c2704d9f5"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5102b9face693e8b2db3b2539c7e1a5d9a5b4dc0d79967670626ffd2f710d6e6"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c9373ef67a127799027091fa53449125351a8c943ddaa97bec4e99271dbb21f4"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36a089dc604032d41343d86290ce85d4e6886012eea73faa88001260abf5ff81"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-win32.whl", hash = "sha256:b48148ceedfb55f764562e04c00539bb9ea72bf07820ca15a594a9a049ff6b0e"},
+    {file = "SQLAlchemy-1.4.22-cp39-cp39-win_amd64.whl", hash = "sha256:1fdae7d980a2fa617d119d0dc13ecb5c23cc63a8b04ffcb5298f2c59d86851e9"},
+    {file = "SQLAlchemy-1.4.22.tar.gz", hash = "sha256:ec1be26cdccd60d180359a527d5980d959a26269a2c7b1b327a1eea0cab37ed8"},
+]
+sqlalchemy-schemadisplay = [
+    {file = "sqlalchemy_schemadisplay-1.3.tar.gz", hash = "sha256:0a9f26d77be9d92c9564d87cc17668fe141a816036c5f5d7c8cb053b253957e0"},
+    {file = "sqlalchemy_schemadisplay-1.3.zip", hash = "sha256:b38f0d5947bd3ed9e2b180b4d8c9cd44c9d09edc0ce26722d89be4cc264903b5"},
+]
+sqlalchemy-utils = [
+    {file = "SQLAlchemy-Utils-0.37.8.tar.gz", hash = "sha256:a6aaee154f798be4e479af0ceffaa5034d35fcf6f40707c0947d21bde64e05e5"},
+    {file = "SQLAlchemy_Utils-0.37.8-py3-none-any.whl", hash = "sha256:b1bf67d904fed16b16ef1dc07f03e5e93a6b23899f920f6b41c09be45fbb85f2"},
 ]
 swagger-ui-bundle = [
     {file = "swagger_ui_bundle-0.0.8-py3-none-any.whl", hash = "sha256:f5255f786cde67a2638111f4a7d04355836743198a83c4ecbe815d9fc384b0c8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ synapseclient = "^2.4.0"
 toml = "^0.10.2"
 Flask = "^1.1.4"
 connexion = {extras = ["swagger-ui"], version = "^2.8.0"}
+SQLAlchemy = "1.4.22"
+mysqlclient = "^2.0.3"
+SQLAlchemy-Utils = "^0.37.8"
+sqlalchemy_schemadisplay = "^1.3"
 
 
 [tool.poetry.dev-dependencies]

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -139,8 +139,13 @@ def get_manifest(
     )
 
     if sheet_url:
-        logger.info("Find the manifest template using this Google Sheet URL:")
-        click.echo(result)
+        if type(result) == list:
+            for r in result:
+                logger.info("Find the manifest template using this Google Sheet URL:")
+                click.echo(r)
+        else:
+            logger.info("Find the manifest template using this Google Sheet URL:")
+            click.echo(result)
 
     elif isinstance(result, pd.DataFrame):
         if output_csv is None:

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -2,24 +2,34 @@ import os
 import logging
 from typing import Dict, List, Tuple
 from collections import OrderedDict
+import socket
 from tempfile import NamedTemporaryFile
 
 import pandas as pd
 import pygsheets as ps
 import json
 
+from schematic.db.rdb import RDB
+from schematic.db.sql import SQL
+
+from schematic.schemas.explorer import SchemaExplorer
 from schematic.schemas.generator import SchemaGenerator
 from schematic.utils.google_api_utils import (
     build_credentials,
     execute_google_api_requests,
     build_service_account_creds,
 )
+
+from schematic.utils.io_utils import load_json
 from schematic.utils.df_utils import update_df
 from schematic.store.synapse import SynapseStorage
 
 from schematic import CONFIG
 
 logger = logging.getLogger(__name__)
+
+timeout_in_sec = 60 * 3  # 3 minutes timeout limit
+socket.setdefaulttimeout(timeout_in_sec)
 
 
 class ManifestGenerator(object):
@@ -69,9 +79,10 @@ class ManifestGenerator(object):
                 "The `use_annotations` option is currently only supported "
                 "when there is no manifest file for the dataset in question."
             )
+        self.path_to_json_ld = path_to_json_ld
 
         # SchemaGenerator() object
-        self.sg = SchemaGenerator(path_to_json_ld)
+        self.sg = SchemaGenerator(self.path_to_json_ld)
 
         # additional metadata to add to manifest
         self.additional_metadata = additional_metadata
@@ -81,6 +92,15 @@ class ManifestGenerator(object):
         if self.root:
             is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
         self.is_file_based = is_file_based
+
+        # Check if manifest is being used in an RDB
+        # Will want to check for central nodes with many foreign keys
+        # referencing many tables
+        self.rdb_root = False
+        if "rdb" in path_to_json_ld.split("/")[-1].split("."):
+            self.max_authority = self.sg.se.get_max_authority()
+            if self.max_authority == root:
+                self.rdb_root = True
 
     def _attribute_to_letter(self, attribute, manifest_fields):
         """Map attribute to column letter in a google sheet"""
@@ -328,16 +348,14 @@ class ManifestGenerator(object):
         else:
             return []
 
-    def get_empty_manifest(self, json_schema_filepath=None):
-        # TODO: Refactor get_manifest method
-        # - abstract function for requirements gathering
-        # - abstract google sheet API requests as functions
-        # --- specifying row format
-        # --- setting valid values in dropdowns for columns/cells
-        # --- setting notes/comments to cells
+    def _get_json_schema(self, json_schema_filepath: str) -> Dict:
+        """Open json schema as a dictionary.
+        Args:
+            json_schema_filepath(str): path to json schema file
 
-        spreadsheet_id = self._create_empty_manifest_spreadsheet(self.title)
-
+        Returns:
+            Dictionary, containing portions of the json schema
+        """
         if not json_schema_filepath:
             # if no json schema is provided; there must be
             # schema explorer defined for schema.org schema
@@ -347,11 +365,69 @@ class ManifestGenerator(object):
         else:
             with open(json_schema_filepath) as jsonfile:
                 json_schema = json.load(jsonfile)
+        return json_schema
 
+    def _get_required_fields_per_manifest(
+        self, foreign_keys: list, json_schema: dict, prop_label_to_display_name: dict
+    ) -> list[list]:
+        """For a RDB root manifest, create a manifest per connected
+        foreign key table, that contains only attributes for the root table
+        and the foreign key. In this step gather the attributes/fields per manifest.
+
+        Args:
+            foreign_keys(list_: FKS linked to the root node
+            json_schema(dict): representing a handful of values
+                representing the data model, including: '$schema', '$id', 'title',
+                'type', 'properties', 'required'
+            prop_label_to_display_name(dict):
+                {property_label: display_name} for all property keys in
+                the json schema.
+        Returns:
+            req_fields_per_manifest(list[list]):
+                for each RDB root manifest that is generated, all the attributes/fields/cols
+                that it should contain.
+        """
+        # Gather just the attributes that we want per manifest
+        root_manifest_base_attributes = [
+            *self.rdb.tables["Resource"]["attributes"].keys()
+        ]
+        # Determine if component should be added to the manifest
+        if "Component" in json_schema["required"]:
+            add_component = True
+        req_fields_per_manifest = []
+        manifest_attributes = []
+        # Each of the foreign keys represents a separate table that will
+        # be linked to the root.
+        for fk in foreign_keys:
+            manifest_attributes = root_manifest_base_attributes.copy()
+            manifest_attributes.append(fk)
+            # Convert naming to property labels.
+            manifest_attributes = [
+                prop_label_to_display_name[attr] for attr in manifest_attributes
+            ]
+            if add_component:
+                manifest_attributes.append("Component")
+            req_fields_per_manifest.append(manifest_attributes)
+
+        return req_fields_per_manifest
+
+    def _get_required_metadata_fields(self, json_schema, fields):
+        """For the root node gather dependency requirements (all attributes linked to this node)
+        and corresponding allowed values constraints (i.e. valid values).
+
+        Args:
+            json_schema(dict): representing a handful of values
+                representing the data model, including: '$schema', '$id', 'title',
+                'type', 'properties', 'required'
+            fields(list[str]): fields/attributes to search
+        Returns:
+            required_metadata_fields(dict):
+                keys: of all the fields/attributes that need to be added
+                    to the manifest
+                values(list[str]): valid values
+        """
         required_metadata_fields = {}
-
-        # gathering dependency requirements and corresponding allowed values constraints (i.e. valid values) for root node
-        for req in json_schema["properties"].keys():
+        for req in fields:
             required_metadata_fields[
                 req
             ] = self._get_valid_values_from_jsonschema_property(
@@ -359,8 +435,27 @@ class ManifestGenerator(object):
             )
             # the following line may not be needed
             json_schema["properties"][req]["enum"] = required_metadata_fields[req]
+        return required_metadata_fields
 
-        # gathering dependency requirements and allowed value constraints for conditional dependencies if any
+    def _gather_dependency_requirements(self, json_schema, required_metadata_fields):
+        """Gathering dependency requirements and allowed value constraints
+            for conditional dependencies, if any
+        TODO:
+            Refactor
+        Args:
+            json_schema(dict): representing a handful of values
+                representing the data model, including: '$schema', '$id', 'title',
+                'type', 'properties', 'required'
+            required_metadata_fields(dict):
+                keys: of all the fields/attributes that need to be added
+                    to the manifest
+                values(list[str]): valid values
+        Returns:
+            required_metadata_fields(dict):
+                updates dictionary to additional attributes, if applicable,
+                as keys with their corresponding valid values.
+        """
+
         if "allOf" in json_schema:
             for conditional_reqs in json_schema["allOf"]:
                 if "required" in conditional_reqs["if"]:
@@ -389,37 +484,91 @@ class ManifestGenerator(object):
                                     json_schema["properties"][req]
                                 )
 
+        return required_metadata_fields
+
+    def _add_root_to_component(self, required_metadata_fields):
+        """If 'Component' is in the column set, add root node as a
+        metadata component entry in the first row of that column.
+        Args:
+            required_metadata_fields(dict):
+                keys: of all the fields/attributes that need to be added
+                    to the manifest
+                values(list[str]): valid values
+        Return:
+            updates self.additional_metadata if appropriate to
+            contain {'Component': [self.root]}
+        """
+
+        if "Component" in required_metadata_fields.keys():
+            # check if additional metadata has actually been instantiated in the
+            # constructor (it's optional) if not, instantiate it
+            if not self.additional_metadata:
+                self.additional_metadata = {}
+            self.additional_metadata["Component"] = [self.root]
+        return
+
+    def _get_additional_metadata(self, required_metadata_fields: dict) -> dict:
+        """Add additional metadata as entries to columns.
+        Args:
+            required_metadata_fields(dict):
+                keys: of all the fields/attributes that need to be added
+                    to the manifest
+                values(list[str]): valid values
+        Return:
+            required_metadata_fields(dict): Updated required_metadata_fields to include additional metadata
+                that is to be added to specified columns
+        """
+        self._add_root_to_component(required_metadata_fields)
         # if additional metadata is provided append columns (if those do not exist already)
         if self.additional_metadata:
             for column in self.additional_metadata.keys():
                 if not column in required_metadata_fields:
                     required_metadata_fields[column] = []
+        return required_metadata_fields
 
-        # if 'component' is in column set (see your input jsonld schema for definition of 'component', if the 'component' attribute is present), add the root node as an additional metadata component entry
-        if "Component" in required_metadata_fields.keys():
-            # check if additional metadata has actually been instantiated in the constructor (it's optional)
-            # if not, instantiate it
-            if not self.additional_metadata:
-                self.additional_metadata = {}
-
-            self.additional_metadata["Component"] = [self.root]
-
-        # adding columns to manifest sheet
+    def _get_column_range_and_order(self, required_metadata_fields):
+        """Find the alphabetical range of columns and sort them.
+        Args:
+            required_metadata_fields(dict):
+                keys: of all the fields/attributes that need to be added
+                    to the manifest
+                values(list[str]): valid values
+        Returns:
+            end_col_letter (chr): google sheet letter representation of a column index integer
+            ordered_metadata_fields(List[list]): Contining all the attributes to
+            add as columns, ordered
+        """
+        # determining columns range
         end_col = len(required_metadata_fields.keys())
         end_col_letter = self._column_to_letter(end_col)
 
         # order columns header (since they are generated based on a json schema, which is a dict)
         ordered_metadata_fields = [list(required_metadata_fields.keys())]
-
         ordered_metadata_fields[0] = self.sort_manifest_fields(
             ordered_metadata_fields[0]
         )
+        return end_col_letter, ordered_metadata_fields
+
+    def _gs_add_and_format_columns(self, required_metadata_fields, spreadsheet_id):
+        """Add columns to the google sheet and format them.
+        Args:
+            required_metadata_fields(dict):
+                keys: of all the fields/attributes that need to be added
+                    to the manifest
+                values(list[str]): valid values
+            spreadsheet_id(str): id of the google sheet
+        Returns:
+            respones: In return for a request, used by google sheet api to add columns
+                to the sheet being generated.
+            ordered_metadata_fields(List[list]): contining all the attributes to
+            add as columns, ordered
+        """
+
+        end_col_letter, ordered_metadata_fields = self._get_column_range_and_order(
+            required_metadata_fields
+        )
 
         body = {"values": ordered_metadata_fields}
-
-        # determining columns range
-        end_col = len(required_metadata_fields.keys())
-        end_col_letter = self._column_to_letter(end_col)
 
         range = "Sheet1!A1:" + str(end_col_letter) + "1"
 
@@ -481,12 +630,25 @@ class ManifestGenerator(object):
             .batchUpdate(spreadsheetId=spreadsheet_id, body=header_format_body)
             .execute()
         )
+        return response, ordered_metadata_fields
 
-        # adding additional metadata values if needed
-        # adding value-constraints from data model as dropdowns
-
-        # fix for issue #410
-        # batch google API request to create metadata template
+    def _gs_add_additional_metadata(
+        self, required_metadata_fields, ordered_metadata_fields, spreadsheet_id
+    ):
+        """Adding additional metadata values, if needed. Add value-constraints
+        from data model as dropdowns. Batch google API request to
+        create metadata template.
+        Args:
+            required_metadata_fields(dict):
+                keys: of all the fields/attributes that need to be added
+                    to the manifest
+                values(list[str]): valid values
+            ordered_metadata_fields(List[list]): contining all the attributes to
+            add as columns, ordered
+            spreadsheet_id(str): id for the google sheet
+        Returns: Response(dict): For batch update to create metadata
+        template.
+        """
         data = []
 
         for i, req in enumerate(ordered_metadata_fields[0]):
@@ -523,217 +685,396 @@ class ManifestGenerator(object):
             )
             .execute()
         )
+        return response
 
-        # end of fix for issue #410
+    def _request_row_format(self, i, req):
+        """Adding description to headers, this is not executed if
+        only JSON schema is defined. Also formatting required columns.
+        Args:
+            i (int): column index
+            req (str): column name
+        Returns:
+            notes_body["requests"] (dict): with information on note
+                to add to the column header. This notes body will be added to a request.
+        """
+        if self.sg.se:
+            # get node definition
+            note = self.sg.get_node_definition(req)
 
-        # store all requests to execute at once
-        requests_body = {}
-        requests_body["requests"] = []
-        for i, req in enumerate(ordered_metadata_fields[0]):
-            values = required_metadata_fields[req]
-
-            # adding description to headers
-            # this is not executed if only JSON schema is defined
-            # TODO: abstract better and document
-
-            # also formatting required columns
-            if self.sg.se:
-
-                # get node definition
-                note = self.sg.get_node_definition(req)
-
-                notes_body = {
-                    "requests": [
-                        {
-                            "updateCells": {
-                                "range": {
-                                    "startRowIndex": 0,
-                                    "endRowIndex": 1,
-                                    "startColumnIndex": i,
-                                    "endColumnIndex": i + 1,
-                                },
-                                "rows": [{"values": [{"note": note}]}],
-                                "fields": "note",
-                            }
-                        }
-                    ]
-                }
-
-                requests_body["requests"].append(notes_body["requests"])
-
-            # get node validation rules if any
-            validation_rules = self.sg.get_node_validation_rules(req)
-
-            # if 'list' in validation rules add a note with instructions on
-            # adding a list of multiple values
-            # TODO: add validation and QC rules "compiler/generator" class elsewhere
-            # for now have the list logic here
-            if "list" in validation_rules:
-                note = "From 'Selection options' menu above, go to 'Select multiple values', check all items that apply, and click 'Save selected values'"
-                notes_body = {
-                    "requests": [
-                        {
-                            "repeatCell": {
-                                "range": {
-                                    "startRowIndex": 1,
-                                    "startColumnIndex": i,
-                                    "endColumnIndex": i + 1,
-                                },
-                                "cell": {"note": note},
-                                "fields": "note",
-                            }
-                        }
-                    ]
-                }
-
-                requests_body["requests"].append(notes_body["requests"])
-
-            # update background colors so that columns that are required are highlighted
-            # check if attribute is required and set a corresponding color
-            if req in json_schema["required"]:
-                bg_color = CONFIG["style"]["google_manifest"].get(
-                    "req_bg_color",
+            notes_body = {
+                "requests": [
                     {
-                        "red": 0.9215,
-                        "green": 0.9725,
-                        "blue": 0.9803,
-                    },
-                )
-
-                req_format_body = {
-                    "requests": [
-                        {
-                            "repeatCell": {
-                                "range": {
-                                    "startColumnIndex": i,
-                                    "endColumnIndex": i + 1,
-                                },
-                                "cell": {
-                                    "userEnteredFormat": {"backgroundColor": bg_color}
-                                },
-                                "fields": "userEnteredFormat(backgroundColor)",
-                            }
+                        "updateCells": {
+                            "range": {
+                                "startRowIndex": 0,
+                                "endRowIndex": 1,
+                                "startColumnIndex": i,
+                                "endColumnIndex": i + 1,
+                            },
+                            "rows": [{"values": [{"note": note}]}],
+                            "fields": "note",
                         }
-                    ]
-                }
+                    }
+                ]
+            }
 
-                requests_body["requests"].append(req_format_body["requests"])
+            return notes_body["requests"]
+        else:
+            return
 
-            # adding value-constraints if any
-            req_vals = [{"userEnteredValue": value} for value in values if value]
+    def _request_note_valid_values(self, i, req, validation_rules, valid_values):
+        """If the node validation rule is 'list' and the node also contains
+        valid values, add a note a note with instructions on adding a list of
+        multiple values with the multi-select option in google sheets
 
-            if not req_vals:
-                continue
+        TODO: add validation and QC rules "compiler/generator" class elsewhere
+            for now have the list logic here
+        Args:
+            i (int): column index
+            req (str): column name
+            validation_rules(list[str]): containing all relevant
+                rules applied to node/column
+            valid_values(list[str]): containing all valid values defined in the
+                data model for this node/column
 
-            # generating sheet api request to populate a dropdown or a multi selection UI
-            if len(req_vals) > 0 and not "list" in validation_rules:
-                # if more than 0 values in dropdown use ONE_OF_RANGE type of validation since excel and openoffice
-                # do not support other kinds of data validation for larger number of items (even if individual items are not that many
-                # excel has a total number of characters limit per dropdown...)
-                validation_body = self._get_column_data_validation_values(
-                    spreadsheet_id, req_vals, i, validation_type="ONE_OF_RANGE"
-                )
+        Returns:
+            notes_body["requests"] (dict): with information on note
+                to add to the column header, about using multiselect.
+                This notes body will be added to a request.
+        """
 
-            elif "list" in validation_rules:
-                # if list is in validation rule attempt to create a multi-value
-                # selection UI, which requires explicit valid values range in
-                # the spreadsheet
-                validation_body = self._get_column_data_validation_values(
-                    spreadsheet_id,
-                    req_vals,
-                    i,
-                    custom_ui=False,
-                    input_message="",
-                    validation_type="ONE_OF_RANGE",
-                )
-
-            else:
-                validation_body = self._get_column_data_validation_values(
-                    spreadsheet_id, req_vals, i
-                )
-
-            requests_body["requests"].append(validation_body["requests"])
-
-            # generate a conditional format rule for each required value (i.e. valid value)
-            # for this field (i.e. if this field is set to a valid value that may require additional
-            # fields to be filled in, these additional fields will be formatted in a custom style (e.g. red background)
-            for req_val in req_vals:
-                # get this required/valid value's node label in schema, based on display name (i.e. shown to the user in a dropdown to fill in)
-                req_val = req_val["userEnteredValue"]
-
-                req_val_node_label = self.sg.get_node_label(req_val)
-                if not req_val_node_label:
-                    # if this node is not in the graph
-                    # continue - there are no dependencies for it
-                    continue
-
-                # check if this required/valid value has additional dependency attributes
-                val_dependencies = self.sg.get_node_dependencies(
-                    req_val_node_label, schema_ordered=False
-                )
-
-                # prepare request calls
-                dependency_formatting_body = {"requests": []}
-
-                if val_dependencies:
-                    # if there are additional attribute dependencies find the corresponding
-                    # fields that need to be filled in and construct conditional formatting rules
-                    # indicating the dependencies need to be filled in
-
-                    # set target ranges for this rule
-                    # i.e. dependency attribute columns that will be formatted
-
-                    # find dependency column indexes
-                    # note that dependencies values must be in index
-                    # TODO: catch value error that shouldn't happen
-                    column_idxs = [
-                        ordered_metadata_fields[0].index(val_dep)
-                        for val_dep in val_dependencies
-                    ]
-
-                    # construct ranges based on dependency column indexes
-                    rule_ranges = self._columns_to_sheet_ranges(column_idxs)
-                    # go over valid value dependencies
-                    for j, val_dep in enumerate(val_dependencies):
-                        is_required = False
-
-                        if self.sg.is_node_required(val_dep):
-                            is_required = True
-                        else:
-                            is_required = False
-
-                        # construct formatting rule
-                        formatting_rule = self._column_to_cond_format_eq_rule(
-                            i, req_val, required=is_required
-                        )
-
-                        # construct conditional format rule
-                        conditional_format_rule = {
-                            "addConditionalFormatRule": {
-                                "rule": {
-                                    "ranges": rule_ranges[j],
-                                    "booleanRule": formatting_rule,
-                                },
-                                "index": 0,
-                            }
+        if "list" in validation_rules and valid_values:
+            note = "From 'Selection options' menu above, go to 'Select multiple values', check all items that apply, and click 'Save selected values'"
+            notes_body = {
+                "requests": [
+                    {
+                        "repeatCell": {
+                            "range": {
+                                "startRowIndex": 1,
+                                "startColumnIndex": i,
+                                "endColumnIndex": i + 1,
+                            },
+                            "cell": {"note": note},
+                            "fields": "note",
                         }
-                        dependency_formatting_body["requests"].append(
-                            conditional_format_rule
-                        )
+                    }
+                ]
+            }
 
-                # check if dependency formatting rules have been added and update sheet if so
-                if dependency_formatting_body["requests"]:
-                    requests_body["requests"].append(
-                        dependency_formatting_body["requests"]
-                    )
+            return notes_body["requests"]
+        else:
+            return
 
+    def _request_notes_comments(self, i, req, json_schema):
+        """Update background colors so that columns that are required are highlighted
+        Args:
+            i (int): column index
+            req (str): column name
+            json_schema(dict): representing a handful of values
+                representing the data model, including: '$schema', '$id', 'title',
+                'type', 'properties', 'required'
+        Returns:
+            req_format_body["requests"] (dict): specifing the format updating for
+                required attributes/columns
+        """
+        # check if attribute is required and set a corresponding color
+        if req in json_schema["required"]:
+            bg_color = CONFIG["style"]["google_manifest"].get(
+                "req_bg_color",
+                {
+                    "red": 0.9215,
+                    "green": 0.9725,
+                    "blue": 0.9803,
+                },
+            )
+
+            req_format_body = {
+                "requests": [
+                    {
+                        "repeatCell": {
+                            "range": {
+                                "startColumnIndex": i,
+                                "endColumnIndex": i + 1,
+                            },
+                            "cell": {
+                                "userEnteredFormat": {"backgroundColor": bg_color}
+                            },
+                            "fields": "userEnteredFormat(backgroundColor)",
+                        }
+                    }
+                ]
+            }
+            return req_format_body["requests"]
+        else:
+            return
+
+    def _request_cell_borders(self):
+        """Get cell border color specifications.
+        Args: None
+        Returns:
+            Dict, containing cell border design specifications.
+        """
         # setting cell borders
         cell_range = {
             "sheetId": 0,
             "startRowIndex": 0,
         }
-        requests_body["requests"].append(self._get_cell_borders(cell_range))
+        return self._get_cell_borders(cell_range)
 
+    def _request_dropdown_or_multi(
+        self, i, req_vals, spreadsheet_id, validation_rules, valid_values
+    ):
+        """Generating sheet api request to populate a dropdown or a multi selection UI
+        Args:
+            i (int): column index
+            req_vals (list[dict]): dict for each valid value
+                key: 'userEnteredValue'
+                value: str, valid value
+            spreadsheet_id (str): id for the google sheet
+            validation_rules(list[str]): containing all relevant
+                rules applied to node/column
+            valid_values(list[str]): containing all valid values defined in the
+                data model for this node/column
+        Returns:
+            validation_body: dict
+        """
+        if len(req_vals) > 0 and not "list" in validation_rules:
+            # if more than 0 values in dropdown use ONE_OF_RANGE type of validation
+            # since excel and openoffice
+            # do not support other kinds of data validation for
+            # larger number of items (even if individual items are not that many
+            # excel has a total number of characters limit per dropdown...)
+            validation_body = self._get_column_data_validation_values(
+                spreadsheet_id, req_vals, i, validation_type="ONE_OF_RANGE"
+            )
+        elif "list" in validation_rules and valid_values:
+            # if list is in validation rule attempt to create a multi-value
+            # selection UI, which requires explicit valid values range in
+            # the spreadsheet
+            validation_body = self._get_column_data_validation_values(
+                spreadsheet_id,
+                req_vals,
+                i,
+                custom_ui=False,
+                input_message="",
+                validation_type="ONE_OF_RANGE",
+            )
+        else:
+            validation_body = self._get_column_data_validation_values(
+                spreadsheet_id, req_vals, i
+            )
+        return validation_body["requests"]
+
+    def _dependency_formatting(
+        self, i, req_val, ordered_metadata_fields, val_dependencies
+    ):
+        """If there are additional attribute dependencies find the corresponding
+        fields that need to be filled in and construct conditional formatting rules
+        indicating the dependencies need to be filled in.
+
+        set target ranges for this rule
+        i.e. dependency attribute columns that will be formatted
+
+        Args:
+            i (int): column index
+            req_val (str): node name
+            ordered_metadata_fields(List[list]): contining all the attributes to
+            add as columns, ordered
+            val_depenencies (list[str]): dependencies
+        Returns:
+            conditional_format_rule (dict):
+                specifies gs conditional formatting
+        """
+
+        # find dependency column indexes
+        # note that dependencies values must be in index
+        # TODO: catch value error that shouldn't happen
+        column_idxs = [
+            ordered_metadata_fields[0].index(val_dep) for val_dep in val_dependencies
+        ]
+
+        # construct ranges based on dependency column indexes
+        rule_ranges = self._columns_to_sheet_ranges(column_idxs)
+        # go over valid value dependencies
+        for j, val_dep in enumerate(val_dependencies):
+            is_required = False
+
+            if self.sg.is_node_required(val_dep):
+                is_required = True
+            else:
+                is_required = False
+
+            # construct formatting rule
+            formatting_rule = self._column_to_cond_format_eq_rule(
+                i, req_val, required=is_required
+            )
+
+            # construct conditional format rule
+            conditional_format_rule = {
+                "addConditionalFormatRule": {
+                    "rule": {
+                        "ranges": rule_ranges[j],
+                        "booleanRule": formatting_rule,
+                    },
+                    "index": 0,
+                }
+            }
+        return conditional_format_rule
+
+    def _request_dependency_formatting(
+        self, i, req_vals, ordered_metadata_fields, requests_body
+    ):
+        """Gather all the formattng for node dependencies.
+        Args:
+            i (int): column index
+            req_val (str): node name
+            ordered_metadata_fields(List[list]): contining all the attributes to
+            add as columns, ordered
+            requests_body(dict):
+                containing all the update requests to add to the gs
+        Return:
+            dependency_formatting_body (dict): specifiying the conditional
+            formatting rules to apply
+        """
+        for req_val in req_vals:
+            # get this required/valid value's node label in schema, based on display name (i.e. shown to the user in a dropdown to fill in)
+            req_val = req_val["userEnteredValue"]
+
+            req_val_node_label = self.sg.get_node_label(req_val)
+            if not req_val_node_label:
+                # if this node is not in the graph
+                # continue - there are no dependencies for it
+                continue
+
+            # check if this required/valid value has additional dependency attributes
+            val_dependencies = self.sg.get_node_dependencies(
+                req_val_node_label, schema_ordered=False
+            )
+
+            # prepare request calls
+            dependency_formatting_body = {"requests": []}
+
+            # set conditiaon formatting for dependencies.
+            if val_dependencies:
+                conditional_format_rule = self._dependency_formatting(
+                    i, req_val, ordered_metadata_fields, val_dependencies
+                )
+                dependency_formatting_body["requests"].append(conditional_format_rule)
+        return dependency_formatting_body
+
+    def _create_requests_body(
+        self,
+        required_metadata_fields,
+        ordered_metadata_fields,
+        json_schema,
+        spreadsheet_id,
+    ):
+        """Create and store all formatting changes for the google sheet to
+        execute at once.
+        Args:
+            required_metadata_fields(dict):
+                keys: of all the fields/attributes that need to be added
+                    to the manifest
+                values(list[str]): valid values
+            ordered_metadata_fields: List[list], contining all the attributes to
+                add as columns, ordered
+            json_schema: dict, representing a handful of values
+                representing the data model, including: '$schema', '$id', 'title',
+                'type', 'properties', 'required'
+            spreadsheet_id: str, of the id for the google sheet
+        Return:
+            requests_body(dict):
+                containing all the update requests to add to the gs
+        """
+        # store all requests to execute at once
+        requests_body = {}
+        requests_body["requests"] = []
+        for i, req in enumerate(ordered_metadata_fields[0]):
+            # Gather validation rules and valid values for attribute
+            validation_rules = self.sg.get_node_validation_rules(req)
+            valid_values = self._get_valid_values_from_jsonschema_property(
+                json_schema["properties"][req]
+            )
+
+            # Set row formatting
+            get_row_formatting = self._request_row_format(i, req)
+            if get_row_formatting:
+                requests_body["requests"].append(get_row_formatting)
+
+            # Add notes to headers to provide descriptions of the attribute
+            header_notes = self._request_notes_comments(i, req, json_schema)
+            if header_notes:
+                requests_body["requests"].append(header_notes)
+            # Add note on how to use multi-select, when appropriate
+            note_vv = self._request_note_valid_values(
+                i, req, validation_rules, valid_values
+            )
+            if note_vv:
+                requests_body["requests"].append(note_vv)
+
+            # Adding value-constraints, if any
+            values = required_metadata_fields[req]
+            req_vals = [{"userEnteredValue": value} for value in values if value]
+            if not req_vals:
+                continue
+
+            # Create dropdown or multi-select options, where called for
+            create_dropdown = self._request_dropdown_or_multi(
+                i, req_vals, spreadsheet_id, validation_rules, valid_values
+            )
+            if create_dropdown:
+                requests_body["requests"].append(create_dropdown)
+
+            if not self.rdb_root:
+                # generate a conditional format rule for each required value (i.e. valid value)
+                # for this field (i.e. if this field is set to a valid value that may require additional
+                # fields to be filled in, these additional fields will be formatted in a custom style (e.g. red background)
+                dependency_formatting_body = self._request_dependency_formatting(
+                    i, req_vals, ordered_metadata_fields, requests_body
+                )
+                if dependency_formatting_body["requests"]:
+                    requests_body["requests"].append(
+                        dependency_formatting_body["requests"]
+                    )
+        # Set borders formatting
+        borders_formatting = self._request_cell_borders()
+        if borders_formatting:
+            requests_body["requests"].append(borders_formatting)
+        return requests_body
+
+    def _create_empty_gs(self, required_metadata_fields, json_schema, spreadsheet_id):
+        """Generate requests to add columns and format the google sheet.
+        Args:
+            required_metadata_fields(dict):
+                keys: of all the fields/attributes that need to be added
+                    to the manifest
+                values(list[str]): valid values
+            json_schema: dict, representing a handful of values
+                representing the data model, including: '$schema', '$id', 'title',
+                'type', 'properties', 'required'
+            spreadsheet_id: str, of the id for the google sheet
+        Returns:
+            manifest_url (str): url of the google sheet manifest.
+        """
+        # adding columns to manifest sheet
+        response, ordered_metadata_fields = self._gs_add_and_format_columns(
+            required_metadata_fields, spreadsheet_id
+        )
+
+        # Add additional metadata
+        response = self._gs_add_additional_metadata(
+            required_metadata_fields, ordered_metadata_fields, spreadsheet_id
+        )
+
+        # Create requests body to add additional formatting to the sheets
+        requests_body = self._create_requests_body(
+            required_metadata_fields,
+            ordered_metadata_fields,
+            json_schema,
+            spreadsheet_id,
+        )
+
+        # Execute requests
         execute_google_api_requests(
             self.sheet_service,
             requests_body,
@@ -741,17 +1082,132 @@ class ManifestGenerator(object):
             spreadsheet_id=spreadsheet_id,
         )
 
-        # setting up spreadsheet permissions (setup so that anyone with the link can edit)
+        # Setting up spreadsheet permissions (setup so that anyone with the link can edit)
         self._set_permissions(spreadsheet_id)
 
         # generating spreadsheet URL
         manifest_url = "https://docs.google.com/spreadsheets/d/" + spreadsheet_id
-
-        # print("========================================================================================================")
-        # print("Manifest successfully generated from schema!")
-        # print("URL: " + manifest_url)
-        # print("========================================================================================================")
         return manifest_url
+
+    def _gather_all_fields(self, fields, json_schema):
+        """Gather all the attributes/fields to include as columns in the manifest.
+        Args:
+            fields(list[str]): fields/attributes to search
+        Returns:
+            required_metadata_fields(dict):
+                keys: of all the fields/attributes that need to be added
+                    to the manifest
+                values(list[str]): valid values
+        """
+        # Get required fields
+        required_metadata_fields = self._get_required_metadata_fields(
+            json_schema, fields
+        )
+
+        if not self.rdb_root:
+            # Add additioal dependencies
+            required_metadata_fields = self._gather_dependency_requirements(
+                json_schema, required_metadata_fields
+            )
+        # Add additional metadata as entries to columns
+        required_metadata_fields = self._get_additional_metadata(
+            required_metadata_fields
+        )
+        return required_metadata_fields
+
+    def _get_rdb_root_fks(self) -> list[str]:
+        """Get all foreign keys related to the root manifest.
+        Used only for relational databases.
+
+        Args:
+            None
+        Return:
+            List, of foreign keys (str)
+        """
+        # get foreign keys based on db schema graph
+        self.rdb = RDB(self.path_to_json_ld)
+
+        # Gather Foreign Key Ids so we know what values to keep per sheet.
+        foreign_keys = self.rdb.get_table_foreign_keys(
+            self.max_authority, table_prefix=False
+        )
+        foreign_keys.extend(self.rdb.get_additional_foreign_keys(self.max_authority))
+        return foreign_keys
+
+    def get_empty_manifest(self, json_schema_filepath=None):
+        """Create an empty manifest using specifications from the
+        json schema.
+        Args:
+            json_schema_filepath (str): path to json schema file
+        Returns:
+            manifest_url (str): url of the google sheet manifest.
+        """
+
+        # Check if creating an empty manifest for the root node of
+        # a relational database. If so, construct them a different way.
+        if self.rdb_root:
+            manifest_urls = self.generate_empty_root_manifests()
+            return manifest_urls
+
+        spreadsheet_id = self._create_empty_manifest_spreadsheet(self.title)
+        json_schema = self._get_json_schema(json_schema_filepath)
+
+        required_metadata_fields = self._gather_all_fields(
+            json_schema["properties"].keys(), json_schema
+        )
+
+        manifest_url = self._create_empty_gs(
+            required_metadata_fields, json_schema, spreadsheet_id
+        )
+        return manifest_url
+
+    def generate_empty_root_manifests(self, json_schema_filepath=None):
+        """In the case of a RDB, when using FK/PKs and having nested dependecies
+        want to only pull relevant columns for the root directory.
+        Make a manifest for each table that is connected through a foreign key,
+        user feedback states this is an easier way to work with the data. Doing it
+        this way will also get through the issue of having many 'required'
+        foreign keys per row, which cannot possibly be supplied.
+
+        Keeping separate from get_empty_manifest since it would
+        require too many if statements to be easily readable.
+
+        Args:
+            json_schema_filepath (str): path to json schema file
+        Returns:
+            manifest_urls (list[str]):
+                list of individual manifest_url's.
+                Each of whom link to a gs manifest.
+        """
+        json_schema = self._get_json_schema(json_schema_filepath)
+        foreign_keys = self._get_rdb_root_fks()
+        spreadsheet_ids = [
+            self._create_empty_manifest_spreadsheet(self.title) for i in foreign_keys
+        ]
+        prop_label_to_display_name = self.sg.se.property_label_to_display_dict(
+            json_schema["properties"].keys()
+        )
+        # Determine the fields/attributes to include per manifest
+        req_fields_per_manifest = self._get_required_fields_per_manifest(
+            foreign_keys, json_schema, prop_label_to_display_name
+        )
+        # Gather all data for generating each manifest
+        required_metadata_fields_per_manifest = []
+        for fields in req_fields_per_manifest:
+            required_metadata_fields = self._gather_all_fields(fields, json_schema)
+            required_metadata_fields_per_manifest.append(required_metadata_fields)
+
+        # Create each manifest
+        manifest_urls = []
+        for ind, required_metadata_fields in enumerate(
+            required_metadata_fields_per_manifest
+        ):
+            manifest_urls.append(
+                self._create_empty_gs(
+                    required_metadata_fields, json_schema, spreadsheet_ids[ind]
+                )
+            )
+        return manifest_urls
 
     def set_dataframe_by_url(
         self, manifest_url: str, manifest_df: pd.DataFrame
@@ -779,13 +1235,13 @@ class ManifestGenerator(object):
         # the sheet column header reflect the latest schema
         # the existing manifest column-set may be outdated
         # ensure that, if missing, attributes from the latest schema are added to the
-        # column-set of the existing manifest so that the user can modify their data if needed 
+        # column-set of the existing manifest so that the user can modify their data if needed
         # to comply with the latest schema
 
         # get headers from existing manifest and sheet
         wb_header = wb.get_row(1)
         manifest_df_header = manifest_df.columns
-        
+
         # find missing columns in existing manifest
         new_columns = set(wb_header) - set(manifest_df_header)
 
@@ -794,14 +1250,19 @@ class ManifestGenerator(object):
 
         # update existing manifest w/ missing columns, if any
         if new_columns:
-            manifest_df = manifest_df.assign(**dict(zip(new_columns, len(new_columns)*[""])))
+            manifest_df = manifest_df.assign(
+                **dict(zip(new_columns, len(new_columns) * [""]))
+            )
 
         # sort columns in the updated manifest:
         # match latest schema order
         # move obsolete columns at the end
         manifest_df = manifest_df[self.sort_manifest_fields(manifest_df.columns)]
-        manifest_df = manifest_df[[c for c in manifest_df if c not in out_of_schema_columns] + list(out_of_schema_columns)]
-        
+        manifest_df = manifest_df[
+            [c for c in manifest_df if c not in out_of_schema_columns]
+            + list(out_of_schema_columns)
+        ]
+
         # The following line sets `valueInputOption = "RAW"` in pygsheets
         sh.default_parse = False
 
@@ -810,10 +1271,14 @@ class ManifestGenerator(object):
 
         # update validation rules (i.e. no validation rules) for out of schema columns, if any
         # TODO: similarly clear formatting for out of schema columns, if any
-        if len(out_of_schema_columns) > 0: 
-            start_col = self._column_to_letter(len(wb_header)) # find start of out of schema columns
-            end_col = self._column_to_letter(len(manifest_df.columns) + 1) # find end of out of schema columns
-            wb.set_data_validation(start = start_col, end = end_col, condition_type = None)
+        if len(out_of_schema_columns) > 0:
+            start_col = self._column_to_letter(
+                len(wb_header)
+            )  # find start of out of schema columns
+            end_col = self._column_to_letter(
+                len(manifest_df.columns) + 1
+            )  # find end of out of schema columns
+            wb.set_data_validation(start=start_col, end=end_col, condition_type=None)
 
         # set permissions so that anyone with the link can edit
         sh.share("", role="writer", type="anyone")
@@ -896,6 +1361,7 @@ class ManifestGenerator(object):
 
         # Generate empty manifest using `additional_metadata`
         manifest_url = self.get_empty_manifest()
+
         manifest_df = self.get_dataframe_by_url(manifest_url)
 
         # Annotations clashing with manifest attributes are skipped
@@ -923,7 +1389,7 @@ class ManifestGenerator(object):
         Returns:
             Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
         """
-        
+
         # Handle case when no dataset ID is provided
         if not dataset_id:
             return self.get_empty_manifest(json_schema_filepath=json_schema)
@@ -933,7 +1399,7 @@ class ManifestGenerator(object):
 
         # Get manifest file associated with given dataset (if applicable)
         syn_id_and_path = syn_store.getDatasetManifest(datasetId=dataset_id)
-       
+
         # Populate empty template with existing manifest
         if syn_id_and_path:
 
@@ -956,7 +1422,7 @@ class ManifestGenerator(object):
             pop_manifest_url = self.populate_manifest_spreadsheet(
                 manifest_data.path, empty_manifest_url
             )
-        
+
             return pop_manifest_url
 
         # Generate empty template and optionally fill in with annotations
@@ -990,7 +1456,7 @@ class ManifestGenerator(object):
 
         # read existing manifest
         manifest = pd.read_csv(existing_manifest_path).fillna("")
- 
+
         manifest_sh = self.set_dataframe_by_url(empty_manifest_url, manifest)
 
         return manifest_sh.url
@@ -1022,7 +1488,7 @@ class ManifestGenerator(object):
                 raise ValueError(
                     f"Provide valid data model path and valid component from data model."
                 )
- 
+
         # always have entityId as last columnn, if present
         if "entityId" in manifest_fields:
             manifest_fields.remove("entityId")

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -10,6 +10,7 @@ import networkx as nx
 
 from rdflib import Graph, Namespace, plugin, query
 from networkx.algorithms.cycles import find_cycle
+from networkx.algorithms.link_analysis.hits_alg import hits_numpy
 from networkx.readwrite import json_graph
 
 from schematic.utils.curie_utils import (
@@ -62,6 +63,12 @@ class SchemaExplorer:
 
     def get_nx_schema(self):
         return self.schema_nx
+
+    def get_max_authority(self):
+        cdg = self.get_digraph_by_edge_type('requiresComponent')
+        hubs, authority = hits_numpy(cdg)
+        max_authority = max(authority, key=authority.get)
+        return max_authority
 
     def get_edges_by_relationship(
         self, class_label: str, relationship: str
@@ -423,6 +430,14 @@ class SchemaExplorer:
                 "displayName"
             ]
         return class_info
+
+    def property_label_to_display_dict(self, display_names):
+        property_label_dict = {}
+        for display_name in display_names:
+            name = display_name.translate({ord(c): None for c in string.whitespace})
+            label = inflection.camelize(name.strip(), uppercase_first_letter=False)
+            property_label_dict[label] = display_name
+        return property_label_dict
 
     def get_property_label_from_display_name(self, display_name):
         """Convert a given display name string into a proper property label string"""


### PR DESCRIPTION
Built off the `develop-rdb` branch this PR creates multiple manifests for the root (max authority (MA)) table of a relational database; one for each foreign key that is attached to it. This eases use for data contributors. Additionally these manifests only contain the columns that apply to the MA manifest and does not repeat attributes that appear in the connected tables. 

Further this code abstracts out a many functions used within `create_empty_manifest`. These changes will be applied to the `develop` branch in a subsequent PR for ease of merging `develop-rdb` into `develop` in the future.