### PR TITLE
Recast column types.

### DIFF
--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -77,6 +77,10 @@ def update_df(
     input_df_idx.reset_index(inplace=True)
     input_df_idx = input_df_idx[input_df.columns]
 
+     # Sometimes pandas update can change the column datatype, recast
+    for col in input_df_idx.columns:
+        input_df_idx[col] = input_df_idx[col].astype(input_df.dtypes[col])
+
     return input_df_idx
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -267,7 +267,7 @@ class TestDfUtils:
         )
         expected_df = pd.DataFrame(
             {
-                "numCol": [1, float(4)],
+                "numCol": [int(1), int(4)],
                 "entityId": ["syn01", "syn02"],
                 "strCol": ["___", "bar"],
             },


### PR DESCRIPTION
When updating tables on synapse the function `update_df` is called in `df_utils.py`. This function invokes a native pandas function called `df.update`. There is a known issue with pandas where sometimes upon calling `df.update` the column types can sometimes be changed, for example, np.int64 to np.float64. This can cause real issues when uploading to Synapse when the column type is expecting a certain type.

This PR addresses this issue by recasting the column type based on the input table.