### PR TITLE
Explicitly defined file encoding as utf-8

### DIFF
--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -52,7 +52,7 @@ class SchemaExplorer:
         self.schema_nx = load_schema_into_networkx(self.schema)
 
     def export_schema(self, file_path):
-        with open(file_path, "w", encoding='utf-8') as f:
+        with open(file_path, "w",encoding="utf8") as f:
             json.dump(self.schema, f, sort_keys=True, indent=4, ensure_ascii=False)
 
     def load_default_schema(self):

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -52,7 +52,7 @@ class SchemaExplorer:
         self.schema_nx = load_schema_into_networkx(self.schema)
 
     def export_schema(self, file_path):
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding='utf-8') as f:
             json.dump(self.schema, f, sort_keys=True, indent=4, ensure_ascii=False)
 
     def load_default_schema(self):

--- a/schematic/utils/io_utils.py
+++ b/schematic/utils/io_utils.py
@@ -16,14 +16,14 @@ def load_json(file_path):
             return data
     # handle file path
     else:
-        with open(file_path,encoding='utf8') as f:
+        with open(file_path, encoding="utf8") as f:
             data = json.load(f)
             return data
 
 
 def export_json(json_doc, file_path):
     """Export JSON doc to file"""
-    with open(file_path, "w",encoding='utf8') as f:
+    with open(file_path, "w") as f:
         json.dump(json_doc, f, sort_keys=True, indent=4, ensure_ascii=False)
 
 

--- a/schematic/utils/io_utils.py
+++ b/schematic/utils/io_utils.py
@@ -16,14 +16,14 @@ def load_json(file_path):
             return data
     # handle file path
     else:
-        with open(file_path) as f:
+        with open(file_path,encoding='utf8') as f:
             data = json.load(f)
             return data
 
 
 def export_json(json_doc, file_path):
     """Export JSON doc to file"""
-    with open(file_path, "w") as f:
+    with open(file_path, "w",encoding='utf8') as f:
         json.dump(json_doc, f, sort_keys=True, indent=4, ensure_ascii=False)
 
 


### PR DESCRIPTION
Defined encoding to use when opening and writing files as 'utf-8' so that the windows default cp-1252. 