### PR TITLE
Generate multiple manifests at a time.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -13,15 +13,13 @@ synapse:
   service_acct_creds: 'syn25171627'
 
 manifest:
-  title: 'Patient_Manifest'
-  # data_type: 'all manifests' to make all manifests.
-  data_type: 'Patient'
-  # for making many manifests
-  title_prefix: 'example'
-  data_type_set:
-    - 'Patient'
+  # if making many manifests, just include name prefix
+  title: 'example'
+  # to make all manifests enter only 'all manifests'
+  data_type: 
     - 'Biospecimen'
-
+    - 'Patient'
+  
 model:
   input:
     location: 'tests/data/example.model.jsonld'

--- a/config.yml
+++ b/config.yml
@@ -14,7 +14,13 @@ synapse:
 
 manifest:
   title: 'Patient_Manifest'
+  # data_type: 'all manifests' to make all manifests.
   data_type: 'Patient'
+  # for making many manifests
+  title_prefix: 'example'
+  data_type_set:
+    - 'Patient'
+    - 'Biospecimen'
 
 model:
   input:

--- a/config.yml
+++ b/config.yml
@@ -19,7 +19,7 @@ manifest:
   data_type: 
     - 'Biospecimen'
     - 'Patient'
-  
+
 model:
   input:
     location: 'tests/data/example.model.jsonld'

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -12,24 +12,16 @@ manifest_commands = {
                 "This is a required argument."
             ),
             "title": (
-                "Specify the title of the manifest that will be created at the end of the run. "
-                "You can either explicitly pass the title of the manifest here or provide it in the `config.yml` "
+                "Specify the title of the manifest (or title prefix of multiple manifests) that "
+                "will be created at the end of the run. You can either explicitly pass the "
+                "title of the manifest here or provide it in the `config.yml` "
                 "file as a value for the `(manifest > title)` key."
             ),
-            "title_prefix": (
-                "Specify the title prefix of the manifest that will be created at the end of the run. "
-                "You can either explicitly pass the title_prefix of the manifest here or provide it in the `config.yml` "
-                "file as a value for the `(manifest > title_prefix)` key."
-            ),
             "data_type": (
-                "Specify the component (data type) from the data model that is to be used "
-                "for generating the metadata manifest file. You can either explicitly pass the data type here or provide "
+                "Specify the component(s) (data type) from the data model that is to be used "
+                "for generating the metadata manifest file. To make all available manifests enter 'all manifests'. "
+                "You can either explicitly pass the data type here or provide "
                 "it in the `config.yml` file as a value for the `(manifest > data_type)` key."
-            ),
-            "data_type_set": (
-                "Specify the set of components (data types) from the data model that is to be used "
-                "for generating a set of metadata manifest files. You can either explicitly pass the data type set here or provide "
-                "it in the `config.yml` file as a value for the `(manifest > data_type_set)` key."
             ),
             "jsonld": (
                 "Specify the path to the JSON-LD data model (schema) using this option. You can either explicitly pass the "

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -16,10 +16,20 @@ manifest_commands = {
                 "You can either explicitly pass the title of the manifest here or provide it in the `config.yml` "
                 "file as a value for the `(manifest > title)` key."
             ),
+            "title_prefix": (
+                "Specify the title prefix of the manifest that will be created at the end of the run. "
+                "You can either explicitly pass the title_prefix of the manifest here or provide it in the `config.yml` "
+                "file as a value for the `(manifest > title_prefix)` key."
+            ),
             "data_type": (
                 "Specify the component (data type) from the data model that is to be used "
                 "for generating the metadata manifest file. You can either explicitly pass the data type here or provide "
                 "it in the `config.yml` file as a value for the `(manifest > data_type)` key."
+            ),
+            "data_type_set": (
+                "Specify the set of components (data types) from the data model that is to be used "
+                "for generating a set of metadata manifest files. You can either explicitly pass the data type set here or provide "
+                "it in the `config.yml` file as a value for the `(manifest > data_type_set)` key."
             ),
             "jsonld": (
                 "Specify the path to the JSON-LD data model (schema) using this option. You can either explicitly pass the "

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import logging
 
@@ -13,8 +11,6 @@ from schematic.manifest.generator import ManifestGenerator
 from schematic.utils.cli_utils import fill_in_from_config, query_dict
 from schematic.help import manifest_commands
 from schematic import CONFIG
-
-from schematic.schemas.generator import SchemaGenerator
 
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
@@ -43,6 +39,7 @@ def manifest(ctx, config):  # use as `schematic manifest ...`
         logger.error("'--config' not provided or environment variable not set.")
         logger.exception(e)
         sys.exit(1)
+
 
 # prototype based on getModelManifest() and get_manifest()
 # use as `schematic config get positional_args --optional_args`
@@ -116,17 +113,14 @@ def get_manifest(
     data_type = fill_in_from_config("data_type", data_type, ("manifest", "data_type"))
     jsonld = fill_in_from_config("jsonld", jsonld, ("model", "input", "location"))
     title = fill_in_from_config("title", title, ("manifest", "title"), allow_none=True)
-
     json_schema = fill_in_from_config(
         "json_schema",
         json_schema,
         ("model", "input", "validation_schema"),
         allow_none=True,
     )
+
     def create_single_manifest(data_type):
-        '''
-        Nesting bc placing outside get_manifest causes it to be run independently.
-        '''
         # create object of type ManifestGenerator
         manifest_generator = ManifestGenerator(
             path_to_json_ld=jsonld,

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -11,6 +11,7 @@ from schematic.manifest.generator import ManifestGenerator
 from schematic.utils.cli_utils import fill_in_from_config, query_dict
 from schematic.help import manifest_commands
 from schematic import CONFIG
+from schematic.schemas.generator import SchemaGenerator
 
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -55,17 +55,9 @@ def manifest(ctx, config):  # use as `schematic manifest ...`
     "-t", "--title", help=query_dict(manifest_commands, ("manifest", "get", "title"))
 )
 @click.option(
-    "-tp", "--title_prefix",help=query_dict(manifest_commands, ("manifest", "get", "title_prefix"))
-    )
-@click.option(
     "-dt",
     "--data_type",
     help=query_dict(manifest_commands, ("manifest", "get", "data_type")),
-)
-@click.option(
-    "-dts",
-    "--data_type_set",
-    help=query_dict(manifest_commands, ("manifest", "get", "data_type_set")),
 )
 @click.option(
     "-p", "--jsonld", help=query_dict(manifest_commands, ("manifest", "get", "jsonld"))
@@ -107,9 +99,7 @@ def manifest(ctx, config):  # use as `schematic manifest ...`
 def get_manifest(
     ctx,
     title,
-    title_prefix,
     data_type,
-    data_type_set,
     jsonld,
     dataset_id,
     sheet_url,
@@ -126,8 +116,6 @@ def get_manifest(
     data_type = fill_in_from_config("data_type", data_type, ("manifest", "data_type"))
     jsonld = fill_in_from_config("jsonld", jsonld, ("model", "input", "location"))
     title = fill_in_from_config("title", title, ("manifest", "title"), allow_none=True)
-    title_prefix = fill_in_from_config("title_prefix", title_prefix, ("manifest", "title_prefix"), allow_none=True)
-    data_type_set = fill_in_from_config("data_type_set", data_type_set, ("manifest", "data_type_set"), allow_none=True)
 
     json_schema = fill_in_from_config(
         "json_schema",
@@ -142,7 +130,7 @@ def get_manifest(
         # create object of type ManifestGenerator
         manifest_generator = ManifestGenerator(
             path_to_json_ld=jsonld,
-            title=title,
+            title=t,
             root=data_type,
             oauth=oauth,
             use_annotations=use_annotations,
@@ -172,18 +160,19 @@ def get_manifest(
             result.to_csv(output_csv, index=False)
         return result
 
-    if data_type == 'all manifests':
+    if data_type[0] == 'all manifests':
         sg = SchemaGenerator(path_to_json_ld=jsonld)
         component_digraph = sg.se.get_digraph_by_edge_type('requiresComponent')
         components = component_digraph.nodes()
         for component in components:
-            title = f'{title_prefix}.{component}.manifest'
+            t = f'{title}.{component}.manifest'
             result = create_single_manifest(data_type = component)
-    elif data_type_set:
-        for dt in data_type_set:
-            title = f'{title_prefix}.{dt}.manifest'
-            result = create_single_manifest(data_type = dt)
     else:
-        result = create_single_manifest(data_type=data_type)
+        for dt in data_type:
+            if len(data_type) > 1:
+                t = f'{title}.{dt}.manifest'
+            else:
+                t = title
+            result = create_single_manifest(data_type = dt)
 
     return result


### PR DESCRIPTION
With a simple user input to the command line or config.py users can specify multiple manifests to make or to make 'all manifests'.

Config now takes the following format:
```
manifest:
  # if making many manifests, just include name prefix
  title: 'example'
  # to make all manifests enter only 'all manifests'
  data_type: 
    - 'Biospecimen'
    - 'Patient'
```

`help.py` also updated to include relevant help information for new format.

**Note:** schematic API not updated with this PR. Can either add to this PR or create another one.