### PR TITLE
Generate multiple manifests from API

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -32,11 +32,18 @@ paths:
           required: false
         - in: query
           name: data_type
+          style: form
           schema:
-            type: string
+            type: array
+            items: 
+              type: string
             nullable: true
-          description: Data Model Component
-          example: Patient
+          description: >
+            Data Model Component(s). 
+            To make all manifests, enter "all manifests".
+          example: 
+            - Patient
+            - Biospecimen
           required: true
         - in: query
           name: oauth
@@ -57,7 +64,8 @@ paths:
           schema:
             type: string
             nullable: true
-          description: Dataset SynID
+          description: >
+            Dataset SynID. Enter 'None' if there is none.
           required: true
       operationId: api.routes.get_manifest_route
       responses:

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -27,8 +27,10 @@ paths:
           name: title
           schema:
             type: string
-          description: Title of Manifest
-          example: Patient Metadata Manifest
+          description: >
+            Title of Manifest or Title Prefix, 
+            if making multiple manifests
+          example: Example
           required: false
         - in: query
           name: data_type


### PR DESCRIPTION
Similar to PR #584 which allows users to generate multiple manifests through the CLI, by adding multiple `data_type` entries or adding one entry of 'all manifests' in the config file, this PR allows users of the API to make multiple or all manifests in an analogous fashion. 

Within the Swagger UI, users now can see multiple entry fields for `data_type`. Can add or remove additional fields.
Further though `dataset_id` is required, users can now enter 'None' it they do not have a `dataset_id`.

For `title` enter a full title if only making a single manifest and a title prefix only if making multiple manifests.

**Important Note**: 
Output will now be a `list` of URL strings instead of a `str`

<img width="467" alt="Screen Shot 2022-02-25 at 10 01 44 AM" src="https://user-images.githubusercontent.com/85905780/155764784-d7a283c0-05df-478a-be36-83d9408f0136.png">

 