### PR TITLE
Change incoming data_type from CLI to list so it is parsed correctly

### DIFF
--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -155,6 +155,9 @@ def get_manifest(
             result.to_csv(output_csv, index=False)
         return result
 
+    if type(data_type) is str:
+        data_type = [data_type]
+
     if data_type[0] == 'all manifests':
         sg = SchemaGenerator(path_to_json_ld=jsonld)
         component_digraph = sg.se.get_digraph_by_edge_type('requiresComponent')


### PR DESCRIPTION
In response to bug report issued in #594. This fix will take data_type inputs from the command line and convert them to lists so they mimic the config file.

