### PR TITLE
Don't coerce "boolean" strings to actual booleans 

### DIFF
--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -209,7 +209,7 @@ class MetadataModel(object):
 
         # get annotations from manifest (array of json annotations corresponding to manifest rows)
         manifest = pd.read_csv(
-            manifestPath
+            manifestPath, dtype=str
         )  # read manifest csv file as is from manifest path
         manifest = trim_commas_df(manifest).fillna(
             ""


### PR DESCRIPTION
This coercion causes validation issues where the schema doesn't have the "python" version of booleans (e.g. True/TRUE). 

Resolves #463. See discussion about previous attempt at this in #465!