### PR TITLE
Develop rdb jupyter notebook

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,46 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "appnope"
+version = "0.1.2"
+description = "Disable App Nap on macOS >= 10.9"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "argon2-cffi"
+version = "21.3.0"
+description = "The secure Argon2 password hashing algorithm."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+argon2-cffi-bindings = "*"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "cogapp", "tomli", "coverage[toml] (>=5.0.2)", "hypothesis", "pytest", "sphinx", "sphinx-notfound-page", "furo"]
+docs = ["sphinx", "sphinx-notfound-page", "furo"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest"]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "21.2.0"
+description = "Low-level CFFI bindings for Argon2"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = ">=1.0.1"
+
+[package.extras]
+dev = ["pytest", "cogapp", "pre-commit", "wheel"]
+tests = ["pytest"]
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -29,6 +69,14 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
+name = "backcall"
+version = "0.2.0"
+description = "Specifications for callback functions passed in to an API"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "black"
 version = "20.8b1"
 description = "The uncompromising code formatter."
@@ -49,6 +97,19 @@ typing-extensions = ">=3.7.4"
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+
+[[package]]
+name = "bleach"
+version = "4.1.0"
+description = "An easy safelist-based HTML-sanitizing tool."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+packaging = "*"
+six = ">=1.9.0"
+webencodings = "*"
 
 [[package]]
 name = "cachetools"
@@ -123,7 +184,7 @@ PyYAML = ">=3.11"
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -141,7 +202,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [[package]]
 name = "connexion"
-version = "2.9.0"
+version = "2.10.0"
 description = "Connexion - API first applications with OpenAPI/Swagger and Flask"
 category = "main"
 optional = false
@@ -149,21 +210,21 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 clickclick = ">=1.2,<21"
-flask = ">=1.0.4,<2"
+flask = ">=1.0.4,<3"
 inflection = ">=0.3.1,<0.6"
 jsonschema = ">=2.5.1,<4"
 openapi-spec-validator = ">=0.2.4,<0.4"
 PyYAML = ">=5.1,<6"
 requests = ">=2.9.1,<3"
 swagger-ui-bundle = {version = ">=0.0.2,<0.1", optional = true, markers = "extra == \"swagger-ui\""}
-werkzeug = ">=1.0,<2.0"
+werkzeug = ">=1.0,<3"
 
 [package.extras]
 aiohttp = ["aiohttp (>=2.3.10,<4)", "aiohttp-jinja2 (>=0.14.0,<2)"]
 docs = ["sphinx-autoapi (==1.8.1)"]
-flask = ["flask (>=1.0.4,<2)"]
+flask = ["flask (>=1.0.4,<3)"]
 swagger-ui = ["swagger-ui-bundle (>=0.0.2,<0.1)"]
-tests = ["decorator (>=5,<6)", "pytest (>=6,<7)", "pytest-cov (>=2,<3)", "testfixtures (>=6,<7)", "flask (>=1.0.4,<2)", "swagger-ui-bundle (>=0.0.2,<0.1)", "aiohttp (>=2.3.10,<4)", "aiohttp-jinja2 (>=0.14.0,<2)", "pytest-aiohttp", "aiohttp-remotes"]
+tests = ["decorator (>=5,<6)", "pytest (>=6,<7)", "pytest-cov (>=2,<3)", "testfixtures (>=6,<7)", "flask (>=1.0.4,<3)", "swagger-ui-bundle (>=0.0.2,<0.1)", "aiohttp (>=2.3.10,<4)", "aiohttp-jinja2 (>=0.14.0,<2)", "pytest-aiohttp", "aiohttp-remotes"]
 
 [[package]]
 name = "coverage"
@@ -194,6 +255,30 @@ pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+
+[[package]]
+name = "debugpy"
+version = "1.5.1"
+description = "An implementation of the Debug Adapter Protocol for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+
+[[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+description = "XML bomb protection for Python stdlib modules"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "deprecated"
@@ -424,6 +509,67 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "ipykernel"
+version = "6.7.0"
+description = "IPython Kernel for Jupyter"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+appnope = {version = "*", markers = "platform_system == \"Darwin\""}
+debugpy = ">=1.0.0,<2.0"
+ipython = ">=7.23.1"
+jupyter-client = "<8.0"
+matplotlib-inline = ">=0.1.0,<0.2.0"
+nest-asyncio = "*"
+tornado = ">=4.2,<7.0"
+traitlets = ">=5.1.0,<6.0"
+
+[package.extras]
+test = ["pytest (!=5.3.4)", "pytest-cov", "flaky", "ipyparallel"]
+
+[[package]]
+name = "ipython"
+version = "7.31.1"
+description = "IPython: Productive Interactive Computing"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+appnope = {version = "*", markers = "sys_platform == \"darwin\""}
+backcall = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+decorator = "*"
+jedi = ">=0.16"
+matplotlib-inline = "*"
+pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
+pickleshare = "*"
+prompt-toolkit = ">=2.0.0,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.1.0"
+pygments = "*"
+traitlets = ">=4.2"
+
+[package.extras]
+all = ["Sphinx (>=1.3)", "ipykernel", "ipyparallel", "ipywidgets", "nbconvert", "nbformat", "nose (>=0.10.1)", "notebook", "numpy (>=1.17)", "pygments", "qtconsole", "requests", "testpath"]
+doc = ["Sphinx (>=1.3)"]
+kernel = ["ipykernel"]
+nbconvert = ["nbconvert"]
+nbformat = ["nbformat"]
+notebook = ["notebook", "ipywidgets"]
+parallel = ["ipyparallel"]
+qtconsole = ["qtconsole"]
+test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.17)"]
+
+[[package]]
+name = "ipython-genutils"
+version = "0.2.0"
+description = "Vestigial utilities from IPython"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "isodate"
 version = "0.6.0"
 description = "An ISO 8601 date/time/duration parser and formatter"
@@ -441,6 +587,21 @@ description = "Various helpers to pass data to untrusted environments and back."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "jedi"
+version = "0.18.1"
+description = "An autocompletion tool for Python that can be used for text editors."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+parso = ">=0.8.0,<0.9.0"
+
+[package.extras]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jinja2"
@@ -473,6 +634,50 @@ six = ">=1.11.0"
 [package.extras]
 format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
 format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
+
+[[package]]
+name = "jupyter-client"
+version = "7.1.1"
+description = "Jupyter protocol implementation and client libraries"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+entrypoints = "*"
+jupyter-core = ">=4.6.0"
+nest-asyncio = ">=1.5"
+python-dateutil = ">=2.1"
+pyzmq = ">=13"
+tornado = ">=4.1"
+traitlets = "*"
+
+[package.extras]
+doc = ["myst-parser", "sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
+test = ["codecov", "coverage", "ipykernel", "ipython", "mock", "mypy", "pre-commit", "pytest", "pytest-asyncio", "pytest-cov", "pytest-timeout", "jedi (<0.18)"]
+
+[[package]]
+name = "jupyter-core"
+version = "4.9.1"
+description = "Jupyter core package. A base package on which Jupyter projects rely."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pywin32 = {version = ">=1.0", markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""}
+traitlets = "*"
+
+[[package]]
+name = "jupyterlab-pygments"
+version = "0.1.2"
+description = "Pygments theme using JupyterLab CSS variables"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pygments = ">=2.4.1,<3"
 
 [[package]]
 name = "keyring"
@@ -515,10 +720,29 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "matplotlib-inline"
+version = "0.1.3"
+description = "Inline Matplotlib backend for Jupyter"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+traitlets = "*"
+
+[[package]]
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
 category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "mistune"
+version = "0.8.4"
+description = "The fastest markdown parser in pure Python"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -539,6 +763,80 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "nbclient"
+version = "0.5.10"
+description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+
+[package.dependencies]
+jupyter-client = ">=6.1.5"
+nbformat = ">=5.0"
+nest-asyncio = "*"
+traitlets = ">=4.2"
+
+[package.extras]
+sphinx = ["Sphinx (>=1.7)", "sphinx-book-theme", "mock", "moto", "myst-parser"]
+test = ["ipython", "ipykernel", "ipywidgets (<8.0.0)", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "check-manifest", "flake8", "mypy", "xmltodict", "black", "pip (>=18.1)", "wheel (>=0.31.0)", "setuptools (>=38.6.0)", "twine (>=1.11.0)"]
+
+[[package]]
+name = "nbconvert"
+version = "6.4.0"
+description = "Converting Jupyter Notebooks"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+bleach = "*"
+defusedxml = "*"
+entrypoints = ">=0.2.2"
+jinja2 = ">=2.4"
+jupyter-core = "*"
+jupyterlab-pygments = "*"
+mistune = ">=0.8.1,<2"
+nbclient = ">=0.5.0,<0.6.0"
+nbformat = ">=4.4"
+pandocfilters = ">=1.4.1"
+pygments = ">=2.4.1"
+testpath = "*"
+traitlets = ">=5.0"
+
+[package.extras]
+all = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pyppeteer (==0.2.6)", "tornado (>=4.0)", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
+docs = ["sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
+serve = ["tornado (>=4.0)"]
+test = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pyppeteer (==0.2.6)"]
+webpdf = ["pyppeteer (==0.2.6)"]
+
+[[package]]
+name = "nbformat"
+version = "5.1.3"
+description = "The Jupyter Notebook format"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+ipython-genutils = "*"
+jsonschema = ">=2.4,<2.5.0 || >2.5.0"
+jupyter-core = "*"
+traitlets = ">=4.1"
+
+[package.extras]
+fast = ["fastjsonschema"]
+test = ["check-manifest", "fastjsonschema", "testpath", "pytest", "pytest-cov"]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.5.4"
+description = "Patch asyncio to allow nested event loops"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "networkx"
 version = "2.6.2"
 description = "Python package for creating and manipulating graphs and networks"
@@ -552,6 +850,36 @@ developer = ["black (==21.5b1)", "pre-commit (>=2.12)"]
 doc = ["sphinx (>=4.0,<5.0)", "pydata-sphinx-theme (>=0.6,<1.0)", "sphinx-gallery (>=0.9,<1.0)", "numpydoc (>=1.1)", "pillow (>=8.2)", "nb2plots (>=0.6)", "texext (>=0.6.6)"]
 extra = ["lxml (>=4.5)", "pygraphviz (>=1.7)", "pydot (>=1.4.1)"]
 test = ["pytest (>=6.2)", "pytest-cov (>=2.12)", "codecov (>=2.1)"]
+
+[[package]]
+name = "notebook"
+version = "6.4.7"
+description = "A web-based notebook environment for interactive computing"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+argon2-cffi = "*"
+ipykernel = "*"
+ipython-genutils = "*"
+jinja2 = "*"
+jupyter-client = ">=5.3.4"
+jupyter-core = ">=4.6.1"
+nbconvert = "*"
+nbformat = "*"
+nest-asyncio = ">=1.5"
+prometheus-client = "*"
+pyzmq = ">=17"
+Send2Trash = ">=1.8.0"
+terminado = ">=0.8.3"
+tornado = ">=6.1"
+traitlets = ">=4.2.1"
+
+[package.extras]
+docs = ["sphinx", "nbsphinx", "sphinxcontrib-github-alt", "sphinx-rtd-theme", "myst-parser"]
+json-logging = ["json-logging"]
+test = ["pytest", "coverage", "requests", "nbval", "selenium", "pytest-cov", "requests-unixsocket"]
 
 [[package]]
 name = "numpy"
@@ -653,12 +981,51 @@ pytz = ">=2017.3"
 test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
 
 [[package]]
+name = "pandocfilters"
+version = "1.5.0"
+description = "Utilities for writing pandoc filters in python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "parso"
+version = "0.8.3"
+description = "A Python Parser"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+testing = ["docopt", "pytest (<6.0.0)"]
+
+[[package]]
 name = "pathspec"
 version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "pexpect"
+version = "4.8.0"
+description = "Pexpect allows easy control of interactive console applications."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+ptyprocess = ">=0.5"
+
+[[package]]
+name = "pickleshare"
+version = "0.7.5"
+description = "Tiny 'shelve'-like database with concurrency support"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "pluggy"
@@ -675,6 +1042,28 @@ importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 dev = ["pre-commit", "tox"]
 
 [[package]]
+name = "prometheus-client"
+version = "0.12.0"
+description = "Python client for the Prometheus monitoring system."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.24"
+description = "Library for building powerful interactive command lines in Python"
+category = "main"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+wcwidth = "*"
+
+[[package]]
 name = "protobuf"
 version = "3.17.3"
 description = "Protocol Buffers"
@@ -686,10 +1075,18 @@ python-versions = "*"
 six = ">=1.9"
 
 [[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -746,6 +1143,14 @@ description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pygments"
+version = "2.11.2"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "pygsheets"
@@ -861,6 +1266,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pywin32"
+version = "303"
+description = "Python for Window Extensions"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.0"
 description = ""
@@ -869,12 +1282,32 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pywinpty"
+version = "1.1.6"
+description = "Pseudo terminal support for Windows from Python."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[[package]]
+name = "pyzmq"
+version = "22.3.0"
+description = "Python bindings for 0MQ"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = {version = "*", markers = "implementation_name == \"pypy\""}
+py = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "rdflib"
@@ -960,6 +1393,19 @@ cryptography = "*"
 
 [package.extras]
 dbus-python = ["dbus-python"]
+
+[[package]]
+name = "send2trash"
+version = "1.8.0"
+description = "Send file to trash natively under Mac OS X, Windows and Linux."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+nativelib = ["pyobjc-framework-cocoa", "pywin32"]
+objc = ["pyobjc-framework-cocoa"]
+win32 = ["pywin32"]
 
 [[package]]
 name = "six"
@@ -1072,12 +1518,58 @@ pysftp = ["pysftp (>=0.2.8,<0.3)"]
 tests = ["pytest (>=5.0.0,<7.0)", "pytest-mock (>=3.0,<4.0)", "flake8 (>=3.7.0,<4.0)", "pytest-xdist[psutil] (>=2.2,<3.0.0)"]
 
 [[package]]
+name = "terminado"
+version = "0.12.1"
+description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+ptyprocess = {version = "*", markers = "os_name != \"nt\""}
+pywinpty = {version = ">=1.1.0", markers = "os_name == \"nt\""}
+tornado = ">=4"
+
+[package.extras]
+test = ["pytest"]
+
+[[package]]
+name = "testpath"
+version = "0.5.0"
+description = "Test utilities for code working with files and commands"
+category = "main"
+optional = false
+python-versions = ">= 3.5"
+
+[package.extras]
+test = ["pytest", "pathlib2"]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
 category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tornado"
+version = "6.1"
+description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
+category = "main"
+optional = false
+python-versions = ">= 3.5"
+
+[[package]]
+name = "traitlets"
+version = "5.1.1"
+description = "Traitlets Python configuration system"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest"]
 
 [[package]]
 name = "typed-ast"
@@ -1091,7 +1583,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1115,6 +1607,22 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+description = "Character encoding aliases for legacy web content"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "werkzeug"
@@ -1151,12 +1659,43 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "692e6efad488b2a7edbda8cb96851f1465e3a2b11b3d2a91e52bee39bf0580fe"
+content-hash = "7cbfed554ce6d4117db650666dd71e5a256d5b10dd2e950bdd9e6fad15403c3b"
 
 [metadata.files]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+appnope = [
+    {file = "appnope-0.1.2-py2.py3-none-any.whl", hash = "sha256:93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442"},
+    {file = "appnope-0.1.2.tar.gz", hash = "sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a"},
+]
+argon2-cffi = [
+    {file = "argon2-cffi-21.3.0.tar.gz", hash = "sha256:d384164d944190a7dd7ef22c6aa3ff197da12962bd04b17f64d4e93d934dba5b"},
+    {file = "argon2_cffi-21.3.0-py3-none-any.whl", hash = "sha256:8c976986f2c5c0e5000919e6de187906cfd81fb1c72bf9d88c01177e77da7f80"},
+]
+argon2-cffi-bindings = [
+    {file = "argon2-cffi-bindings-21.2.0.tar.gz", hash = "sha256:bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ccb949252cb2ab3a08c02024acb77cfb179492d5701c7cbdbfd776124d4d2367"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9524464572e12979364b7d600abf96181d3541da11e23ddf565a32e70bd4dc0d"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b746dba803a79238e925d9046a63aa26bf86ab2a2fe74ce6b009a1c3f5c8f2ae"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58ed19212051f49a523abb1dbe954337dc82d947fb6e5a0da60f7c8471a8476c"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:bd46088725ef7f58b5a1ef7ca06647ebaf0eb4baff7d1d0d177c6cc8744abd86"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_i686.whl", hash = "sha256:8cd69c07dd875537a824deec19f978e0f2078fdda07fd5c42ac29668dda5f40f"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f1152ac548bd5b8bcecfb0b0371f082037e47128653df2e8ba6e914d384f3c3e"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-win32.whl", hash = "sha256:603ca0aba86b1349b147cab91ae970c63118a0f30444d4bc80355937c950c082"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-win_amd64.whl", hash = "sha256:b2ef1c30440dbbcba7a5dc3e319408b59676e2e039e2ae11a8775ecf482b192f"},
+    {file = "argon2_cffi_bindings-21.2.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e415e3f62c8d124ee16018e491a009937f8cf7ebf5eb430ffc5de21b900dad93"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3e385d1c39c520c08b53d63300c3ecc28622f076f4c2b0e6d7e796e9f6502194"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c3e3cc67fdb7d82c4718f19b4e7a87123caf8a93fde7e23cf66ac0337d3cb3f"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a22ad9800121b71099d0fb0a65323810a15f2e292f2ba450810a7316e128ee5"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f9f8b450ed0547e3d473fdc8612083fd08dd2120d6ac8f73828df9b7d45bb351"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:93f9bf70084f97245ba10ee36575f0c3f1e7d7724d67d8e5b08e61787c320ed7"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3b9ef65804859d335dc6b31582cad2c5166f0c3e7975f324d9ffaa34ee7e6583"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4966ef5848d820776f5f562a7d45fdd70c2f330c961d0d745b784034bd9f48d"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20ef543a89dee4db46a1a6e206cd015360e5a75822f76df533845c3cbaf72670"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2937d286e2ad0cc79a7087d3c272832865f779430e0cc2b4f3718d3159b0cb"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:5e00316dabdaea0b2dd82d141cc66889ced0cdcbfa599e8b471cf22c620c329a"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1166,8 +1705,16 @@ attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
+backcall = [
+    {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
+    {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
+]
+bleach = [
+    {file = "bleach-4.1.0-py2.py3-none-any.whl", hash = "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"},
+    {file = "bleach-4.1.0.tar.gz", hash = "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da"},
 ]
 cachetools = [
     {file = "cachetools-4.2.2-py3-none-any.whl", hash = "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001"},
@@ -1249,8 +1796,8 @@ configparser = [
     {file = "configparser-5.2.0.tar.gz", hash = "sha256:1b35798fdf1713f1c3139016cfcbc461f09edbf099d1fb658d4b7479fcaa3daa"},
 ]
 connexion = [
-    {file = "connexion-2.9.0-py2.py3-none-any.whl", hash = "sha256:656d451e21df5f38c4ddb826b805ebe5a641423253f7f33c798ca3ec1cb94cda"},
-    {file = "connexion-2.9.0.tar.gz", hash = "sha256:0105b03ea1c54fa0e8160825c729e416b8bd6bf3f007981b04c92ce6d5ae990b"},
+    {file = "connexion-2.10.0-py2.py3-none-any.whl", hash = "sha256:b10df8b67dde1b9d61ff0676f354d02ab838bed9818eb89d582504b3a3acbd71"},
+    {file = "connexion-2.10.0.tar.gz", hash = "sha256:de0cab04ff548e392ba206228ded9d46620765a4b27f0d0c8ab3999ad20b53dc"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
@@ -1321,6 +1868,37 @@ cryptography = [
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3"},
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
+]
+debugpy = [
+    {file = "debugpy-1.5.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:70b422c63a833630c33e3f9cdbd9b6971f8c5afd452697e464339a21bbe862ba"},
+    {file = "debugpy-1.5.1-cp310-cp310-win32.whl", hash = "sha256:3a457ad9c0059a21a6c7d563c1f18e924f5cf90278c722bd50ede6f56b77c7fe"},
+    {file = "debugpy-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:5d76a4fd028d8009c3faf1185b4b78ceb2273dd2499447664b03939e0368bb90"},
+    {file = "debugpy-1.5.1-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:16db27b4b91991442f91d73604d32080b30de655aca9ba821b1972ea8171021b"},
+    {file = "debugpy-1.5.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2b073ad5e8d8c488fbb6a116986858bab0c9c4558f28deb8832c7a5a27405bd6"},
+    {file = "debugpy-1.5.1-cp36-cp36m-win32.whl", hash = "sha256:318f81f37341e4e054b4267d39896b73cddb3612ca13b39d7eea45af65165e1d"},
+    {file = "debugpy-1.5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b5b3157372e0e0a1297a8b6b5280bcf1d35a40f436c7973771c972726d1e32d5"},
+    {file = "debugpy-1.5.1-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:1ec3a086e14bba6c472632025b8fe5bdfbaef2afa1ebd5c6615ce6ed8d89bc67"},
+    {file = "debugpy-1.5.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:26fbe53cca45a608679094791ce587b6e2798acd1d4777a8b303b07622e85182"},
+    {file = "debugpy-1.5.1-cp37-cp37m-win32.whl", hash = "sha256:d876db8c312eeb02d85611e0f696abe66a2c1515e6405943609e725d5ff36f2a"},
+    {file = "debugpy-1.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4404a62fb5332ea5c8c9132290eef50b3a0ba38cecacad5529e969a783bcbdd7"},
+    {file = "debugpy-1.5.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:f3a3dca9104aa14fd4210edcce6d9ce2b65bd9618c0b222135a40b9d6e2a9eeb"},
+    {file = "debugpy-1.5.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b2df2c373e85871086bd55271c929670cd4e1dba63e94a08d442db830646203b"},
+    {file = "debugpy-1.5.1-cp38-cp38-win32.whl", hash = "sha256:82f5f9ce93af6861a0713f804e62ab390bb12a17f113153e47fea8bbb1dfbe36"},
+    {file = "debugpy-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:17a25ce9d7714f92fc97ef00cc06269d7c2b163094990ada30156ed31d9a5030"},
+    {file = "debugpy-1.5.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:01e98c594b3e66d529e40edf314f849cd1a21f7a013298df58cd8e263bf8e184"},
+    {file = "debugpy-1.5.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f73988422b17f071ad3c4383551ace1ba5ed810cbab5f9c362783d22d40a08dc"},
+    {file = "debugpy-1.5.1-cp39-cp39-win32.whl", hash = "sha256:23df67fc56d59e386c342428a7953c2c06cc226d8525b11319153e96afb65b0c"},
+    {file = "debugpy-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:a2aa64f6d2ca7ded8a7e8a4e7cae3bc71866b09876b7b05cecad231779cb9156"},
+    {file = "debugpy-1.5.1-py2.py3-none-any.whl", hash = "sha256:194f95dd3e84568b5489aab5689a3a2c044e8fdc06f1890b8b4f70b6b89f2778"},
+    {file = "debugpy-1.5.1.zip", hash = "sha256:d2b09e91fbd1efa4f4fda121d49af89501beda50c18ed7499712c71a4bf3452e"},
+]
+decorator = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+defusedxml = [
+    {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
+    {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
 deprecated = [
     {file = "Deprecated-1.2.12-py2.py3-none-any.whl", hash = "sha256:08452d69b6b5bc66e8330adde0a4f8642e969b9e1702904d137eeb29c8ffc771"},
@@ -1438,6 +2016,18 @@ iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
+ipykernel = [
+    {file = "ipykernel-6.7.0-py3-none-any.whl", hash = "sha256:6203ccd5510ff148e9433fd4a2707c5ce8d688f026427f46e13d7ebf9b3e9787"},
+    {file = "ipykernel-6.7.0.tar.gz", hash = "sha256:d82b904fdc2fd8c7b1fbe0fa481c68a11b4cd4c8ef07e6517da1f10cc3114d24"},
+]
+ipython = [
+    {file = "ipython-7.31.1-py3-none-any.whl", hash = "sha256:55df3e0bd0f94e715abd968bedd89d4e8a7bce4bf498fb123fed4f5398fea874"},
+    {file = "ipython-7.31.1.tar.gz", hash = "sha256:b5548ec5329a4bcf054a5deed5099b0f9622eb9ea51aaa7104d215fece201d8c"},
+]
+ipython-genutils = [
+    {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
+    {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
+]
 isodate = [
     {file = "isodate-0.6.0-py2.py3-none-any.whl", hash = "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"},
     {file = "isodate-0.6.0.tar.gz", hash = "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8"},
@@ -1446,6 +2036,10 @@ itsdangerous = [
     {file = "itsdangerous-1.1.0-py2.py3-none-any.whl", hash = "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"},
     {file = "itsdangerous-1.1.0.tar.gz", hash = "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19"},
 ]
+jedi = [
+    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
+    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
+]
 jinja2 = [
     {file = "Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"},
     {file = "Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"},
@@ -1453,6 +2047,18 @@ jinja2 = [
 jsonschema = [
     {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
     {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
+]
+jupyter-client = [
+    {file = "jupyter_client-7.1.1-py3-none-any.whl", hash = "sha256:f0c576cce235c727e30b0a0da88c2755d0947d0070fa1bc45f195079ffd64e66"},
+    {file = "jupyter_client-7.1.1.tar.gz", hash = "sha256:540ca35e57e83c5ece81abd9b781a57cba39a37c60a2a30c8c1b2f6663544343"},
+]
+jupyter-core = [
+    {file = "jupyter_core-4.9.1-py3-none-any.whl", hash = "sha256:1c091f3bbefd6f2a8782f2c1db662ca8478ac240e962ae2c66f0b87c818154ea"},
+    {file = "jupyter_core-4.9.1.tar.gz", hash = "sha256:dce8a7499da5a53ae3afd5a9f4b02e5df1d57250cf48f3ad79da23b4778cd6fa"},
+]
+jupyterlab-pygments = [
+    {file = "jupyterlab_pygments-0.1.2-py2.py3-none-any.whl", hash = "sha256:abfb880fd1561987efaefcb2d2ac75145d2a5d0139b1876d5be806e32f630008"},
+    {file = "jupyterlab_pygments-0.1.2.tar.gz", hash = "sha256:cfcda0873626150932f438eccf0f8bf22bfa92345b814890ab360d666b254146"},
 ]
 keyring = [
     {file = "keyring-12.0.2-py2.py3-none-any.whl", hash = "sha256:26edbe23dd0d79682b9c2cf825e58376fa87412ba4c94018edbbcabb7dcedfcf"},
@@ -1518,9 +2124,17 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
 ]
+matplotlib-inline = [
+    {file = "matplotlib-inline-0.1.3.tar.gz", hash = "sha256:a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee"},
+    {file = "matplotlib_inline-0.1.3-py3-none-any.whl", hash = "sha256:aed605ba3b72462d64d475a21a9296f400a19c4f74a31b59103d2a99ffd5aa5c"},
+]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mistune = [
+    {file = "mistune-0.8.4-py2.py3-none-any.whl", hash = "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"},
+    {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -1533,9 +2147,29 @@ mysqlclient = [
     {file = "mysqlclient-2.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:fc575093cf81b6605bed84653e48b277318b880dc9becf42dd47fa11ffd3e2b6"},
     {file = "mysqlclient-2.0.3.tar.gz", hash = "sha256:f6ebea7c008f155baeefe16c56cd3ee6239f7a5a9ae42396c2f1860f08a7c432"},
 ]
+nbclient = [
+    {file = "nbclient-0.5.10-py3-none-any.whl", hash = "sha256:5b582e21c8b464e6676a9d60acc6871d7fbc3b080f74bef265a9f90411b31f6f"},
+    {file = "nbclient-0.5.10.tar.gz", hash = "sha256:b5fdea88d6fa52ca38de6c2361401cfe7aaa7cd24c74effc5e489cec04d79088"},
+]
+nbconvert = [
+    {file = "nbconvert-6.4.0-py3-none-any.whl", hash = "sha256:f5ec6a1fad9e3aa2bee7c6a1c4ad3e0fafaa7ff64f29ba56d9da7e1669f8521c"},
+    {file = "nbconvert-6.4.0.tar.gz", hash = "sha256:5412ec774c6db4fccecb8c4ba07ec5d37d6dcf5762593cb3d6ecbbeb562ebbe5"},
+]
+nbformat = [
+    {file = "nbformat-5.1.3-py3-none-any.whl", hash = "sha256:eb8447edd7127d043361bc17f2f5a807626bc8e878c7709a1c647abda28a9171"},
+    {file = "nbformat-5.1.3.tar.gz", hash = "sha256:b516788ad70771c6250977c1374fcca6edebe6126fd2adb5a69aa5c2356fd1c8"},
+]
+nest-asyncio = [
+    {file = "nest_asyncio-1.5.4-py3-none-any.whl", hash = "sha256:3fdd0d6061a2bb16f21fe8a9c6a7945be83521d81a0d15cff52e9edee50101d6"},
+    {file = "nest_asyncio-1.5.4.tar.gz", hash = "sha256:f969f6013a16fadb4adcf09d11a68a4f617c6049d7af7ac2c676110169a63abd"},
+]
 networkx = [
     {file = "networkx-2.6.2-py3-none-any.whl", hash = "sha256:5fcb7004be69e8fbdf07dcb502efa5c77cadcaad6982164134eeb9721f826c2e"},
     {file = "networkx-2.6.2.tar.gz", hash = "sha256:2306f1950ce772c5a59a57f5486d59bb9cab98497c45fc49cbc45ac0dec119bb"},
+]
+notebook = [
+    {file = "notebook-6.4.7-py3-none-any.whl", hash = "sha256:968e9c09639fe4b9dbf4b9f028daf861b563c124d735a99d6d48c09317553f31"},
+    {file = "notebook-6.4.7.tar.gz", hash = "sha256:b01da66f11a203b3839d6afa4013674bcfff41c36552f9ad0fbcb2d93c92764a"},
 ]
 numpy = [
     {file = "numpy-1.21.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50"},
@@ -1609,13 +2243,37 @@ pandas = [
     {file = "pandas-1.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:9e1fe6722cbe27eb5891c1977bca62d456c19935352eea64d33956db46139364"},
     {file = "pandas-1.3.1.tar.gz", hash = "sha256:341935a594db24f3ff07d1b34d1d231786aa9adfa84b76eab10bf42907c8aed3"},
 ]
+pandocfilters = [
+    {file = "pandocfilters-1.5.0-py2.py3-none-any.whl", hash = "sha256:33aae3f25fd1a026079f5d27bdd52496f0e0803b3469282162bafdcbdf6ef14f"},
+    {file = "pandocfilters-1.5.0.tar.gz", hash = "sha256:0b679503337d233b4339a817bfc8c50064e2eff681314376a47cb582305a7a38"},
+]
+parso = [
+    {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
+    {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
+]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
+pexpect = [
+    {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
+    {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
+]
+pickleshare = [
+    {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},
+    {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
+]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+prometheus-client = [
+    {file = "prometheus_client-0.12.0-py2.py3-none-any.whl", hash = "sha256:317453ebabff0a1b02df7f708efbab21e3489e7072b61cb6957230dd004a0af0"},
+    {file = "prometheus_client-0.12.0.tar.gz", hash = "sha256:1b12ba48cee33b9b0b9de64a1047cbd3c5f2d0ab6ebcead7ddda613a750ec3c5"},
+]
+prompt-toolkit = [
+    {file = "prompt_toolkit-3.0.24-py3-none-any.whl", hash = "sha256:e56f2ff799bacecd3e88165b1e2f5ebf9bcd59e80e06d395fa0cc4b8bd7bb506"},
+    {file = "prompt_toolkit-3.0.24.tar.gz", hash = "sha256:1bb05628c7d87b645974a1bad3f17612be0c29fa39af9f7688030163f680bad6"},
 ]
 protobuf = [
     {file = "protobuf-3.17.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ab6bb0e270c6c58e7ff4345b3a803cc59dbee19ddf77a4719c5b635f1d547aa8"},
@@ -1645,6 +2303,10 @@ protobuf = [
     {file = "protobuf-3.17.3-cp39-cp39-win_amd64.whl", hash = "sha256:85d6303e4adade2827e43c2b54114d9a6ea547b671cb63fafd5011dc47d0e13d"},
     {file = "protobuf-3.17.3-py2.py3-none-any.whl", hash = "sha256:2bfb815216a9cd9faec52b16fd2bfa68437a44b67c56bee59bc3926522ecb04e"},
     {file = "protobuf-3.17.3.tar.gz", hash = "sha256:72804ea5eaa9c22a090d2803813e280fb273b62d5ae497aaf3553d141c4fdd7b"},
+]
+ptyprocess = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
@@ -1695,6 +2357,10 @@ pydot = [
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+]
+pygments = [
+    {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
+    {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
 pygsheets = [
     {file = "pygsheets-2.0.5-py2.py3-none-any.whl", hash = "sha256:85a4c871ac1d53013e042c13552b07f908b991c3d8c8770b3a68eb3452c8c218"},
@@ -1751,9 +2417,31 @@ pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
     {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
+pywin32 = [
+    {file = "pywin32-303-cp310-cp310-win32.whl", hash = "sha256:6fed4af057039f309263fd3285d7b8042d41507343cd5fa781d98fcc5b90e8bb"},
+    {file = "pywin32-303-cp310-cp310-win_amd64.whl", hash = "sha256:51cb52c5ec6709f96c3f26e7795b0bf169ee0d8395b2c1d7eb2c029a5008ed51"},
+    {file = "pywin32-303-cp311-cp311-win32.whl", hash = "sha256:d9b5d87ca944eb3aa4cd45516203ead4b37ab06b8b777c54aedc35975dec0dee"},
+    {file = "pywin32-303-cp311-cp311-win_amd64.whl", hash = "sha256:fcf44032f5b14fcda86028cdf49b6ebdaea091230eb0a757282aa656e4732439"},
+    {file = "pywin32-303-cp36-cp36m-win32.whl", hash = "sha256:aad484d52ec58008ca36bd4ad14a71d7dd0a99db1a4ca71072213f63bf49c7d9"},
+    {file = "pywin32-303-cp36-cp36m-win_amd64.whl", hash = "sha256:2a09632916b6bb231ba49983fe989f2f625cea237219530e81a69239cd0c4559"},
+    {file = "pywin32-303-cp37-cp37m-win32.whl", hash = "sha256:b1675d82bcf6dbc96363fca747bac8bff6f6e4a447a4287ac652aa4b9adc796e"},
+    {file = "pywin32-303-cp37-cp37m-win_amd64.whl", hash = "sha256:c268040769b48a13367221fced6d4232ed52f044ffafeda247bd9d2c6bdc29ca"},
+    {file = "pywin32-303-cp38-cp38-win32.whl", hash = "sha256:5f9ec054f5a46a0f4dfd72af2ce1372f3d5a6e4052af20b858aa7df2df7d355b"},
+    {file = "pywin32-303-cp38-cp38-win_amd64.whl", hash = "sha256:793bf74fce164bcffd9d57bb13c2c15d56e43c9542a7b9687b4fccf8f8a41aba"},
+    {file = "pywin32-303-cp39-cp39-win32.whl", hash = "sha256:7d3271c98434617a11921c5ccf74615794d97b079e22ed7773790822735cc352"},
+    {file = "pywin32-303-cp39-cp39-win_amd64.whl", hash = "sha256:79cbb862c11b9af19bcb682891c1b91942ec2ff7de8151e2aea2e175899cda34"},
+]
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
     {file = "pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
+]
+pywinpty = [
+    {file = "pywinpty-1.1.6-cp310-none-win_amd64.whl", hash = "sha256:5f526f21b569b5610a61e3b6126259c76da979399598e5154498582df3736ade"},
+    {file = "pywinpty-1.1.6-cp36-none-win_amd64.whl", hash = "sha256:7576e14f42b31fa98b62d24ded79754d2ea4625570c016b38eb347ce158a30f2"},
+    {file = "pywinpty-1.1.6-cp37-none-win_amd64.whl", hash = "sha256:979ffdb9bdbe23db3f46fc7285fd6dbb86b80c12325a50582b211b3894072354"},
+    {file = "pywinpty-1.1.6-cp38-none-win_amd64.whl", hash = "sha256:2308b1fc77545427610a705799d4ead5e7f00874af3fb148a03e202437456a7e"},
+    {file = "pywinpty-1.1.6-cp39-none-win_amd64.whl", hash = "sha256:c703bf569a98ab7844b9daf37e88ab86f31862754ef6910a8b3824993a525c72"},
+    {file = "pywinpty-1.1.6.tar.gz", hash = "sha256:8808f07350c709119cc4464144d6e749637f98e15acc1e5d3c37db1953d2eebc"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
@@ -1785,6 +2473,55 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+]
+pyzmq = [
+    {file = "pyzmq-22.3.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:6b217b8f9dfb6628f74b94bdaf9f7408708cb02167d644edca33f38746ca12dd"},
+    {file = "pyzmq-22.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2841997a0d85b998cbafecb4183caf51fd19c4357075dfd33eb7efea57e4c149"},
+    {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f89468059ebc519a7acde1ee50b779019535db8dcf9b8c162ef669257fef7a93"},
+    {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea12133df25e3a6918718fbb9a510c6ee5d3fdd5a346320421aac3882f4feeea"},
+    {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76c532fd68b93998aab92356be280deec5de8f8fe59cd28763d2cc8a58747b7f"},
+    {file = "pyzmq-22.3.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f907c7359ce8bf7f7e63c82f75ad0223384105f5126f313400b7e8004d9b33c3"},
+    {file = "pyzmq-22.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:902319cfe23366595d3fa769b5b751e6ee6750a0a64c5d9f757d624b2ac3519e"},
+    {file = "pyzmq-22.3.0-cp310-cp310-win32.whl", hash = "sha256:67db33bea0a29d03e6eeec55a8190e033318cee3cbc732ba8fd939617cbf762d"},
+    {file = "pyzmq-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:7661fc1d5cb73481cf710a1418a4e1e301ed7d5d924f91c67ba84b2a1b89defd"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79244b9e97948eaf38695f4b8e6fc63b14b78cc37f403c6642ba555517ac1268"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab888624ed68930442a3f3b0b921ad7439c51ba122dbc8c386e6487a658e4a4e"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:18cd854b423fce44951c3a4d3e686bac8f1243d954f579e120a1714096637cc0"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:de8df0684398bd74ad160afdc2a118ca28384ac6f5e234eb0508858d8d2d9364"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:62bcade20813796c426409a3e7423862d50ff0639f5a2a95be4b85b09a618666"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ea5a79e808baef98c48c884effce05c31a0698c1057de8fc1c688891043c1ce1"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-win32.whl", hash = "sha256:3c1895c95be92600233e476fe283f042e71cf8f0b938aabf21b7aafa62a8dac9"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:851977788b9caa8ed011f5f643d3ee8653af02c5fc723fa350db5125abf2be7b"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4ebed0977f92320f6686c96e9e8dd29eed199eb8d066936bac991afc37cbb70"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42abddebe2c6a35180ca549fadc7228d23c1e1f76167c5ebc8a936b5804ea2df"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1e41b32d6f7f9c26bc731a8b529ff592f31fc8b6ef2be9fa74abd05c8a342d7"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:be4e0f229cf3a71f9ecd633566bd6f80d9fa6afaaff5489492be63fe459ef98c"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:08c4e315a76ef26eb833511ebf3fa87d182152adf43dedee8d79f998a2162a0b"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:badb868fff14cfd0e200eaa845887b1011146a7d26d579aaa7f966c203736b92"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-win32.whl", hash = "sha256:7c58f598d9fcc52772b89a92d72bf8829c12d09746a6d2c724c5b30076c1f11d"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2b97502c16a5ec611cd52410bdfaab264997c627a46b0f98d3f666227fd1ea2d"},
+    {file = "pyzmq-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d728b08448e5ac3e4d886b165385a262883c34b84a7fe1166277fe675e1c197a"},
+    {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:480b9931bfb08bf8b094edd4836271d4d6b44150da051547d8c7113bf947a8b0"},
+    {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7dc09198e4073e6015d9a8ea093fc348d4e59de49382476940c3dd9ae156fba8"},
+    {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ca6cd58f62a2751728016d40082008d3b3412a7f28ddfb4a2f0d3c130f69e74"},
+    {file = "pyzmq-22.3.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:468bd59a588e276961a918a3060948ae68f6ff5a7fa10bb2f9160c18fe341067"},
+    {file = "pyzmq-22.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c88fa7410e9fc471e0858638f403739ee869924dd8e4ae26748496466e27ac59"},
+    {file = "pyzmq-22.3.0-cp38-cp38-win32.whl", hash = "sha256:c0f84360dcca3481e8674393bdf931f9f10470988f87311b19d23cda869bb6b7"},
+    {file = "pyzmq-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:f762442bab706fd874064ca218b33a1d8e40d4938e96c24dafd9b12e28017f45"},
+    {file = "pyzmq-22.3.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:954e73c9cd4d6ae319f1c936ad159072b6d356a92dcbbabfd6e6204b9a79d356"},
+    {file = "pyzmq-22.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f43b4a2e6218371dd4f41e547bd919ceeb6ebf4abf31a7a0669cd11cd91ea973"},
+    {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:acebba1a23fb9d72b42471c3771b6f2f18dcd46df77482612054bd45c07dfa36"},
+    {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cf98fd7a6c8aaa08dbc699ffae33fd71175696d78028281bc7b832b26f00ca57"},
+    {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d072f7dfbdb184f0786d63bda26e8a0882041b1e393fbe98940395f7fab4c5e2"},
+    {file = "pyzmq-22.3.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:53f4fd13976789ffafedd4d46f954c7bb01146121812b72b4ddca286034df966"},
+    {file = "pyzmq-22.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d1b5d457acbadcf8b27561deeaa386b0217f47626b29672fa7bd31deb6e91e1b"},
+    {file = "pyzmq-22.3.0-cp39-cp39-win32.whl", hash = "sha256:e6a02cf7271ee94674a44f4e62aa061d2d049001c844657740e156596298b70b"},
+    {file = "pyzmq-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:d3dcb5548ead4f1123851a5ced467791f6986d68c656bc63bfff1bf9e36671e2"},
+    {file = "pyzmq-22.3.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3a4c9886d61d386b2b493377d980f502186cd71d501fffdba52bd2a0880cef4f"},
+    {file = "pyzmq-22.3.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:80e043a89c6cadefd3a0712f8a1322038e819ebe9dbac7eca3bce1721bcb63bf"},
+    {file = "pyzmq-22.3.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1621e7a2af72cced1f6ec8ca8ca91d0f76ac236ab2e8828ac8fe909512d566cb"},
+    {file = "pyzmq-22.3.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:d6157793719de168b199194f6b6173f0ccd3bf3499e6870fac17086072e39115"},
+    {file = "pyzmq-22.3.0.tar.gz", hash = "sha256:8eddc033e716f8c91c6a2112f0a8ebc5e00532b4a6ae1eb0ccc48e027f9c671c"},
 ]
 rdflib = [
     {file = "rdflib-5.0.0-py3-none-any.whl", hash = "sha256:88208ea971a87886d60ae2b1a4b2cdc263527af0454c422118d43fe64b357877"},
@@ -1865,6 +2602,10 @@ rsa = [
 secretstorage = [
     {file = "SecretStorage-2.3.1.tar.gz", hash = "sha256:3af65c87765323e6f64c83575b05393f9e003431959c9395d1791d51497f29b6"},
 ]
+send2trash = [
+    {file = "Send2Trash-1.8.0-py3-none-any.whl", hash = "sha256:f20eaadfdb517eaca5ce077640cb261c7d2698385a6a0f072a4a5447fd49fa08"},
+    {file = "Send2Trash-1.8.0.tar.gz", hash = "sha256:d2c24762fd3759860a0aff155e45871447ea58d2be6bdd39b5c8f966a0c99c2d"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -1917,9 +2658,64 @@ synapseclient = [
     {file = "synapseclient-2.4.0-py3-none-any.whl", hash = "sha256:1da62759ef5ec51bd467db7bf84f5b335b59282f97979be0348b34ce3fafdeef"},
     {file = "synapseclient-2.4.0.tar.gz", hash = "sha256:b06c4ef81fc6bfc533a6b372678f7103568c685d3ea631eb230aa2e237081ab9"},
 ]
+terminado = [
+    {file = "terminado-0.12.1-py3-none-any.whl", hash = "sha256:09fdde344324a1c9c6e610ee4ca165c4bb7f5bbf982fceeeb38998a988ef8452"},
+    {file = "terminado-0.12.1.tar.gz", hash = "sha256:b20fd93cc57c1678c799799d117874367cc07a3d2d55be95205b1a88fa08393f"},
+]
+testpath = [
+    {file = "testpath-0.5.0-py3-none-any.whl", hash = "sha256:8044f9a0bab6567fc644a3593164e872543bb44225b0e24846e2c89237937589"},
+    {file = "testpath-0.5.0.tar.gz", hash = "sha256:1acf7a0bcd3004ae8357409fc33751e16d37ccc650921da1094a86581ad1e417"},
+]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tornado = [
+    {file = "tornado-6.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32"},
+    {file = "tornado-6.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:0d321a39c36e5f2c4ff12b4ed58d41390460f798422c4504e09eb5678e09998c"},
+    {file = "tornado-6.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9de9e5188a782be6b1ce866e8a51bc76a0fbaa0e16613823fc38e4fc2556ad05"},
+    {file = "tornado-6.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:61b32d06ae8a036a6607805e6720ef00a3c98207038444ba7fd3d169cd998910"},
+    {file = "tornado-6.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:3e63498f680547ed24d2c71e6497f24bca791aca2fe116dbc2bd0ac7f191691b"},
+    {file = "tornado-6.1-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:6c77c9937962577a6a76917845d06af6ab9197702a42e1346d8ae2e76b5e3675"},
+    {file = "tornado-6.1-cp35-cp35m-win32.whl", hash = "sha256:6286efab1ed6e74b7028327365cf7346b1d777d63ab30e21a0f4d5b275fc17d5"},
+    {file = "tornado-6.1-cp35-cp35m-win_amd64.whl", hash = "sha256:fa2ba70284fa42c2a5ecb35e322e68823288a4251f9ba9cc77be04ae15eada68"},
+    {file = "tornado-6.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0a00ff4561e2929a2c37ce706cb8233b7907e0cdc22eab98888aca5dd3775feb"},
+    {file = "tornado-6.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:748290bf9112b581c525e6e6d3820621ff020ed95af6f17fedef416b27ed564c"},
+    {file = "tornado-6.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:e385b637ac3acaae8022e7e47dfa7b83d3620e432e3ecb9a3f7f58f150e50921"},
+    {file = "tornado-6.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:25ad220258349a12ae87ede08a7b04aca51237721f63b1808d39bdb4b2164558"},
+    {file = "tornado-6.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:65d98939f1a2e74b58839f8c4dab3b6b3c1ce84972ae712be02845e65391ac7c"},
+    {file = "tornado-6.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:e519d64089b0876c7b467274468709dadf11e41d65f63bba207e04217f47c085"},
+    {file = "tornado-6.1-cp36-cp36m-win32.whl", hash = "sha256:b87936fd2c317b6ee08a5741ea06b9d11a6074ef4cc42e031bc6403f82a32575"},
+    {file = "tornado-6.1-cp36-cp36m-win_amd64.whl", hash = "sha256:cc0ee35043162abbf717b7df924597ade8e5395e7b66d18270116f8745ceb795"},
+    {file = "tornado-6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7250a3fa399f08ec9cb3f7b1b987955d17e044f1ade821b32e5f435130250d7f"},
+    {file = "tornado-6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ed3ad863b1b40cd1d4bd21e7498329ccaece75db5a5bf58cd3c9f130843e7102"},
+    {file = "tornado-6.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:dcef026f608f678c118779cd6591c8af6e9b4155c44e0d1bc0c87c036fb8c8c4"},
+    {file = "tornado-6.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:70dec29e8ac485dbf57481baee40781c63e381bebea080991893cd297742b8fd"},
+    {file = "tornado-6.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d3f7594930c423fd9f5d1a76bee85a2c36fd8b4b16921cae7e965f22575e9c01"},
+    {file = "tornado-6.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3447475585bae2e77ecb832fc0300c3695516a47d46cefa0528181a34c5b9d3d"},
+    {file = "tornado-6.1-cp37-cp37m-win32.whl", hash = "sha256:e7229e60ac41a1202444497ddde70a48d33909e484f96eb0da9baf8dc68541df"},
+    {file = "tornado-6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:cb5ec8eead331e3bb4ce8066cf06d2dfef1bfb1b2a73082dfe8a161301b76e37"},
+    {file = "tornado-6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:20241b3cb4f425e971cb0a8e4ffc9b0a861530ae3c52f2b0434e6c1b57e9fd95"},
+    {file = "tornado-6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c77da1263aa361938476f04c4b6c8916001b90b2c2fdd92d8d535e1af48fba5a"},
+    {file = "tornado-6.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:fba85b6cd9c39be262fcd23865652920832b61583de2a2ca907dbd8e8a8c81e5"},
+    {file = "tornado-6.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:1e8225a1070cd8eec59a996c43229fe8f95689cb16e552d130b9793cb570a288"},
+    {file = "tornado-6.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d14d30e7f46a0476efb0deb5b61343b1526f73ebb5ed84f23dc794bdb88f9d9f"},
+    {file = "tornado-6.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8f959b26f2634a091bb42241c3ed8d3cedb506e7c27b8dd5c7b9f745318ddbb6"},
+    {file = "tornado-6.1-cp38-cp38-win32.whl", hash = "sha256:34ca2dac9e4d7afb0bed4677512e36a52f09caa6fded70b4e3e1c89dbd92c326"},
+    {file = "tornado-6.1-cp38-cp38-win_amd64.whl", hash = "sha256:6196a5c39286cc37c024cd78834fb9345e464525d8991c21e908cc046d1cc02c"},
+    {file = "tornado-6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0ba29bafd8e7e22920567ce0d232c26d4d47c8b5cf4ed7b562b5db39fa199c5"},
+    {file = "tornado-6.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:33892118b165401f291070100d6d09359ca74addda679b60390b09f8ef325ffe"},
+    {file = "tornado-6.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7da13da6f985aab7f6f28debab00c67ff9cbacd588e8477034c0652ac141feea"},
+    {file = "tornado-6.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:e0791ac58d91ac58f694d8d2957884df8e4e2f6687cdf367ef7eb7497f79eaa2"},
+    {file = "tornado-6.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:66324e4e1beede9ac79e60f88de548da58b1f8ab4b2f1354d8375774f997e6c0"},
+    {file = "tornado-6.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:a48900ecea1cbb71b8c71c620dee15b62f85f7c14189bdeee54966fbd9a0c5bd"},
+    {file = "tornado-6.1-cp39-cp39-win32.whl", hash = "sha256:d3d20ea5782ba63ed13bc2b8c291a053c8d807a8fa927d941bd718468f7b950c"},
+    {file = "tornado-6.1-cp39-cp39-win_amd64.whl", hash = "sha256:548430be2740e327b3fe0201abe471f314741efcb0067ec4f2d7dcfb4825f3e4"},
+    {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
+]
+traitlets = [
+    {file = "traitlets-5.1.1-py3-none-any.whl", hash = "sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033"},
+    {file = "traitlets-5.1.1.tar.gz", hash = "sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -1965,6 +2761,14 @@ uritemplate = [
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
     {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+webencodings = [
+    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
+    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
 werkzeug = [
     {file = "Werkzeug-1.0.1-py2.py3-none-any.whl", hash = "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ mysqlclient = "^2.0.3"
 SQLAlchemy-Utils = "^0.37.8"
 sqlalchemy_schemadisplay = "^1.3"
 configparser = "^5.2.0"
+notebook = "^6.4.7"
 
 
 [tool.poetry.dev-dependencies]

--- a/scripts/Create, Load and Query Relational Database.ipynb
+++ b/scripts/Create, Load and Query Relational Database.ipynb
@@ -1,0 +1,1861 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a6f3fb99",
+   "metadata": {},
+   "source": [
+    "# Please read before starting:\n",
+    "\n",
+    "## About this notebook:\n",
+    "\n",
+    "- This notebook is intended to aid a user who is familiar with Relational Databases (RDBs), Data Models and Synapse in creating a relational database, uploading data to it, performing SQL joins on that data and uploading the data to Synapse. This will all be done using a series of csv files.\n",
+    "\n",
+    "- The program will use a series of csv and config files to _automatically_ generate the RDB and perform the queries.\n",
+    "\n",
+    "- There is a query 'playgound' to test out queries before adding them to the actual query list.\n",
+    "\n",
+    "- Since everything is being automatically generated, the names _must_ match so please pay attention to all the naming conventions to avoid odd errors (ie. file structure, file names, attribute display names vs labels etc..)\n",
+    "\n",
+    "## Additional Notes/Assumptions:\n",
+    "\n",
+    "- This notebook is specific to the NF Tools Registry, please contact the Fair Data Workstream at Sage Bionetworks, if you are planning to use this for another project.\n",
+    "\n",
+    "- This also assumes you have a working Data Model. For information on how to construct a Data Model please consult the Confluence documents for this project.\n",
+    "\n",
+    "- Assumes you already have Schematic downloaded as a developer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da366957",
+   "metadata": {},
+   "source": [
+    "### Set up Schematic-RDB Environment\n",
+    "1. `poetry install`\n",
+    "2. Install MySql Server:\n",
+    "    - Download instructions for [Mac OSX.](https://flaviocopes.com/mysql-how-to-install/)\n",
+    "    - Save your Username and Password and add these to the sql_config.yml file. NEVER COMMIT THIS FILE TO GITHUB!\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b154a325",
+   "metadata": {},
+   "source": [
+    "### Set up Config Files\n",
+    "\n",
+    "Establishing the RDB requires **3** config files.\n",
+    "\n",
+    "1. **Config.yml**\n",
+    "    - This is the standard schematic configuration file and should have been set up when installing schematic.\n",
+    "2. **sql_config.yml**\n",
+    "    - Put this file in the same folder as config.py (if moving them to a new folder)\n",
+    "    - Use the template in the repo to store your database login info.\n",
+    "    - NEVER COMMIT THIS FILE TO GITHUB!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00d03637",
+   "metadata": {},
+   "source": [
+    "### Download all .csv files and place them in the correct file structure.\n",
+    "\n",
+    "The files that are needed to run this program are:\n",
+    "\n",
+    "1. **Data Model CSV:**   \n",
+    "\n",
+    "    - Download the Data Model from Google Sheets as a csv and stored in a data folder.\n",
+    "        - Alternatively, data model may be available as a versioned github release.\n",
+    "    \n",
+    "        - The naming should follow this structure:\n",
+    "    \n",
+    "            `datamodelname.rdb.model.csv`\n",
+    "    \n",
+    "        - For NFTI this model name is: \n",
+    "    \n",
+    "            ` nf_research_tools.rdb.model.csv`\n",
+    "    \n",
+    "    - For context, when Schematic is making the Relational Database, it will know to make a RDB and what to name it based on the name provided here. This is the database name that you will access in your MySql database.\n",
+    "    \n",
+    "        - This is saved so that the JSONLD can be made when there are changes to the `.csv` but if your model is stable you can skip this step.\n",
+    "        - We will convert this `.csv` model into a JSONLD format (used by schematic) at a later step.\n",
+    "        \n",
+    "2. **Data Model JSONLD**\n",
+    "\n",
+    "    - If you already have a `JSONLD` version of the data model (perhaps from a github repo) add it to the same folder you created for the `.csv`\n",
+    "    \n",
+    "    - JSONLD naming convention follows the same as the `.csv` but the suffix is `.jsonld`.\n",
+    "    \n",
+    "    - If you do not have the `JSONLD` run the following command:\n",
+    "    \n",
+    "        `schematic schema convert /Path/to/datamodelname.rdb.model.csv`\n",
+    "        \n",
+    "        -`datamodelname.rdb.model.jsonld` will be saved to the same folder as the `.csv`\n",
+    "        \n",
+    "3. **Manifests**\n",
+    "\n",
+    "    - Manifests are used to load data into the database.\n",
+    "    - If you do not already have manifests you can make them for each table.\n",
+    "        - Make sure your `config.yml` -- `model->input->location` -- points to the `datamodelname.rdb.model.jsonld`\n",
+    "        - Fill out the manifest section of the `config.yml` file to point create manifests for each `data_type`.\n",
+    "        \n",
+    "   - Fill out all manifests and download them locally.\n",
+    "   - For NF the file names have the following example structure:\n",
+    "       `XX_nfti_YYYY.rdb.manifest.csv`\n",
+    "       - `XX` is an abbreviation for the group of manifests this manifest belongs to. For example, would be CL for the `Cell Line` group of manifests.\n",
+    "       - `nfti` name of the database but could be anything to identify the dataset.\n",
+    "       - `YYYY` is the name of the table the manifest fills out for the given manifest group (for example 'Resource')\n",
+    "   \n",
+    "   - Save files within the follwing file structure\n",
+    "       - `rdb_data`:\n",
+    "           - `XX`:\n",
+    "               - `XX_nfti_Resource.rdb.manifest.csv`\n",
+    "               - `XX_nfti_Development.rdb.manifest.csv` ... etc...\n",
+    "   - Place combined manifests into a folder called `ALL`\n",
+    "\n",
+    "4. **Column Types**\n",
+    "    - `column_types.csv` is used to specifying a Synapse Table schema when uploading data to synapse.\n",
+    "        - See [Synapse Documentation](https://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/ColumnType.html) for details on column types available.\n",
+    "    - Download `NF_column_types.csv` from Google or fill out blank example `notebook_examples/column_types.csv`.\n",
+    "    - Filling out `column_types.csv`:\n",
+    "        - `column_name`: \n",
+    "            - For each attrubute you want to assign a type, find the label name in the JSONLD (usually just the Display name as camelCase). Use that name as the `column_name` then fill out the rest of the columns depending on the column type you are specifying. \n",
+    "        - Enter `column_type` in all UPPERCASE. \n",
+    "    - Note name of this file in `sql_query_config.yml`.\n",
+    "    - Place in same folder as the manifests (see below).\n",
+    "    \n",
+    "5. **Joins For Synapse**\n",
+    "    - `joins_for_synapse.csv` is a file that allows users to specify the joins they would like to run on the tables in their database and either upload to synapse or save locally.\n",
+    "    - Download `NF_joins_for_synapse.csv` from google or fill out blank example `notebook_examples/joins_for_synapse.csv`\n",
+    "    - Notes:\n",
+    "    \n",
+    "        - **Table Name:**\n",
+    "            - String. The name of table you want to save the join as. Do not repeat table names within a Synapse project.\n",
+    "        - **MySql Query:**\n",
+    "            - String. Query in MySql Syntax\n",
+    "        - **Table ID / NF table ID:**\n",
+    "            - String. Synapse Table ID for the final project table. If this is your first time creating the join, you will not have this value yet. It will be generated once the join is performed for the first time. Enter the Synapse ID once it is available.\n",
+    "        - **Staging table ID:**\n",
+    "            - String. I use a Staging Project folder to test out joins before putting them into the actual project folder. This is the table ID that is present in the staging project folder.\n",
+    "        - **Define Column Schema:**\n",
+    "            - True: Set to true if you want to define the column schema when uploading the table to Synapse, must upload `column_types.csv` with all columns in the table that you want to define added to that spreadsheet.\n",
+    "            - False: Use default column types when uploading to Synapse. This may cause some things to not be loaded properly (Lists, intergers etc) but is straightforward.\n",
+    "        \n",
+    "   \n",
+    "        \n",
+    "        \n",
+    "    \n",
+    "\n",
+    "    "
+   ]
+  },
+  {
+   "attachments": {
+    "filestructure.png": {
+     "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0YAAAC8CAYAAABcxb76AAAAAXNSR0IArs4c6QAAAGJlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAABJKGAAcAAAASAAAAUKABAAMAAAABAAEAAKACAAQAAAABAAADRqADAAQAAAABAAAAvAAAAABBU0NJSQAAAFNjcmVlbnNob3RR/y14AAAB1mlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczpleGlmPSJodHRwOi8vbnMuYWRvYmUuY29tL2V4aWYvMS4wLyI+CiAgICAgICAgIDxleGlmOlBpeGVsWURpbWVuc2lvbj4xODg8L2V4aWY6UGl4ZWxZRGltZW5zaW9uPgogICAgICAgICA8ZXhpZjpQaXhlbFhEaW1lbnNpb24+ODM4PC9leGlmOlBpeGVsWERpbWVuc2lvbj4KICAgICAgICAgPGV4aWY6VXNlckNvbW1lbnQ+U2NyZWVuc2hvdDwvZXhpZjpVc2VyQ29tbWVudD4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+Cv7oHFQAAEAASURBVHgB7F0HfBXFE55Ueu9NOihIlaL0Ih2kiKBSpEpT/0pRLIiAgAoCUkSaCFgAaWIBG1ItiApSpEsH6aS3l/znm2Tj5fFaQgIvcSa/l2t7e7vf3t7NNzO751OhTMU4UlEEFIF0j8Dh44eI+3O6r4dWQBFQBOIR0D6td4IioAgoArcXAd/bezm9miKgCCgCioAioAgoAoqAIqAIKALeh4ASI+9rEy2RIqAIKAKKgCKgCCgCioAioAjcZgSUGN1mwPVyioAioAgoAoqAIqAIKAKKgCLgfQgoMfK+NtESKQKKgCKgCCgCioAioAgoAorAbUbA39Pr+fj6ULZsWSlrdv7xUkURUATSBoGw0DAKCwmjUP7FxaXt3CjZc2anbNyns2TNkjaV0VwVAUWAwsPCpT+HBIWkKRr6nk5TeDVzRUARyAAIuHsee0SM8LDNnSc35cqTMwNAolVQBLwbARge8AsIDKLrV6+nCTny8/ejnLlzUi7+qSgCikDaIgDDA34BgQEUdD2IbDG2VL+gvqdTHVLNUBFQBDIgAu6exx6F0sFTpKQoA94dWiWvRgB9Dt6ctBA8GJQUpQWymqci4BwB9LmsaeSddfeehvc5NjbW4Q/H0to77RwVPaIIKAKKwO1HwNnz2COPEcLnHElMTAxFRERQVFRU4kPVz8+PMmXKJD9fX494l6OsdZ8ioAgwAuh7IcGhqY5FliyZHeapfdohLLpTEUg1BDJz3wtOg5A6Z+9pFByE6PHHH6cuXbrIu9oQIeyH7Ny5k9577z15n/v4+Mg+/acIKAKKQEZHwNHz2DNi5GRMEUhRZPfXKKZkJbKxxSmGEYwJCyX/n9dRph0ryY+37R+y2A4MDKTMmTOTv79Hl8/o7aL1UwScIpBW4/my5cjm8Jrapx3CojsVgVRDAH3v0j+XUy0/k5GrZwWIUNeuXYUUXbx4UYhSQECAECGbzUa5c+em559/nt566610R46gR8Cg40iga4D8OTvu6JzU2gddB3pOeHh4amWp+SQgkDVrVgoLC0uCB4zyuM8N2U9yUDcUAScIOHoe3xIzgafoRIHyFB4USf4cMu0T50N+cYEUWKs7BdTuTr48btzHn61PGD/OS9y0NnYiZTt/mPKtfI2yZ8/upKjudz/11FMEj9TMmTPphRdeoKCgIJo7d677E92kaNiwIfXo0YNGjhxJISGuB8oaj5h2RDeg6uF0g0Ba9+l7772XBgwYQJMnT6Z//vknEZe77rqLxo4dS7/99htdv36doKydO3eOfv31V1HUEhPqiiKgCCQbAbyjjJES72G8L6FcRkdHS/+6fPkytWnTRt6lb775ZrLI0Z3q0yVLlqShQ4dS/vz56cMPP6QffvhBjK2oq6kv6oLnybhx4zzGzFl93GVgrw9Aj2jcuDG9+uqrosSjLEuXLqUff/zRXVZuj0N3evvtt2nFihW0adMmt+mTk8CqWzVq1Ej0oeHDh1NoaOpHLiSnXCbtPffcI/rZmjVr6Msvv5TopCFDhlDlypXp8OHDNGXKFJM02UuQbHP/JPtkPSHDIHBLsW54wF4JiaSwSKKI8FiKDI/hsDpeRsZRZAT/ouIoIjSWIqJtFBESw9uxFBwcS3/nKyfhd7eCIh7q2bLFW71xM5v1W8kT5yIvWNKwdCfPPfccvfzyy+6S6XFFIN0gkNZ9ulOnTpQjRw5RGKygFC9eXDbvu+8+gmLSvHlz6tOnjyhq1nS6rggoAilDAMQIP7wr4SGCNyNnzpxUoEABeedBsa9Tp454jrJkySKGTE+udKf6NJ4RIEXLly+n33//XQyt8+bNE4KHcuNZBkX52LFjnlQjMY2z+iQmcLJirw+cOXNGrg3PBrwZ0CvwSw1BO0JHMWQsNfI0eVh1K2+M7AHRRZteuHBBilyxYkWqUqUK7dq1iz766CNTjWQvQTat90+yM9ATMgwC7rV/N1VtWiEvFc2XnbIH+pNfgC8F8gx2ftxpbRy6zJsUzefjAWWLZZIUE0vh0TF09kIwBfM+d4KHCMYrGc8NHi54YJttR+fj5saDCKw/OQJlzVW+eIEEBwcneVngoeTowYQHFh4orvJLTtk0bcZDoHz58nTq1Ck2IrBVwcskrfp0kSJFqHTp0lLbunXr0qpVq27qp/AaQaGA8jZs2DDCS69gwYKE8B8VRcCbEfDmPg3cjMcISxNihvcXtmGY2Lx5M+XJk4eKFStGgwcPpmnTpiWe4wz329WnzfsZuoSRXLly0fnz5+nbb7+VXY4iUJIbReJJfXAx6CHQMazPb3t9AHjiB8mbN68s8Q94o6zQJxwJ6ursGK6bGmGBKdGtcM9AB/M0NNC+HtCh4Km0F3f6kj3WaPNJkyYlZoP7AALvEaIMrAKcHelhaAOUz1F5rOc7W3dWl1vN19n1dP/tReCWiZG/TyB7iuLIzxZHARxOh8dWIIfN2TiCDqSIFxTDx5gTUXRMHIWzFynQL5PTWkIJghcGSmOZMmUILn4oS+3ataMWLVrIzXzkyBGxeN24cSMxn3z58tHo0aMJLyc8VL7++mvasGFD4nFnKxUqVJBBqSVKlBCX+9mzZ5MkhSu8ffv28mBDvngIowOOGjWK7r77bkn7zjvvyMDVEydOUPfu3al27dpCjJAXXOdHjx5NkqduKAJ4wdeqVUssnZ6+aG4Xaqndp025H3jgAVnduHEjtW7dmipVqkT79u0zh5MsEbaBfg5ihBeYEqMk8OiGFyLgzX0acEFpM4KxhFBIEUoHBR/rIEQIYYXSB88R9jsy/Jk8sEzLPo0QeZQB/R9lg8Hzgw8+kHDbF198kcqVKydFwft35cqV8u7Fjg4dOlCDBg0IaUaMGEGXLl2S97AkdvPPVX1atmxJHTt2pD///JPg2QaeO3bskDI50geKFi1KDz30kJTBXLZmzZqyDx476Dgff/yxPOdwvGnTptSqVSvx4KHM0DW+//57ORVenL59+1LVqlVlG94RI8jziSeeoEWLFknZsP/hhx8mhMEBAzMWJ6W6FfLDxB14X0H27NlDixcvdkiQ0GboB6hfoUKF6OTJk1IPeOHg3UO94JX5+++/hVw605dcYQ1dD+GJuBeQZ+fOnaVcY8aMkdDrhQsXUpMmTcRziOMwtK1evToRG+iRCBsFobp69SohJO/gwYOJ4ZbW+0cytvxDvnh3wct67do10TFNGznKF6HgGLf3xx9/0LJlyyQn6KgIV4Sn86effrLkrqvegsAthdKhElERsRQSxjHLPL4wkteDOYQuiIlSMO8LDo2jMF4PDeFlWCzd4LFykbweDpbkRGCVAMuH0oSY4XXr1lH9+vVlNh24ThFTC6sFbkyroNPjIY7jSIeBpuYhZ01nXYd17Omnn5ZOjM6BBx7iVI3gwda7d2+6cuWKPMBgqcCsPiBsIF1Q1uDWxQ0OSwU6BsYo4WEJazge6IMGDTLZ6VIRSETg9OnTQvrhOUmtMNDEzG9xJbX7NIoDJQL9EcYDGBZg9axXr95NJQUeSNetWzd5uaFf4eWqogh4OwLe3KeBHfogfjA6wMiHJZRmKLLoj7CsYx1pIFh3JWndp0HQYHwEgfjss8+kjHj/QvAMwXseyinevwit+vzzz+XYX3/9RevXr5d15AEl3RNxVx88pxEJAq8SFO3jx4/L+x7eNkf6AMiMvRcLYcIgFtA3oH8888wzoqCDiPbs2TOxPlDYQUaMDjNw4EACAdq6davUs3r16olVQrggymXSoh54tkI/MaQIiVOqW+FcEDJgum3bNiGFGCfqSIA3jFkgGl988QXB4Iy02IZOhLZ45JFH5FRX+pIrrOHtAq6o86FDh4QoI0O0CUgKCFyvXr3k/Qp9EHhgLBraCWNZH330UXkPgUBBf+vXr5/ojo7uH2sd0UbIFwZ5EHEY7dFGNWrUcJovIp7wXLj//vsTwyjRTqgfMFHxTgRu2WMUyR+q8/Oz8c3HYWX854fwOQ6bi2PvEdxFHFnHc4UyGeJfTJSNSZGNrVTOiZGBCTf5V199JZtg13hoT58+XVzX27dvv2mAHazuOI4lOi9YOh4erhg5OjAeXrNmzaLdu3fLtdDh8ACCYHA4LEEgXEiHJTxMsF7hGnh4Yb+5Biw8KBusb7jxYVUqzaFDcAV7m1dAKqj/7hgCCMHAixX3Ch6U33333R0ri/2F06JPQ8FBOMk333wjL2sYIdDP7PtG27ZtZfwhXuIQECmsp0b4iH09dVsRSE0EvLlPo55QECEw2KFPYdu81+CZwQ/7TDpJ7OLf7ejTsPZDgYXAIIroDRhF8fzAGCO8r837FzoClF5EaJh9Lop/0yFP6wOPB4yk+/fvFy8DxreAGNnrAzddgHfA04MoEgjyQLgwdAoo8yj/jBkzRMcBAcJkDdiPCWlAqH7++efEMTQgPcboivOgv0DfgSIOwy0ICMikI0muboU8lixZImXHOu4ZlAvvLkfPZTyzTR1haIYuBA8TBGUrVaqUrLvSlyQB/3OENbwvRkCaQQxBBDHODGQFHh/I2rVrpXwgzwgNRTuhbEZg8Ea4KN5BaDvcM67uH0QCwZgAPRMeV7QRvHwwMqCORqz5Ij10RbQfyCVIMfRCREqgXCreicAtE6MYJjk2f54Ok8lRFMfO8XOVyRE/XCWojreZKNli2LMkD14bu+o5bSxYk2uBy9UIXLIgKSaeF1YQ63Gkw3FDPrDEg6Nw4cImC4dL5AuxWqSxbogRHi6wNJiO7DATy07MltKHB4xbO4nlsK4qAkkQgHKCmZW8zXKUFn0aSgwELy2EeMAbC8ELFi8OI2aMEV7wsNChPyF85ZNPPjFJdKkIeC0C3tqnAZghPPAEQZmGQogxFnifwgoPJRfvLk89LLejT1tnrjSD7aGQp4V4Wh9TDrMEdp6KVTGHUg+BngIvlFXHga6D/LEfRBBGWXs9xXpNPEPxLIXuAoMvzkcYlyOx6k6e6FbIw77c8OyjXCB39gJyYgTlQHimERAKI57oSwZjs/QE62rVqsklEEZoFdQVhjl4lRCFhHQoHyJ84HV0J2gntJGpA/RMY7wHaXeWL0gryBMwQ+gqyDxIlYr3InDLT5hYziHKhz1G0UyFmPT4ZWKvEU/bzTyIXfHxRAkPYiFEvIQ12sZjjZgveSwgOWXLlhUrF6YTxgMdnRLWJCMIpYMyhRsdSxyHm9WVIF8IXKyGvcP1awRhcSBFiA2FpQfKHGJorWJ9SMPNj4fAxIkTxX0Kl7F52FrP0XVFACEHuL9g+bQfMHqn0UntPo3+iHADiBn3hxccCA8sfVZiZOqOfrx3717ZtA5cNsd1qQh4GwLe3KeBlSFGJgICJA5eIhAhvFcRmoR3q0nnCt/b1afdhfM5KiOU1ORKSurj6BpWfcDRcat+gcgTCJRt/DBmCs9FKM/IBzrNCfZwgGignUx6nAOdxSrwXsFTgecpdBboK8ZQbE1nv+6JboVzUG5DeHBt6Dlm2z5PT7fTSl8CESnNkTr4LhfKifsZ45JgDMC9jxA/hMIBJxjqmjVrJt4mhLxBnN0/IGfw7uFewfsJ/QfRHjBswuPkLF+EdmKKdlwH7QtjBN77Kt6LwC0To6DgCMoc4E9h/tE8Ix3PcBPOxMgPHiN8bZtD6ZgBYfIFG2/YCLO4xFI0u5Di5xHxDBjcRHATYzwQlCWs4yFuFbh3Ea8LVyVcprB8ubv5QJxwg8MqDbaPwXiwuhjBAwoCQgTFDgMprYJYU3QUDBTEjY/0xmIIF3KTJk2syXVdEUhEAC8whEjgxYSXnjdJavdp44F9//33xTpn6grCA3KIAbJG8PLACwrHjOXP2zxqpqy6VASsCHhzn0Y5DeExzxu8r6Co4R0IhRHkCF4j+3ertY5m3Rv7NCz5qAs8zSAU7t7/pi5YJqc+1vOs6/b6gPWYWYfXAOmgpONZhzJjkhm0A3QMo+Mg9Ar6CMLGUCfoKphQAufBw4eQY6uAQCKMH8YmiDE2YawmromhBY7EE90K5/Xv31+MWtCzQAYQCob7B14fhPRh/FFyv6eUVvoSMIOOiCEY8JqhjCjzBzxZA+59jCkCPtAVTV+AR8fR/WPFD6F6uE+gZ+7cuVPaC7omZj4EqXWWL/DD9TCxBsLpMPmQoxBEpFPxDgRumRj5ZfGlWCY+fj5Mfvx4FhuML2JaBFUPXiHm6xTrx/t8OYYZniIOu8N03s7EuF3NEum2bNki5AQPBkzKAOaOQXNG8ECHxweDGTEbC246uEzNw8Gks1+C5S9YsEDiSnGeeUhh1hBcH+fjRsYDDC8VxC5DYTM3Ndyh6HQ4F+5pDC588sknJT90OOxzF85nXybd/m8ggPsTL7OUWETTGqHU7tN4SeEliBeLVX755RchRuhjiMWGYBZICPoPrKiYfCW5L1zJQP8pArcZAW/u04DCECO8L6EIwvKNfgcLOd5p8DDAsm7SuYLvdvRp85415cD7GYLyQ/COtuoJSI9xK5g1DB/8xM8+DznRwT9P6oO8cG1nz2x7fQDp8UN6U06QIDzjgD08LhhDA90F4VzAHroGjKpoH3ggjA4DPQX1gREWJBZKvQkFM9VBHiBGIE64DgREBkQXHihTBrPEcXe6FdJAMI4HHh48l5E3ZsCDgNAZTyO27fEGqTPkA8et4kpfcoW1uYaph9k2eYMgwtgGwzSIC9LB8A18UF6QToTSwSiHewoTYZjoI/v7x4ofxiChjRAFhEm5UDeE0sHACYO4q3wRcgj9EQTKtKkpry69DwGfCmUqup56hstcqlxJhyUHsTgxaBn5+PvyJAt+/Iuf0QbbPhJKx1knLOP4GD8fxHMUF26jUot7C8lwmLGTnejc6ISwmjgThAJACUNngSva2ewpOB+WaTOFIjoAHnr2nQzp8BDDw8iRaxovEfNiQVpsowzO8kIaFUUgOQicOHrSo+SHjx8i7s8epfWWPu1RYTWRIpDBELidfRrQ4Z2ICV6gpEMhByGCwop3Kt5ZeF9hUga866A8Ih2UbKynhSTn3Zzc66NOEOu7HF4NKLXOZM6cOeLJcXbc0/32+oCj81A+4OpMn0C0C9rHEQGD/oNrODoXXhHoO5iJDSTdCHQXZ+TEpPFUt0I+IARW8SR/a3rrelrqS8gb9zSIovVewPVRX9zrOGaPs/39Y18/5ItxQtBDHZ3rLF9rvXXduxCwfx7fkscILDn/1b/oWt7K7BGyUZw/x/byAzUOs87FslcILiN/ZkOR/OPwOumcPA4vf9BBYdjJhQY3tytShPysDwykN2OHHF3L+nEvdBBnYv8gsKZDx7B2Omy7yst6rq4rAt6GwO3u095Wfy2PIpAREYByh3EVCA2CNR0kAe8qZz9Y0XFOWkly3s3JLYP1fWzORfias/o4UvbNecld2usDjs5H+RyVEWlxvisdx3jN7PMdPny4eJoQpQIvkFXckSKkRXlcXRdprLoVto14kr9Ja79EfdNKX0LeVh3Pem1XbWDfNvb1Q77w6DkSV/k6Sq/7vBOBW/IYwUWJzuLKvWxfbbBtKF/wqjgb5GZ/jm4rAv9lBOytGc6wSA2PkfZpZ+jqfkUg9RC4nX0apYZyh74NxQ2KnSvBOxpWc7yfnZEJV+frsduPAEL6EfWCsUjuCM7tL51eURHwbgTsn8ceeYzCQsMoa7asN9UMD064FFUUAUUgbRAIC3HuybyVK4YGh1K2HP9+e8HkpX3aIKFLRSBtEEDfSwtx9p7GtUBw8Eur0Li0qI/m6TkCmPlMRRFQBJKPgKPnsUe+8rRSzpJfBT1DEfhvIQBlJy0kIvzf70mkRf6apyKgCDhGIK36nr6nHeOtexUBRUARcIaAo+exR8QolK3WN64FOctX9ysCikAaIIA+h76XFhIWFk43rmufTgtsNU9FwBkC6HPoe2kh+p5OC1Q1T0VAEcioCDh7HnsUSoeY5OtXr1M0z1yTNXtWh2F1GRU4rZcicLsRgOUXniIoOu7GA6S0bDb+0PK1y9e4T0dTNu7TWbJmSWlWep4ioAi4QSA8NJxnGgujkCDnM6q6ycLtYX1Pu4VIEygCioAiQO6exx4RI+CIh24Ix0bjp6IIKAIZAwEoammprGUMlLQWikD6QEDf0+mjnbSUioAi4L0IeBRK573F15IpAoqAIqAIKAKKgCKgCCgCioAicOsIeOwxuvVLaQ6KgCKgCCgCioAicCcQcBeWi2m6VRQBRUAR+K8joMTov34HaP0VAQsC+N5JdEy0fPOEA2jliI+Pr3zXxN/PX766bkmuq4qAIpAOEAApGvr0UOrbr4+ExWMbP/Pxyq2bt9L4cRMoPI0mhkgHEGkRFQFFQBEQBJQY6Y2gCCgCiQiAFOUbMY9spSuTjRWnGD4SExZKcVs/pbAvFhDZYpkcJSZPWPGRj0EG+AfoByHtodFtRcALEAAJ6j+gn5ChixcvCiHCN40iIiLECFK4aGGaOm0KjRw+Kt2RI9QjOjraIcqZMmWSujo77vAk3ZmuEHDUxvgeHwQfNVZRBJKLgBKj5CKm6RWBDIwAXiQnC1Wg8KBI8ud3ik8ck564QAqs15MC6vckX3Yi+fgzM4IziZdQuGw8UjHT2UMUOW0QZQrM5BKdWrVr0cgXRtKIZ0fQ2TNnE9OWLVeWWrVqSStXrKTLl68k7seKq2NJEuqGIqAIOESA/UOJ3l702aCgIMqaNasQCpCjy5cvU5s2bejt6VNpxHMjk0WOXPXpOXNn0/btO+gq9+kYPFtOnqStW7YmK3+HFeKd5cuXo1fGvkKFChWi2TNn0xeffykfsIUXDM8xfNB2yYcf0JUrV2jY4KecZSP7oUgPeHIA+fE5EOB1/twF2rlzJ507e072/Rf/tWrTip56ehj1eKwnY+NHSz9aQu9Mn0nfffudV8Bh38aZM2eml8e8RDVr1aR9e/fRCyNHp7icSq5SDF26P1EnX0j3TagVUARSE4E4uhISSWGRRBHhsRQZHkNRUbyMjKPICP5FxVFEaCxFRNsoIiSGt2MpODiWThQo75F1rtcTvSh3rlzUpm2bJIUuXbo0PdTpIcqRM2eS/dhwdeymxLpDEVAEHCKAMUT4ZcuWjXLnzk1QInNyfytQoIAQCiiZjRo3Es9R1mxZHebhaKerPo30DRrUp/tq3Sf9+7nhz0r+jvJJ7j48L0CK5s2dRzu2/0g5c+Wkz79aT4906ypZgSDtZeX4rwMH3Wbt7+9Pnbt0ohatWlCtOrWp+YPNafDQQTSbid09le5xe35GTRDI3jh45BAN4B/gL+uBgYFeU137Nq5arQrV5vbbvnU7vTvr3Vsq54RJE2j6zOm3lIeenD4RUI9R+mw3LbUikGYINK2Ql4rmy07ZA/3JL8CXAn3Za8QKFUfREW8SglbEUxTLJCkmlsKjY+jshWA6Km4k58UqUaIEVaxYQRI0a96UFi9a7BGZcp6jHlEEvAeBe6vcS0ePHJXwNO8p1b8lMZMrYAnlFkolyBC2ixcvTps3b6Y8efKIh3bM2DE0etRoOfZvDjevedKnhwwaSn8f/5ty5MhBY9jDU7VaVSparGiyPDG5cuei4KDgxDFRKEnevHnp9OnTtHbNOikYiJG9TBw/0X6Xy+11az+jJYuXyJjKDg+1p0FDBlGXhzvTxAN/JZ6HeoSFhTl8diGsC54GHLcXEAwcDwlJ2bes8uXLR9euXUvEIHv27GywinQYRoj2BdlzVA77cmHbPm/gHXTD+QfAcc8A7xvXbzjK7qZ99pg5KzvKDE8mPJqOBNhmy54tSdmsbZyH7wnIJx8vZ+/kqSRZ2JfBehAGgtDQ0CRt6ufny23p3nfgrC7I31G+1uvquncioMTIO9tFS6UI3DEE/H0C2VMUR362OArgcDpEzQVy2JyNI+hAijDEKIaPMSfiiRriKJy9SIF+rkPoUJnmLZpjQatWrqKubNWtUbMG7fp1l+zTf4pAekcARKNho4b0444fRcnytvoYYoRyIXwOSijG3qDcWC9WrJgohlDmGjdpJMYP6zmO6pOcPh0cHEz79x8QYpSLvcbuQtQw5skWa6NcuXJTqVIlBdPp02aIN2DaO29TpUqVpEgrV6+ghfMX0sBBA2X78Z6PU8vWrajfE/1o8luT6cL58xL+5aj8zvbFxMTQ+s8+p348LgseNQhCeocMG0KVK1diL3kwbdywkY07HwhOULqHPjWUGjSsL1ju37efZs6YRadOnRLP3DCe+KJ+wwaUhb10B5hkvffue3Tk8BEJB5z4xkQa9+o4wQbXQXigLxOP8a9NEO+aLyvnIC7wjg3s9yQFZgqkIUMHU+V7Kwsx2sH3G7wjUOxBvHCtBnwfghz98dvvNGPaOxJOiLytAnzt886dJzfXcTCVKVNGzjl54qT1FFmv36Ae9ezdQ4jpsWPH6N3Zcwn1tZeHu3bhdD3pj9//oAfqPSDlW7Tw/UQPYlh4OH3y0Sf06YpPhQyBhDZq3JCyZMlCJ/i6s2bMFEyKFi1CM2bNoAN871Ri7HF/gmi/OmYsXbp4KbGNTzEReqLvE1KM2e/Ooi0csjnljSku263i3RXp6f89ReXKlaNwLs+m7zfR/PcW0PiJ46hatWqSF+6vSa9Pot1/7ElSRbkfnLSDo3zfX7iYFi5eIM+HWe/MlrzQhmPHvUrvsddz03ebkuSvG3cOAfd0+M6VTa+sCCgCdwCBqIhYCgnjcQjhxOFzHCrHIXRBTJSCeV9waByF8XpoCC/DYukGG0YjeT0cLMmFwDKN8JTDrAws/2QFQfF4MIEouThNDykC6QaB48eO04ULF6hJsyYcEprD68oNkoMfFGgo9ljCowDvL/ojPBlYN2QI42xciad9uinjgb6PMTzt2rcVSz48a+4ESjqUUyjfy5Z+KCSuT4Liu/zjFXTmzBkZGzVv7nwhGx9/+LFkuXv3Hvpw2YeynodDBuFZSolUqXqvhI79feIEwYMycfLrBCX9ffZ0/86Eo1v3btT90W6S9SPduxLqiTK8O2culWEShVkAIaNeGEUtWrag7775jha//4HkgbxAdjIlhDNmZjJgJBcr/rm43BBgAAJ47OgxGUcVHhFOk96YRHeVvIuWfrCUx/p8T82bN2MyNEzSjxg1nFryWM2vN3wtpKNa9Wqi5MtBu3/2eUdFRdFr48dSXi7XB1zOnTt/pZr31bQ7iyQs8ueffpY0+fMXoHETXnOIcTb2aIHk5Mufn8Md5zPxiKD/PfuM1AkYXbzwj0wIAmy7dO1MrVq3pG+//lbwzc37Rr/8olzbYHT/A/eLd/CrL7+i0mVKJ4Zjmzbe++c+DqncIecgGmH9uvVu2230Sy9IWOnbU6bR90xMWrdtzeS2AZO1VXTu3Hkhhyj7yRNJvU/wrLpqB0f5ovx4RjTl9gJphTR/sJl4Uv/c86ds6z/vQEA9Rt7RDloKRcBrEIiMsXEIgY0VJF/CH6IJojlsLg4T/LC7iCPriHg7nH8xUTYmRTZWWlwTI8R+FyiQn9asWi0K2M5fdlK9+vXEUuhpuIfXAKQFUQQcIAAvzKGDh1jpCaBmrPx8xmFZ3iSG8MC7AcUM2whbAsGB1wg/7DPp3JXd0z4NAoGQL3gzIPCUYN2TmeJO/H1CrP44D2FUj/d4jIoUKUJ4fnRMGJP4/Xff47CEX8HrcIC9Fym1vrfv0I7q3l+HEB5VsGBB8ayBZICgYVwWFO7df+ymPUy+mjRlwsfGHRh6kB4CYrn7993UZ3Mf2QbOdR+oy0r39+xZiR/zAm/HhInjqVr1qnSRPR7u5OjRo+I9QrrGTRqzBy0njRs7nn768Sc59S/2QPn7+wmJwxgxEEl4PiClSpeihqzoFy5cWEi77LT8s+bdrHlTGX/2GnuvQHwgOXPkJHiIrLJt6zbxhmEfQhkRdokwUkyq4UgmTZhE//zzD/lxGQcyOZ42dboQvWAOl3vhxRekPdesWktfb/xG6gAs6/O4tIoVK8j9afJcumSZkD1sIxyzdp1aQg7NcdTlzz/3CgnHmDMYKYCHq3ZDX4CnCH132dJl9NGyj8RYgPv10qWL0q7m/jLXMdd31g447ixfkE+Mt6tTtzZj/IuQMERNXL502Zq9rt9hBJQY3eEG0MsrAt6GQAyTHJt/LMUwOYri2DnWlZgcscKUYEFmvkQ2nsc7SpQpG4ffcFoOeXElHTt1lMMIc2nNEy+UZIsnpCGHTkDxUFEEMgICUPgRlrPHCy3AhvBAeYd3CNZ8jOWAYQLjX+A1MhMzeNIWnvZpM8YIkz00btqYMAEDQrHee3ee28ucOfvvzJXwEEEQ9pdWAi8BQr+qVK0ixGjmO7Po4F8HqXbtWnLJvv37En5GMMYKsnL5pzJOq0+/PoQfpkRfOH8RexpOkD8TOnh8jJj14nyuJ8To/PkL5lS666746x05ciRxn1HczTO1bNmyNGvOzMTjWMmXP59DYmTNG6GUkKOWvEE27InREYu37+iR+HoVL1FcznX0D1hAIpl8QG5cvy7L0ND4cVi4L2vUrE7P8n0BQuFMrLOYnjl9hgozQXYnBhNn7YZwx/4D+8lMdsgLM9lNfetth1hZr+WqHZDOWb4gnDd47FaTZk15UqNoCQtESKaKdyGQdk8Y76qnlkYRUAQ8RCCWnwpRPuwximYqxKTHLxN7jXjabuZBbBGNJ0pQroQQ8RIeJhuPNXImWbJklhhzHF/J8eQQWFJ7cfx5ixYPKjESRPRfekcAlunWbVvRr7/8Sid4WmpvE0OM4CGCpwh9EF4ilBuWbBAXkCWTzlX5U9KnYZXftTN+TCG8MZ4InjPJFcyellJBiBwmX8B4HowH6f5od9rywxY6m0DQRj8/mv7cs1eyRziVKR/CEl9PmOgBYyefHDxQxq70fKyXjJMqWapUYpFK8ngpCBT9ODxUWYoUKSxLYF+gYAEO4boq2/b/Tp06LbtAvo2XASFaILVQ6tGeULRnz5wj6dCmGM8F74k7OXvunCQpzeOLzCcTynDImr2ULv3vvlKlS8lhd+PF7POw3waZxBTrzz7znISbDRjYX2YxtKYzWFv3uVt3124H9u+nAX0HCubwAPZ+ohchLNKMAfLn2fgciat2gAfIVb6Y6vyhjh2k/11nkvjLzzsdXUL33UEEUv4EuYOF1ksrAopA2iEQFBxBmVm5CPOP5hnpfMknHLPzwGPEEXT8HuddMvmCjTdshKm8YykaLiQnUq9+fTkybeo0+oZjyI1AOUJcOcI8jCCc40rCoFfsO3jwoDnE4Uk3H4M1V0UR8AYEMNXz9m07ZFIBKKjeJobwmLIhlA2eIoQNgSyBHEHBhjLtTpLTpzG7G8ZWFCxUkEOI6krWGAeU2hIeFh8ShXCzw4eOSLhdSq+B0K81q9fKGKIOD3Xgdt3GYyvDacSokewdWkEYE9SzVw8hIy+/+ArvHy4hUvPnLZDZ83BdzOoGbH/f9bs85xA6FsRju6AUI689e/ZQVGSUFLFzl85CSMuVLy/PQ2fEaC+HisHb9+zw/9GKTwrLWKRHH+tOCG+DQg5ih08hBAeH8H14ljo/3IU9WcXo8Ud78IQKpenFl1+S8Veff/b5TdAgb5BX5I3xOXny5pHJROwTNm3WRGbHC7pxQ8gL6rJv716qXqOay/zt87Fu496L97aWlXFNbTmkMTUEY3ectdubb7xFSz5awt684zIBhI3vfUgQz34IuXb1GlWpUoUwicS3PD6sG48nQ92fH/kCuWqHw4cPu8wXERLIsw5PK46JiNDnVLwLASVG3tUeWhpF4I4j4JeFxxzwrHN+PuwV8uMpfTG+iGkRVD3mREyGeN2P9/nyuAT2FPly2B2m83Ym93OMPZQwKI1W+WHTJlEYanO8dQgrDJBHuj1iTUIbvtrAFtr4gamOjikxSgKXbtxBBFbz+Lk49JUUeDluR7ENMYISiskXoIjC04GxO1DOMNYCEwKYdK7KlJw+3bZdW8kKhAwWfIwVcaSY218vJjqpwhjBg/chkVGRskSZbRaDDJ4xmLob3zHCRz47tu/Es2ZGS1p3/1A2/KxK6goeOwTDzWM8rmn9Z+tp/NhxMvMcZp8DRgcOHEgca4M6IbRrGB+DnOWPwsIQBHlz8ls8luZ56ti5o5x3jj0zU9+amujxwbilHkyyMIECPkaLtolJKLc9BlevXqWxY15jb9TT7JV6UvIHwZo7573Ea2HgPxRvCEIl35j8ppA0eAizZs1C2dhbCLHPGzO8oaz4fhNCz3A/YBZBzMIXwzj7xfnJedjXtl0bIdAgkJj1Dh6mMmXLJM2f2wfE0Fl/iEpoR5CxRQveJ5R7MM/yBs8RZhLEFPLWciZpa0vbW9vYvk4ol7N2A3GdO3uuzDyI+wUzIP7y8y98D62V6274aiOTveqCBUIsEeYHTytCOV21g7t8MVMh7h1MqrFx49dyLf3nXQj4VChTMfm+au+qg5ZGEVAEGIHDxw8R9+dbwiIsPIwixn9DPv487YKPH//iZ6nCtg8zI3nJJSzj+Bh0QHiO4sJtlPn1VpQ1S/xL95YKoScrAoqAIJAafRoZQek7fOyQ9N/Lly8LIQIRgJIHJR9kCYofyBK8SOjnNarW5LGF8cpwajcHZncbNXqU02zhYTLhTE4TOTlg6gSiZOTFl0eLx8ps2y8nvPa6KLv2+x1tw6MGD5ujSWMwRgvYOToGYgKsQRbsBWVGGCOIKtrFE0FbIT8QC3vBtZCnfTlAgkE83AkmQEC+VqJoPQd5G2Jt3e9p/tZzzDrqAvyAj7XtzPFbXbpqN3yTCR5H++uinVEns99R/Vy1g7N8b7Uuen7aIqAeo7TFV3NXBNIVAv5+/pT38n66kb8Ke4RsFOfPihG/6OMw61wse4XgMvJnNhTJPw6vk5c4v2fzXj9AUXyuiiKgCHgfAgiEXbRgEQ8070/58+cXzxAUeGc/jLOJD55Nm7pEs8XfjJFxdIXr1+IH6Ds65m6fI2X+KodFQcl1JHiGYRpsT8URETHngtg4E5BPZ4Iyw1OUHHFEsMz5uJaj63lCipCHu4/QoryOcPY0f1NO6xL3orvrWtMnd91Vuzn7mC3uDStRdVQ/V+3gLN/kll3T314E1GN0e/HWqykCaYZAaliX8RKQl56EqHjqTPbhmZf8xULpTPlIs0prxopABkYgNfo04IHSKUpenLh7XSPGlntfTNXPRAJWfBVFQBFQBP5LCKiJ97/U2lpXRcANAlCGEIaBPxVFQBHIGAiA4CAMCH8qioAioAgoAs4RcOxbdp5ejygCioAioAgoAoqAIqAIKAKKgCKQ4RBQYpThmlQrpAgoAoqAIqAIKAKKgCKgCCgCyUVAiVFyEdP0ioAioAgoAoqAIqAIKAKKgCKQ4RBQYpThmlQrpAgoAoqAIqAIKAKKgCKgCCgCyUVAiVFyEdP0ioAioAgoAoqAIqAIKAKKgCKQ4RDQWekyXJNqhRQBRUARUAQUgaQIYMpuV6JTc7tCR48pAorAfwUBJUb/lZbWeioCHiCAb51Ex0QnfB09XpHy4W+a4Evn+FaRKk8egKhJFAEvQwCkaOjTQ6lvvz5JPupqPl65dfNWGj9uAoWHef6hUy+rohZHEVAEFIFUQUCJUarAqJkoAhkDAZCifCPmka10ZbKxMhXD1YoJC6W4rZ9S2BcLiGyxTI7s6xr/jZQA/wCnX5e3P0O3FQFF4PYhAGLUf0A/IUUXL16Uj70GBARQRESEGEEKFy1MU6dNoZHDR6U7coR6REdHOwQzU6ZMUldnxx2epDtTBYHs2bNTSEhIquRlzSSt8rVeIz2vO8IH3zCD2Gy29Fy121Z2HWN026DWCykC3o8AHpwnC1WgI0GRdOp6FJ2/Fk1XIwIptF5P8p28hfzf3Eb+U7eT/xT+Td9BftO2E83YRpmGzxNPk7sa1qpdi5avWk7FihdLkrRsubI0+qUX6L5a9yXZbzYefuRhOQ5FR0URUASSh0AcxYm3Fx5fkKSgoCAKDw+nqKgoCg0NpcuXL1PjJo3p7elTKUvWLMnK3FWf3vjtBnpl7Cs0dNgQenLwk9SqTatk5++sMOXLl6MlH35An3+1ntp3aCfJQJKMEoiPVeP4jFnTnWWRuB/nDBoySMqJsg4ZNpg6de5ERYsVTUyTUVby5MlD782fS90e7ZaqVUIbfLHhc8qRIwdVr1GNVq39lB59rPstXQNtiDY1klr5mvySuxw77lUa9/o4Oa1129aJ9U1uPmmV3h6fzJkz04SJ42n9V5/RpDcn3tJlrX3rljJKBycrMUoHjaRFVARuHwJxdCUkksIiiSLCYykyPIaVJ15GxlFkBP+i4igiNJYiom0UERLD27EUHBxLJwqU98ga1euJXpQ7Vy5q07ZNkiqVKVOGmjRtQgMHDUyyHxsFCxWkgU8OkOOBgYE3HdcdioAi4B4BkCL8smXLRrlz5yYoTTlz5qQCBQqI8gkltFHjRuI5ypotq/sME1I469OlS5eWFA0a1BeDx0OdHqLnhj8r+XucuYuEyK9QoUI0b+482rH9R8qZK6eQpEe6dZWzECa4d+8++uvAQRe5xB9CqHDnLp2oRasWVKtObWr+YHMaPHQQzZ47m+6pdI/b89NTgmYPNqNSpUtRv/59UzU0GkYr4Ai5euUa/fXXX3TmzBnZTum/tu3aSJvmz59PskitfFNaHvSdHDmyy+nZsmZNrG9K80vt8+zxqVqtCtXm+3n71u307qx3U3w5+76V4ozSyYkaSpdOGkqLqQjcLgSaVshLRfNlp+yB/uQX4EuBvhwqxwoVR9ERbxKCVmB1tsUySYqJpfDoGDp7IZiOslXalZQoUYIqVqwgSZo1b0qLFy1OJFPID1KqVEmqeHdFOnTwkGzjnz2JSjygK4qAFyFwb5V76eiRoxKe5kXFSiwKSBEESxgYQBxAhrBdvHhx2rx5M8GbAO/tmLFjaPSo0W4VZ1d92lx4yKCh9Pfxv8WTMIa9R1WrVRVPzLmz50wSt8tcuXNRcFCwlNkkzps3L50+fZrWrlknu6C82cvE8cmzkq9b+xktWbxEFN4OD7UXL1KXhzvTxAN/JWYNj0hYWFjisyvxAK+AHMD7hOP2Aos7jqc0vCxfvnx07dq1RAwQMhUZGekwjBDtC5LiqBwtWjyYWLQqVavQn3v+TNw2K7gvsjMBCLoRZHYlWbo7furUKXrumeFJzsGGqzJnZaKBiAXUyV4CEyIFnOULwgLvp7OQSeSN+x2ho+4E2GXOkjmx7mhP5A8vqzNx1e6OzsH9fOP6jcRDMFRcv349cdusuMIEaezrZY9PHu4jkE8+Xk4nT56SdfMP/cVR++J5kIuNl47KY851tXRWl1vN19U1U/uYEqPURlTzUwTSOQL+PoHsKYojP1scBXBIMihLoD8TI9arQIqgXsXwMeZEHD4XR+HsRQr0cx/i1rxFc0Fm1cpV1JWtujVq1qBdv+6SfdZ/7dq3TSRGeLm35vAbFUXA2xGA4tWwUUP6ccePEp7mbeWFYmIECiL6FhRJlBvrxYoVE8UUXqTGTRqJ8cN6jjnXuvS0T+Oc4OBg2r//gBAjKF7uiBHGPNlibayk5SYYTBDyN33aDLF+T3vnbapUqZIUZeXqFbRw/sJEb/PjPR+nlq1bUb8n+tHktybThfPn6Z3pM63FdrseExND6z/7nPrxuCx41CAgjEM4zK5y5UpSl40bNrJx5wPBCWRp6FNDqUHD+oLl/n37aeaMWQRFFZ65YTzxRf2GDSgLrx9gkvXeu+/RkcNHqHz5cjTxjYk07tVxgg2ug9BDX26r8a9NEO+ar58vgRTBOzaw35MUmCmQhgwdTJXvrSwkYgffb/AGAB8o6LhWA74PoeD/8dvvNGPaO3TlyhVkLXUoVboUrVu7jto/1EE8Y4YYFS1ahMMOZ/Az+TeqVfs+8SbCQDXrndl09OhRcndcLpDwD17+2e/Ooulvz6CffvwpHjsnZS5XrhxPDDKE7rnnHrn/dv6yU8rcqHFDGsCRApD5i+bT14z3iuUrk+SLcwcPG8z3wj0UwYTqJ8Zi9szZHCYaQQ937UI9e/ck5Afsgem333zHZbo5tNLU7dix43Q3G+b+ufAPDX5yiIQCdmJijCiHfdym8FxdvXo1oZbxC9wTKCvk559/oWlTpjkkpLifYQDMy21ZjEM0gena1euod59e0rbn+T59Y9Kb8u5zhgnImat6WXEvXLgQPdH3CSkX2mLLlq005Y0p1K59Ow6jfESueeLvE/Q+GyiBEQReU4RYwkBy6dIlWvz+B/Tn7j00l0MvIda+JTss/5Bv124PU5EiRSQ091N+z3/GhgaIo3wjuI2eHf4/eovLZPQAtHdL9tr26dXXIYaWy6XpqobSpSm8mrkikP4QiIqIpZAwHofAE1RF8nowh9AFMVEK5n3BoXEUxuuhIbwMi6UbbBiN5PVwsCQXAgsjwlMOszKw/JMVBMXjwQSiZD3tt12/ScgcLIuQB+o9IA/p3/kFr6IIeDMCx1mpunDhAjVp1oRy5MzhdUUFycEPCjRICpbwKEBZQ3+EJwPrhgxhXJIr8bRPN2U80Peh9MDoAcs1PGvuJHee3FStWjU6duwYLVv6oZC4PgmK3vKPV0iYFsZGzZs7X8jGxx9+LFnuZkXuw2UfynoetsTDs5QSqVL1Xgkx/PvECYKFf+Lk14UcQJHE86hb927UPWGcziPduxLqiTK8O2culWEShVkAIaNeGEUtWrag71gph6IJJRx5gexkSghnzJzl33FduZiY5uJyQ4ABCOCxo8fiFf6IcJr0xiS6q+RdtPSDpfTdt99T8+bNmAwNk/QjRg1nxbIlk4iv6ZOPPqFq1avR+Inj5Bj+PZjgLVq35jPCs7YhK/QgUxBTlmbNm9Km7zfR0iXLqARfB+fDM+HuuGSS8A+kDAQb50HJdlXmUaNHETyPILdfffEV1atfjx59/FEhir/u/FVy/IBx2/DlRiF7SfLlcTPFixcTL9+3X38j99kLL74g52Tjd0gWxvWuu+6S6ISDBw9Sq9YtqXSZ0taiyrqpW40a1emLz7+QuqPN+vTrQ2dOn6EF8xZQABsPChcufNO5de+vQx8t+4g2MuYIG32e6+NI0Jbw0O3ZvZs+5rZB+PioF0by9h5atPB9uR8GDOwvpzrDBAdd1cuK+94/93GI6Q7JD9EZ69etF8PN0/97Sp5T89+bD/cxe4dfIZBlkDGMszt86DBNeXMqXbl8hXA/+bLHzFHfkowT/mF8IvKFR3MBt+MFJpYg73h/O8v3BPcr3B/N+P6FwDP3YMsHpV878nQmXOq2LNRjdFtg1osoAukHgcgYGz+kbPzM9CX8scGSomNZTcKENj7Eljde8nY4/2KibEyKbKy0uCZGiHUuUCA/rVm1WhQwWKjwAsSD0foQ/OLzL2U8Qgt+QCJEpv1D7dhydVkscTXvq5l+QNSS/ucQgBcGFvbAwAB52RtrqbcAYQgPvBtQoLCN/geCA68Rfthn0rkrt6d9GgQC4VFGAYenBOvOwp6s14VFG1ZuCBSnx3s8JhZpPD868hijHKx8f//d93Ic1nQodgfYsr/pu02yL7n/MIEAFF0YZgoWLCihVyAZIGgIEYKCufuP3aLMYkwkPGYw9BhDDojl7t93U5/NfeTSwLnuA3WljO/Ojh/jgbBCDIivVr0qXbx4yW0R4VmA9wgCBTQXh0CNGztePDHY9xd7oPz9/YTEYYwYiCSIDQQKb0P2lkChhwegabMmTCIPiGL8w/c/UN26dah+g3qc/gckF9nw1Qb2aM2T9StMPJ8b8Rzdfc/dovRip7PjcoKDfwiddFZmJEfIph+XHxhi3A7Gjt19T0WC4g7SYLyw8DAWL1E88QrIFyRp7JjX6Bf21EBAhNAm5l7DvkmvT5aQS5DZufPelTE3aANHgvaFVwqCiRZwT4156RXxQH298Rta9vHSm06DR27b1m2yP3v2bOKtQ9iko/sbhkF4EiGYaAh9cdrUeA/WPYxx+QrxoebOMJETE/45qhe81UZw3/z5514hixiDB6MN+g9k6eKlFBUdzZ6dK/TSKy8KJuiXRv755x96afTLTMKy0SW+R7/n+8lV38J9B2PLyy8yVjzl/4YvNxBCUW9weCBCMo3Y5wtv4gP17hevKkKR4Zl7f8Eik/yOLZUY3THo9cKKgHciEMMkx+YfSzFMjqKixajE5IgVpgQLMvMlsvE83lGiTNk4/IHTcsiLK+nYqaMchiu+dds2VJItkRBYLKF4GDly+DAdYotVO1ZQENIBhQSWy1idZtRApEsvRgAKGSykexyM27jTxTaEB8o7vENQIqH4wTABRQ5eIzMxgydl9bRPmzFGCClr3LSxTMDQs3ePROXb1bXOnD2beNgM5EfYX1rJuXPn6Y/f/xDLPojRzHdm0cG/DlLt2rXkkn379yX8jMDTAVm5/FMZpwUPA36YEn3h/EV0kq3i/kzo4PExYtaL87meEKPz5y+YU9n7EX+9I0f+VWINMTTP1LJly9KsOUlDB/PlzydeJpA7/OYtnMfKaLynqGfvXkmI0dEj/5b1SIJnD4QE3gCIs+OJhbRbcVVmJO31RE+ZrdDP1y/xzPz58yeuO1sx+R5jAmAEoXDwmFlnEzT3zelTpyUZ7nVnYsUaM6ee5fsPYXkQ9JkLlrYweVgJxVFuZxBmEFGMf7MXEAMjEez9s+FFmiCYJdKIJ5gkp14m37r315XVt2e8bXbJEmMM16xaI14lTECCdDD0fPP1tzK5SZLEDjZK3FWczp5hrBK+g4ZniiGYMGjAW+UoX3jZQHxxvTp1a3M0Sjht3bLNwRVu7660e8Lc3nro1RQBRSCVEIjlp0KUD3uMopkKMenxy8Reozgftihj0oV4ogTlSggRL+FhsvFYI2eShQeywqUOWbniU1nCktqrd0/CQGArMcLBL9Z/IS78F18ZzWOZbGJ9glVTRRHwZgSgcLZu24p+/eVXOnHypNcV1RAjeIjgKUIfhJcI5cbAdRAXkCWTzlUFktunkRcUrV0748cUgnR4InjOJFf8A1Ku1sCrgMkXMJ5n4eIFHCrXnbb8sEUUZJRj9POjebKCvVIkhIiZ8iEs8fWEiR4wdvLJwQMltKjnY71knFTJUqXkHPwryeOlIFAk4/BQZSlSJD5EC9gXKFiAxwQlHcciifjfqQTlHuT78qXLsvv+B+4XUruPZ+BDe2Ls0+yZc+QY2hTjueAtgGcAsurT1XTjRvzAf3zbCqF9GDtjxBpqVqp0KdltHQ/m7LghZiYfs3RVZnix2rZrK7MKIpQOhBJeGUNiTB74uLi9GGJQqnRp8XzgOMaiAQOMK7tVQZ3v4TBGGDvg8USfKcTtdOLvv5NkXaZsGcEXO4EN3llWApQksQcbuD88wcSDrG5K8vNPP8vkRr17PCHjuXC/oS/ifgCBQYgfQuEqVCgv44ke6tiBx0zuoOPH4+vsrG+dPnWGjQn38vMjsxBJYIbw2T179ojHyVm+MEKgzTGNP7ySmzf94NEEGTdVLJV33Hy3pfIFNDtFQBFIXwgEBUdQZlYuwvyjeUY6nrUqnImRHzxGHEHH73HeJZMv2HjDRpjKO5aiLZYv+9rWq19fdk2bOk0sUOY4HsiI+baP296yeYsoFojB3soDRo2l0pynS0XAGxGARXT7th0yqQCUM28TQ3hM2RDqA+s5lD6QJZAjeI2gTLuT5PRphNRg/BUGhtepG2+xxjig1BZYq0G+EG52+NCRxAHlKbkOFNs1q9fKGKIOPEnB9m3bxJo9YtRI9g6t4FnLslDPXj0IZAThQxiLgdCo+TwWBbPnQTDjF7D9fdfv8pwLZu9cEIcbQdmEZRxKY1RklKTt3KWzENJy5cvL89AZMdr7517xXGDQ+opPCstYJHwrCKFcGMAOYodZPIODQ/g+PEudH+4iY3Ce7P+kGKcwZgcExAhCyl6fNIGa8jiyvbsJAABAAElEQVQPMwAe4YQgehFcxi5du4hXESGi+TkUGuLsuDNi5KrMCF2D5MuXVyaTGFBvgIwJM6FuV6/Ge6ke7/kYff7Z53SDMTSCfOGZeG7Es+KRQNgX6o6xU8bLY9I6WmLMW9NmTej5kfFjkuzT7GQDB0jn2PFj6TfGFutZud3tZeTzI+jTFXeJtxXjvXB99CVr/iDBnko0nwtxhomn+ThKh9A1qROHCW7ZvJWq16wuY9QwqQlI+vCRwwkhgyBQeL9DbvB97KhvWeu3g8kTjJevTXiNDQlbOUz+AZ7AoxZNnDBJJitxli+eRbgejKQQeJC8QZQYeUMraBkUAS9CwC8LjzngWef8fNgr5MdT+sbK5yGZAjEp4h/7kijWj/f58rgE9hT5ctgdpvN2JvdzjD2UMCiNVvlh0yZRGGqzCz2EFQZYX6M4dg8vFbjwMfvO5+w9gkRERIrlNSaGY/tUFAEvRGA1j5+LQ19JgZfjdlTHECP0L4wHgFUXCjAsxSBECOXBhAAmnasyedqnkQes3xAoQQhNQmgslFx3EhP9b5gR0mIWK0hkVKQsUWZrKBKeMRiXiO8YvTzmJerYvpNHH51GZigbfsjTyAoeOwTDzWM8LmP9Z+tp/NhxMvMcZp8DRhirY8aLoE6FeTauYXwMcpa9DTAEQd6c/Ba98OLz1LFzRznv3LlzNPWtqYkeH5CDHkyyMIECZo9D25jnnD0GmBENY2qe/t/T8sFc5A+CNXfOe1iVa+FD2Xh2QhAq+cbkN3lWuHIyW94PbJG3Ciz219lbULdunURihNBBTFEO0ox6zJwxU8pkiJGz4/CUYBZBlN2UG3i6KjOOwYPVqUsnAsFAKCMMYXjeQ0DWMC4HY1hiuW9hwgkI8sX4mNd4Nj/ghvBFTPUNUoKZ3UwaEFNn/RHje+AFQmimKa/1fvrqy684/LCEzHBYk72A8FCZ2f3kAgn/8K0szP6G+2cfj2/DxAUQa/7YNtfAOkTeafgGhp0AA1eYoO7O6mWuYe5js20uARICb2i7Du2FuKDNEOaGiUEwNhLk/sGWzeW+B3nHpBeGpNr3LWv9MKYP+WLc3zPPPi0GipUrVvI7f7uEbLrK9xueNANGBownxMQP3iA+FcpUjPOGgmgZFAFF4NYQOHz8EHF/vqVMwsLDKGL8N+Tjz9Mu+PjxL36WKmz78DNcXjIJyzg+Bh0QlqW4cBtlfr0VW9Sy3tL19WRFQBH4F4HU6NPIDQrr4WOHpP9iJjcQIihyUAqh5IMsQdEBWYJCjH5eo2pNHlvo929hUnEN4VuYecuZwMOEaaJTIqZOIEpGXnx5tHiszLb9csJrr980DbN9GrMNjxo8bNZJY8wxjNECdo6OmQkvoNTaC8qMMEbTLvbHHW2jrdB28JLZC66FPB2Vwz6t2UYYGCYnwKB+eBZwH1jPd3fc5ONq6azMuFaWrFnE2+aIyKA+ID74ORLki/NwHydHYBRwlqfJBzjig8eOvvlj0oBgxcXxN/0SyLvZ70n+Jq390h0m9umTs437BiGWGDdlSJQ5H9fFPW5mqTT7sbTvW/b1Q774PpL9N8dwrqt8cdybRD1G3tQaWhZF4A4jgFjuvJf30438VdgjZKM4f1aM+IUTh1nnYtkrBJeRP7OhSP5xeB2UK3YhUd7rByjKQRz4Ha6OXl4RUAQYAQTCLuLZnvrzdMAY2A7PEBRJZz+Ms4kPnk0b+KJh8U8YI+PoCtev3fyxS0fpHO2zV/SQBiFZIDOOBM+wcB4I76k4IiLmXBAbZ+JKaUeZ4SlKjjgiWOZ8XMvV9Uw6Z0uQSiuxtE/n7rh9erPtrMyS341/iaxJb5bu6uIsX3O+s6U7UoTz0DauSBHSWAkkto14kr9Ja790h4l9+uRso987+4Crq7a171v29UO+1g/XWsvkKl9rOm9YV4+RN7SClkERSAUEUsO6DCUBD78YGTPkqTPZh2de8hdrkjPlIxWqp1koAv85BFKjTwM0KCzo27Fs1Yahw6Ww1deXp55EX4YFWOW/gQAs+vju0WGeGdQREXB3/L+Bktbyv4CAeoz+C62sdVQEPEQAyhDCFvCnoggoAhkDARAchL3gT0URcIQALPpmAoaUHHd0ju5TBNIjAo59y+mxJlpmRUARUAQUAUVAEVAEFAFFQBFQBFKIgBKjFAKnpykCioAioAgoAoqAIqAIKAKKQMZBQIlRxmlLrYkioAgoAoqAIqAIKAKKgCKgCKQQASVGKQROT1MEFAFFQBFQBBQBRUARUAQUgYyDgBKjjNOWWhNFQBFQBBQBRUARUAQUAUVAEUghAjorXQqB09MUAUVAEVAEFIH0ggCm7HYlOjW3K3T0mCKgCPxXEFBi9F9paa2nIuABAvjWSXRMdMLXwOMVKR/+pgm+eI1vFany5AGImkQR8DIEQIqGPj2U+vbrk+SjrujvkK2bt9L4cRMoPMzzD516WRW1OIqAIqAIpAoCSoxSBUbNRBHIGAiAFOUbMY9spSuTjZWpGK5WTFgoxW39lMK+WEBki2VyZF/X+G+kBPgHOP26vP0Zuq0IKAK3DwEQo/4D+gkpunjxonzsFR/sjIiIECNI4aKFaeq0KTRy+Kh0R45QD3yDx5FkypRJ6ursuKNzdF/aIwADW5YsWSgsLCzxYtgHA5y2VSIkunKHEFBidIeA18sqAt6IgM1mo5OFKlB4UCT524h84pj0xPHnXuv1pID6PcmXnUg+/syM4EziJRQuG49UzHT2EEVOG0SZAjPdVC18WPKd2TMoc+bM9Puu3/nUOLp48RLt/HknnT59WtJ36NiBhj01lNavWy/bIaGhdGD/AZcfHLzpQrpDEVAEHCKAPme8veizQUFBlDVrVlFCQY4uX75Mbdq0obenT6URz41MFjmqVbsWjXxhJI14dgSdPXM28fply5WlOXNn0/btO+jq5SsUg2fLyZO0dcvWZOWfmKHdSvny5eiVsa9QoUKFaPbM2fTF518SSBK8YHiO4WPVSz78gK5cuULDBj9ld3bSzfYd2sm5a9esS3KgYaOGVLpMaVr6wdIk+715I2eunPTx8o9o3nvz6fPPPhfCe+36dZo4fqLXFHvY08OoTbvWNHjAEHkHdO3WlR7v+ThlZbLUrWt3CroRlKKy4l0DQfurKAIpRUCJUUqR0/MUgQyJQBxdCYlk9hNAgdGxTITiyJ8VjDhmPwi68YW3KJJZUQD/Ing9wIfC2Vh7sUB5KujkZQQrYLly5QQtH/KhXLlzUfbs2alX7540nJWp48eOU7t2beX4fbXuo8BMgVSgQAHZ/uD9D2j5JytkXf8pAopAyhEwxChbtmxCkkAcYLXPkSMHXbt2TYhEo8aNRJEeNeJ5Cgv915rv6qq9nuhFuXPlojZt29DC+QsTk5YuXVrWGzSoL4SpUJHCHI7rRw/BCOKGqCRm4mLloU4PCSmaN3ce7dj+I4EQrFy1gswzAwRp7959dOP6DRe5xB96oN4DVLBQQbInRtWqV6NWrVumK2JkPC9+vvEkAc9ftLE3yd/H/6a/DhykkJAQue9Aiq4ygZ390Se3RJonTJog75Znhj3jTdXVsqQzBJQYpbMG0+IqAmmNQNMKealovuyUPdCf/AJ8KZDZkB+HOXAUHfEmIWhFPEWxcRQRE8vEKIbOXgimo+JGcl66Tz5eTksWLyFY9R5+5GHq178v1alTW4jRxUuXxGLbv+8AyQBW2llzZlKjJo2UGDmHVI94EQL3VrmXjh45KuFpXlSsxKIYYoRlYGCgeFZAjrBdvHhx2rx5M+XJk4fg6RkzdgyNHjU60cuUmIndSokSJahixQqyt1nzprR40eKbrPVDBg0lKMJQzsewh6dqtapUtFhROnf2nF1uzjdhTAkOCpYym1R58+YVb4MhMyBG9pIWXhLglYuJ4HX2wtgLSAg8cfDI2QueeyCljo6ZtKiDp96SnDlzUlRUVOL9huvGxCD42bngnFD2xnviUUF7IdTNpIUxKzIy0mGoW+7cuenGjRvyXrC/utQ7O9fb4gX68osvCT8Iyg1P0Toe57bpu01JTrcvg/Wgo7r4+fny+8X9ZMvwLCLMEsTMXrAfZbaG+dmn0e2MjYASo4zdvlo7RSDZCPj7BFJkeBz52eIogCMSEDUXyGFzNvYWgRTBaRTDx5gT8UQNcRQeFUeBfjeH0Dm7MF60v+78VYhRLn6hOhIoUv9c+Ifw8lNRBNIDAvBQIPTqxx0/ivLpbWU2xAjlQvgclHiM50C5sV6sWDFRgtHnGrNBAsYP6zmO6tO8RXPZvWrlKkI4VI2aNZyGvwYHB9N+Do8FMQKxcEeMMObJFmvjtLmpVKmSgun0aTNo+9btNO2dt6lSpUpy7ZWrV4inauCggbIN70PL1q2o3xP9aPJbk+nC+fP0zvSZjoqf7H2du3Sibo92EwJ5iY05i9mjDWUeyv2gIYOoUeOG4oU7ceIkzZoxU+qLi6BM8HDBs7Zv33657rWrV2nihEmy3q59O873EfGAnfj7BL3PBHPnLzvlmPXfw127UO8+vWnPnj/FqLR0yTIJPx4+8jmqU7eOJN26ZZv1FFkvWLAgvT3jbapcuRJdZwKz+tPV9OmKT29Kh/x7sif/j9//IHjRQKIWLXyf4PWDNz8sPJw+Ya+OObcte/of6/EYe/jzMzEKorWr14ghq2jRIjRj1gwJh67E18Q9hWf6q2PG0iUOowYWPXv1kIiB6e9Mk3LAWNaSvXO9ezwh4YtDhg2R8uK+2bhhI5PuD+SerHh3RXr6f09JFEI4l2fT95to/nsLaPzEcVStWjXJC/fEpNcn0e4/9iSpI0jPMJ6EpAH3U5CxQ4cO05xZc+gwL0HChnI4d4OG9aU/7Od2mjljFj3SvavcswP6DpT+AmPC/EXzpD6m/ZJcRDfSPQLuqXW6r6JWQBFQBJKDQFRELIWE8TgEnqAqkteDI7AeR8G8Lzg0jl+OcRQawsuwWLrB0TaRvB4OluRGmjRtTE2aNqHurFg8N+I5sW5u2bxFzvLjl02x4sXkOJSE50c/L9vf21kQ3VxCDysCdwwBhIReuHCBmjRrQjlyelfoEkABycEPyi6UTSxhFQcBgqcB1nMrGcK4JFcCBbH5g83p8OEjogwjjwcTiJL1vKbNmki6AU8OoHbt2/I4o1PiWbOmcbSeO09uUXSPHTtGy5Z+KEppn75PSNLlH6+gM2fOyNioeXPn04EDf9HHH34sx3bv3kMfLvtQ1vOw4QWepdQQhAOD/ECJnvLmVLrC46ZGjBouCnWXrp0l5O7br78VUpObPVyjX35RLovxS7053PDkiROswM/n0DEfuvfeypQvfz45DjINRR/3Do5zI4lnrVTpUnLc+i8be22g3IN4gLD8/tvv9PyLz1O9+vXoqy830EeMwf317reeIutIj+sumLdAwhoxEUezB5vdlA75I7wyX/78BFzDwyPof88+Q2iLd+fMpYtsrMK58OCVLHkXPfPs0/TPP//Q3Hffo9OnTlGffn3o7nvupkw8nhRk6P4H7pfwxK++/ErIDsItIfA+4XhoSKhEEWDf7j92C/lB35k4+XWpIwgi6titezd5byDd6JdeIHio3p4yjfB+aN22NZOZBkzWVtG5c+dlTBnKfvLEKSRPIqNGj6KWrVrSD0ymQCoLFixAk96YyHXOLAQI9yruI9S1DHtOMZMjiCzGsWEsHaRqtSriYd2/74Bs67+Mh4B6jDJem2qNFIFbQiAyxsahBDZ+P/sS/hCZEB3LahLGs7K7SMYZ8XY4/2KibEyKbKy0uCdGRYoUYUL0LPkHcIgex79DMYOlGpI/YUwRjiOMwewPt8xaJAn1nyLgpQjAC3Po4CEOUwugZs2b0WdrP/OqkhrvDyzjCKXDNjwdIDjwGuFnyJMnBYeCCE/BmlWrhVTBwwEFHXlaw5Cg1CIECwo95AgTKax7MvsYvCdT3pgi5+G58Dh7J/AcwbU6stchByvX33/3vRxHiBqIywFWZO1DsiTBLf7LniN7Yg4gAy+NfpmyZc8mJHPNqrX09cZvJBwYSn999rAgxBBYwPOCMVxjXnpVQt82fLWBln60NDEvQyaXLl5KUdHRTPau0EuvvEi1OcwY9Xckr778qpAA4HhfrZrsNfmB3p39riQ9z+QA5MEqaI+XR78i7bLhq418/SVSLmc4TWJPFuro5+9HA5nQTps6nY4dPcbhjEH0wosvSBugHXv16C3PctTZl+8nhJOWZO8eyCME5AMeJgg8hbXr1EoyXgtkHGV/6pmnhICgLTHODcQHYZkgS3uY6MKgBu8kxpvi/oWnCP1t2dJl9NGyj6ReuMcuXboopMvcE3LhhH+450HUcL1Z78yWvbt+3UU1alTn902AnIedMA7s/n039dncR9LgPh3M9xVI008//sTLZmJIgKdKJWMioMQoY7ar1koRSDECMUxybP6xFMPkKIpj5/h9xy8/TJsQb0FmvkQ2DmWPEmXKxuE3nJZDXtyJdYxRmbJl6NXXxtCLL4+mHo/2lJcwBmabMUYY6wBrHSyQf3LYCCzCKoqAtyMARRWeBYQ6eZsYYgTFDwopPAMgE1CaMeYCHh+MgYFS6ol07NRRkiFMrDV7AuBBgDTkcLKvN3wt6/hnxhhhVsrG7DV+bvizHK7Vg957d15iGmcrZ87+O8sdPEQQYzRxdk5K9wMDe7Hu2/vnXglba9GqBdW9v64o5t98/S17VuZxCGF1epbrBaXdXuB9uXTpspAiHIMXBt4mI8gLglA3q2DclzM5f/6CHCrME1rAyHT0yJHEpEcs62bnWcbRkFUs4Vkp4SJ/TOkOiWTyAbmRMJ4qNGFCDtxL8Hi98uorVKFCeUnj6J91lsIzp89QYSa17sTcR3379yX8jGA8GwThbf0H9qOXx7wk2/v27qOpb70tHjfZ4eRfkYTJP44dPZqYAgTOkLiVyz8VTxDeOfgBg4XzF8ksilt4/BOIEcaAIdRuB8+06GqsWOIFdCVdIqDEKF02mxZaEUg7BGL5qRDlwx6jaKZCTHr8MrHXiKftZh7E1rR4ogTlSggRL+FhsvFYI08FY4xgbUSM/t133y1Kmf25sLDu37ufGnKIRKHChZQY2QOk216HAAhF67at6NdffqUTPC21t4khRvAQwZMBCzq8RCg3BvGDuIAsmXSuyo/QI3hCICsTxqogP8w02aLFg0mIkckHFv5dO3fJJsa8eCJ4ziRX4JFOrpzliSAwhgbeqPM8JgkCUgQPCI5B4LH6mL0fC3jmPZABGTfUsQOPKdshijSea88+85xMJjNgYH8ZR4PzEArYmL0gIMxHWSmvXLkSlShZQryLOP7zTz8Txs1gbA3yAP7AB5MZuBOMw0QblipdKjEpJq6xF9QLbQZShnYGSfhzz177ZMnabt26leAA78u2rdvEUzTl7beS5JGS9gOJg4x+fnRiGWEoM3kd2L+fMN6nAIfBwZOEMEWMAzJeIHh/HAnIJKaML8vtYATeLYT+wXOGCIbXE6Y0x1i5JwcPlBBHTC+PMU6t27Ti0MFnxHgAr5tKxkUg+U+QjIuF1kwRUAQYgaBgfnmychHmH80z0vGsVeGY6QceIxJyxLtk8gUbv5BtPIl3ZGQsRcOF5EYQa3+Fv5eShZUyxNhj8DSsfQhVyJQpUMYUIY0vKyBly5blsJwH5KUPS62KIuDtCMCTsH3bDplUAMqqt4khPKZs6HdQ/hGCBLIEcgSvERRnd1Kvfn1JMm3qNILXxAgUekxvXbhwYbOLOjzUXsgCpsOuUzfeO4JxQKkt4WHx4VWNmzRmL8ARh5MXOLsmyA3K+ebUN2j1qjXiDWrO4ZDFePY8M3YJYySHjxwuIXMgM3j+QTDpALCL9xaWpZr31aS2/BwzspbD7OoxiZwxazqH1F2nvPnyiJfHHEd4FkK8xo57leCZqM7eJ1wbE01AYZ/z3uz48LoX4j0k5jwsQTb/5Ocjxs1g1jco95gcwl4Q6vbahNfk23G1OEQPnq2dO3dK+7vK3z4f6zbqDIGHJ4af1ZhMITUEEQKY5GHEqJG0cvkKysxkHXnjXfHmG2/Rko+WcFjfcZkAwsb3KySIZyyEXLt6japUqUKYROLbb76jMmVLc1TCSzLmDN902rXzVw5zbSozCmJM1yPdHmGik5W28YQVGC8Gcjx/3gKZARH5mZn0Dv51kDChBiahwHkI71PJuAgoMcq4bas1UwRShIBfFh5zwLPO+fmwV8iPv2XEY4l4fqr47xhxjmzTpFg/3ufL4xLYU+TLYXeYztuZGEUML2PEkkPw0cVt27bTnJlzZBsWbIg5jhjyEydOyMBcxNyrKALejsBqHmsTh76SAi/H7aibIUZQaDH5AhR5KNLwhIAQoc/ly5fPI4/R/Q/UFYMGiKBVfti0SYhR7bq1KYSvAcHMZRA8B+ANwLgTKKnuJCY6qbElgr0dkMioSFmizDaLQQZED1N3P8Kz4yHMqmP7TjxrZrSkdfcPs5dNeXMKYWa7IUMHS3LgsW7tOpn4ATvgFYHi/GDL5lJHKO/4ZhJmW1u04H0Z1zOYz4XXBzPhmVA4eIngSWrEkyzAy4HZzjp17iTed+SLsUkY3N+uQ3sZ4A+vBj50/R0r9ggbRHgj6gZBnUFkrffYm5PelA/ddmEyAIL7C4+/qlu3DoVHhMs5wAsf8M2fL7+EpmEc05rVPCaKwx1xD7jLXzJJ+BeVgD0I2UY+v879dQgf58a9deDAAfn+HNrNtF2S9rG0F+qDuuCeiIuLH9+GPCF43o8fO05miMMscSZvhNCBqMydPZf68QQQaGPMWvjLz79wu6+Vc+HJqc5jhhCCh3BBXD9r1iyULeH98tYbU+gFHn8FEox8QVQn8ngqhBfivkSoHz40DoGnEMTfyNfsNcIYNrSXFX9zXJcZBwGfCmUqJt9XnXHqrzVRBDIMAoePHyLuz7dUn7DwMIoY/w35+PO0Cz5+/IufshfbPhJKx4+LhGUcH4MOCMtpXLiNMr/eiqdAjSc4t1QIPVkRUAQEgdTo08gICuThY4dEoYOSDEIEpRSKNxREkCUYLqAow4sExa9G1ZpJPBup2SSYJQ0zhDkTzPBnQqOcpXG239TJkAmkw1hGeKycyYTXXqerPH02BOl8eSAlxpgYo471POADr5qZxc8cA44gGSAu1mvDe4HpqTFJwK87dwmZwDgrTMJgnUYc52Mac+QL0mAE+yHulPEsTADg1zdjicz51iUMUGjrlORvzce6DixAyFxd15o+Oeuu8sZ4H3gJrVgjb5QFZN/sxzrIqlXQhv7+fhJaaN2PdbQhsE6L+thfS7e9EwH1GHlnu2ipFIE7goC/nz/lvbyfbuSvwh4hG8Xxy4PfEhSHWedi+QXNYXTkz2wokn8cXieKA79z8l4/QFF8rooioAh4HwJQmBctWMSD1vtTfp4MAJ4hKH/OfvgQc3zwbNrUJZoV/8uXLjvN/Dpb8lMqVqXf5HGVQ6ygMDsSPMOMdwXHL/5z0VGyxH1QuI3SnbiTV4AlSI297Nj+I3Xq0knC8MwxTMawjr1bVsH5jj4ai/2eCEiCO3Gk7Huav7O8jafH2fFb2e8qbxPmZp8/2tNKaO1JEdI7a0Mcg9FA5b+NgHqM/tvtr7XPQAikhnUZLxQoFjESouLZCxlzeINQwVLrTPnIQDBrVRSB24ZAavRpFBbKryiMHLbEG67Lzx4KeEzQl423wvUJetQdAvDmVK5cmb/dk4M9U9dkJjRHJMVdPnpcEVAE0h4BNfGmPcZ6BUUg3SAAZQizS+FPRRFQBDIGAiA4CCnCn8rtRwDeHHwzR0URUAS8HwHHvmXvL7eWUBFQBBQBRUARUAQUAUVAEVAEFIFUQ0CJUapBqRkpAoqAIqAIKAKKgCKgCCgCikB6RUCJUXptOS23IqAIKAKKgCKgCCgCioAioAikGgJKjFINSs1IEVAEFAFFQBFQBBQBRUARUATSKwJKjNJry2m5FQFFQBFQBBQBRUARUAQUAUUg1RDQWelSDUrNSBFQBBQBRUAR8E4E3H2vRqfm9s5201IpAorA7UVAidHtxVuvpgh4NQL41kl0THTCl8Ljv3fiw980wTeK8K0iVZ68uvm0cIqAQwRAioY+PZT69uuT5KOu5kOYWzdvpfHjJpAnHwl1eAHdqQgoAopABkFAiVEGaUithiKQGgiAFOUbMY9spSuTjZWpGM40JiyU4rZ+SmFfLCCyxTI5sr9S/DdSAvwD9AOv9tDotiLgBQiAGPUf0E9I0cWLF+VjrwEBARQRESFGkMJFC9PUaVNo5PBR6Y4coR7R0dEOUc6UKZPU1dlxhyfpzgyNAIx7WbJkIesHdrEPxj+9TzJ003tcOR1j5DFUmlARyPgI2Gw2OlmoAh0JiqRT16Po/LVouhoRSKH1epLv5C3k/+Y28p+6nfyn8G/6DvKbtp1oxjbKNHyeeJpcIVSiRAl69LHuNOnNSfTa+LHU7dFulDlzZjkFH58cNGQQ3VfrPldZ6DFFQBFIAQJxFCfeXiiAIElBQUEUHh5OUVFRFBoaSpcvX6bGTRrT29OnUpasWZJ1hVq1a9HyVcupWPFiSc4rW64sbfx2A70y9hUaOmwIPTn4SWrVplWy80+SqWWjfPlytOTDD+jzr9ZT+w7t5AhIEp4lEHysGsdnzJou287+tW7bmgYM7H/T4fz580m5q9eodtOxW9kxdtyrNO71cSnOolXrltTl4c6J51vrnLjzDq3kzJWTvtjwOXXo2IHy5MkjbfNgiwfvUGkcX3bY08Po07UrCe8jSNduXWn1Z6ulrCh/SkU+oJxw76U0Dz3POxBQYuQd7aClUAS8BIE4uhISSWGRRBHhsRQZHsPKEy8j4ygygn9RcRQRGksR0TaKCInh7VgKDo6lEwXKJ4TfOa5G1WpV6d15c6hPvz5UuHBhKlmqJPXr35emvzON8DKCta5zl050b5V7HWegexUBReCWEAApwi9btmyUO3duMUrkzJmTChQoQFCuQSQaNW4knqOs2bJ6fK1eT/Si3LlyUZu2bZKcU7p0adlu0KC+GDwe6vQQPTf8Wck/ScIUbiC/QoUK0by582jH9h/lOQKS9AgruhCECe7du4/+OnDQ5RWKFCkiyvHd99ydJF3T5s0I1/BnT3hqCvDPkSN7irOs37ABtWsfTwTx7LTWOcWZptKJxvPi5+tH/gH+cl8FBgamUu6pk83fx/+WeyIkJETu+cd7Pk5Xr1yht96cckve0gmTJtD0ma5JeOrUQHNJawQ0lC6tEdb8FYF0hkDTCnmpaL7slD3Qn/wCfCnQl0PlWKHiKDriTULQCqzOtlgmSTGxFB4dQ2cvBNNRtko7k8FDB8lLctLrk2nrlq2ioI18fgQ1f7A5dez4EK1c8amzU3W/IpAuEACpP3rkqISneWOBobRCsISyCuIAMoTt4sWL0+bNm8XKD0/PmLFjaPSo0XLMVV1gda9YsYIkada8KS1etPgmA8mQQUMJymiOHDk431cIRpKixYrSubPnXGWd5Fiu3LkoOChYymwO5M2bl06fPk1r16yTXY6s/RPHTzTJnS6/++Y76s7e6yZNG9PBv/4lUdi+evUq/fH7H4nnog4IwYJn3ZE4KifSwZsAQgRPnTPBuTeu33B2mPLly0fXrl1zetz+gLuy2h/Pnj07G8AiPQonA6GGtxGhmJCsWbNSTAwCrx0L7jG0j6v6Wc9MTtlA8m/cuCHvJGseWBfcszPuN/7F/csvviT8ICh3Vg6rW8dj7DZ9t0n2mX/2ZTD7sUT94Wm13gd+fr58Pfe+BhghEOIJYmYvjvK1T6PbaY+AEqO0x1ivoAikKwT8fQLZUxRHfrY4CuD3P+hOoD8TI9arQIqgXsXwMeZEHD4XR+HsRQr0y+S0jnjBlClThn7b9ZuQIiQEsXp39lyqXqM6lUqwLDvNQA8oAukAARCNho0a0o87fhSlyduKDOXUCBRaM6YC5cZ6sWLFRNGDcta4SSPpo9ZzzLnWZfMWzWVz1cpV4nWpUbMG7fp1lzVJ4npwcDDt339AiFEu9jC5I0YY82SLtVGuXLmpFHuYoYhOnzaDtm/dTtPeeZsqVaokea9cvYIWzl9IAwcNlG14AFq2bkX9nuhHk9+aTBfOn6d3ps9MLIf9CsjVoUOHJZRw/nsLhHyB8JUtW5ZWfbpaMAFZHMLhgJUrV2IPeTBt3LCRSeAHgpGrcuJaCB/uxKFv8Krt27efEKIHwmUEYYAPP/IwwXN14cIFWrN6La1ft14OI29fVrZBiuAdG9jvSXOa5DN3/lzZttbZVVkf7tqFevbuKWTvgXoPCKaLFr5PxqsXxuGVn3z0CX3qwFCFc3v36U179vxJderUpqVLlkk5h498jurUrSPl2LplW2L5zEr9BvX4mj0IRPbYsWPy3N/PONhLcsvWtl1beqzHY+zxzM/EKIjWrl5Dyz9ZQUWLFuHwyRl0gO+1StxeuJ9BzF8dM5YuXbwkXsCevXrQ8GdHSMQCygH8W3KIYu8eT1DpMqWdtnXFuyvS0/97isqVKyehqJu+30S4Z8ZPHEfVqsWHXOJ+nPT6JNr9x54kVQQZGsYToDTgZwTIGO65ObPm0GFeOsv3qWeGSX8Z0HegEFYYMuYvmif1mThhUpL8dSP1EHBPb1PvWpqTIqAIpAMEoiJiKSSMxyGEE4fPcagch9AFMVEK5n3BoXEUxuuhIbwMi6UbYZyG18PBkpxImbJl5MiPO35KkgKKTo9He9IEng1LRRFI7wgcP3ZcFNsmzZpQjpw5vK46IDn4od9BuccS3g8YKWDthwUb64YMYVySK4GSBo/v4cNHRCFFHg8mECXreU2bNZF0A54cwCFgbenkyVPiWbOmcbT+//bOAz6Kam3jbwqEDkrv9eK9oKIUQZoU6Sr2XmheEVGxcGliQZFeFKRKLzaUD71Xem8CgnSlBEFDDxASSN/ke5+TzLpJdjYJWWSTPG9+m52dOXPmzH92k/PsW6bYTcXMZBOT6Xlz55uJYZeuL5imXy78SkJCQkxu1NTJ0+TgwV9l4fyFZtvu3Xtk/rz5Zvkm9SZgQp6erVq5ynjL4M2CwVsEW71qtcCTM3TYR2bCPVM9Yrt27pLHn3jceJnQxtM427RtY8KHQ/4MkelTp0seFaAIJbasRcsW0vu13nIh9IIJCTx39pzJa2p1byvTBH1DAAYfDZaJn06U0yryLIuMjEpzzumNtaB6hVB4oHiJEnq8aTq5j5bX+7xmzmHSZ5Pl3JmzpkgH+klt2BeTewgPiClw+M+A/0jjJo3lx/8tlQXKv1HjRql3M2GUP239SWbPnK1irqR88OH7bq9JZsZWuXIlea3Pq3L27FmZPGmK/PnHH4YzwiGDNG8VYqjR3Y2MN/HH//1oxI4V6gnPmPHMXLkqc2bNMePd/ctuI3TxufV0rfsP7GfCUMeMGqvvjTWC/LSmzZqqkFwkp06dlgsakgeuJ47/kYZD3/59pW27trJWxRREZalSJeXj4UP1euQTu34hpCGIkccHu73Obca7e2D/wTT9c4X3CNBj5D2W7IkEcgSBmHiHhgQ4dILkL/hBdECchs0lInpEv3TWyDoN4FcxpI/4WIeKIodOWuyFUalSpQwX/BOjkUBOJQAvzKHfDmmYWh5ppfkpSxYv8alTtQQPPLgIpcNrhBJB4MBrhAfWWe3SGzwmafi2/rtF3xpRtX3bdjNJRp+uFb8gIhCihUk17IgKKSxnpALY8d+Py6jho8x+CIt6Wj0E8KzgWJ01/6ewToAhXmAIU0MBl4M6mUwdFmUaePi1ft16eUmLQ7Rs1VK/6d+twqiFHDt2zHwzj7wrhGshTBDb9qjwwnZ4y+ChgNmNs3GTu824Bg98x4iQ5ctWyLyFc50jadq8adL2QYPN9qU/LpPZ82dLc/UqWOdw9OhRGfL+h859rAUwXq2TbNdzzshYsf/H6m3A3+OAwAB5UQXr2NHjjPiKUIb9BvQzjO3C3t4d9K4RAbiG9erXlTWr16oXaJIZ1mkVB5jku9rGDRvl0/ETzCp45xCmibBThFS7s4yMDe+h5555Xv83BQiEjr++b9EnclfhgYFBfMD7BYPgbXBXfZk7+y/2+CIAY4cwhQDB+yg9fvjsoGgJPuvz5s6TBfMWmPc63t/nz58zY7Hej+bAyb/weYNQw/EmfDLRrIVn9U6NmEAOm12/8Bb21Pd0y1YtZOuWrfrcynyJAU8V7foRoDC6fmzZMwlkSwLxKnIcgQkSr+IoVmPn9H+O/gPSCVPyN8iql8Sh4eSxZjLl0FATbashL3aGf4YwVK2yC7Ox25frSSA7EcBkEWE2CDfyNbMED7xCmBTCcwAxgQk28h7g8bEKM2Rk7J0f7GyaIYyrvRZewLf4sGb3NJPlS5ebZfyycoxQgfIe9cSgAANCq6ZMmupsY7cQcvKkcxM8RDCE/XnbkIMCsdW0WRMd+zLztwpFHWDWeXXt3lXwsMyqaobXduPE37yTeg7wzMDA/czpM2YZvypVqphiOybc8C659n3apb1zR5uFjIwVu6JkOyxGjwe7HBZmnq9e1RAANeu9Yl6k+mWNp0zZMkaYHD1yxNniiMuytfKI5t1ZdvRIsFmsULGCtSrNc0bGVlzDEd959x2pWfMfafa3VpwMcXnvKNMyKqjTs/T4QeB1f7GbDBo80HS1X4t7jB45xniKPfVdVlkFqrAPVpFrGQScJeI89bte858gjJCjhffn5k2bzefW6ofP3ifg/b8w3h8jeyQBEvgbCSToX4VYP/UYxakUUtETEKReo0Q//UYZuUFJQgmTKyOI9BkeJofmGtkZwkDiNVm5Q4f2smLZcuckAeEaI0ePlP379pk4bbv9uZ4EsgMBeBXad2wnO7btkOMnTvjckK3JLjxE8OpYBRgwbiTSQ7hALFntPJ0Awn+QowKzCqegv+c0f6WNlmd2FUZWP5j0/7w9Kf/I8iJb2+ye8Xcms4ZqaNdiK7UIA8LC3u7X1+Q2rV2zznQDYQPr/5/+snfPPrOMUtSuY3NdNg2SfyGP6l8aCgfBDK8CuJfWSfLx3383LTB5r1W7trkWuAYQqOW1MIU1YXbty9Oydc4ZGaunfjKz7ayG3cHLWKVqFeduyM9JbVWr/rXOapteflnqPlK/bq85ZBBF8L7AIwVP0agxI1M0s7smKRqlepEev4MHDgjyfUpqGBy8hs+/8Jw89sSjTi+QXQVDiEn8D6yuX5pYhjEj9A+eQU/9Ip+tvZa5f01DHvHFBbyKtOtL4Nr+glzfMbF3EiCBG0ggPCJa8unkIjIwTivSadWqKFTbgccIJXBxf5Ck4gsOfeEQlPJOkDi4kGwMITOI/8c/kWEjhpnwD4eKKSTb4hvVGdNnOPesVftf8uBDDzpfR0VFCsJPaCTg6wTatGsjmzZuNkUFMGH0NbMEjzU2fC4xEceEHWIJE3N4jax7i3kaf+MmTczmsaPHyorlK51NIXhwnx3XPJr7H7hPkH9VqnQpTdJvaNoiD8jbFqU5NxBfuB/T4UNHjAcoM8fYsX2H+SYeOTTbdTks2YuyV71/KErwVt+35esvv5J8Kh6RvA9vwaAB73g8xHYVyQihek/v27ZTQ6ewjMR7yxAeBYGJ+7rh+MglgejaouszYqnPOStjTX083L9pwKCBJl/rhyU/pN5sWO/du8/kzcDjhpw13JsutcHbgWp64Vo5DuXPwRJfhuG999mUiZondkEG9kvywKTe1+413qsweHjiNVwR18Mb5onfiOEjZc6COer1OWaKUzj0swIL12qJsEsXL8ltt91m/q9BZFerXjUFv5/1+rZq3dK8r1Bk47HHH1OhU0D2aJGGGXM+t+0XlRKPHz9hCmRgP4Ry0q4vAQqj68uXvZNAtiMQkF9zDrTqXICfeoUCtKSv5hJpSrZKIBVF+lBfkiQE6Dp/zUtQT5G/ht2hnLcngzDCN8ptdfL4Su9epinCeHDvCISw4J8kJmyo7GNV90GjMP1nSmHkiSy3+QqBbzXXJhGflWvwcvwd52AJI0wqUXwBXgxMZpG7A0GE3AlUP7PaeRpTo7sbmhwhCEFXW7tmjRFGDRo2kCt6DBiqh8Hw+cY38sj9cDfRNo1cfsXHpfyyJTo5HC0mNsa0wpgdLl/IQOihdDfuY4RQp873PZjuTaddDmcYrFu7Xh7ofL+sdBF7mLgPee8D6aV/t/AAn4MHDzrzZjyNE4n/lSpXNFXy6mrFPoQDIkHfMohKCMb7Hrhf6tara6qrLdS8GMvjlrpv7Bev52mZu3P2OFZlBiFs9x6NTWYLgYl7LRXQm/0WVC8XDLxT7zvi4xHmBr4P65dcENfb9G95Q61QFxUdpVEESeHVqETYsVMHI7iR1zR+7CdGDOH9Bw8IzsGuf7Mh+Zfr2JZpqOZdje4yN5K1rgfuxwVeFrMU7w2X9wqOh3PB+zExMSm3DucL83StIf4mT5ws3XokhdKhYuK2n7bpe26x2ReeHFRZRbglCjHg+K78Rg4fJf00/wpfFGDMly6FCSrLQex46hedI7wTuWT4X2h37cwg+MsrBPxqVrsl875qrxyanZAACXiTwOFjh0Q/z1nqMlI9NNFDVohfoJZd8AvQR1KVKrz2M6F0+uci+TlRt2EOCM9RYpRD8n3UTr8NTfon6mkQmAj4a6IS/iHQSIAE7Al44zON3jGJOxx8yEyqQkNDjSDCxBD5OpikQSwhARyTVXxJgcnXnbfXNTkk9qO79i3wyqBKl53Bw2Qlqdu1sVtvnZM14Ua7AYP6GwFit8+H73+UooS2XTt40yAAXItL2LV1XY8x4aa5rvfTcd2Oa4CKaLhX07VMfN2d87WO1XVcEM2u9+px3ea6nF8FFGIK7LhgfJYQd90P5w27lnPGft44R/Tjzjz1jXwfeOtc32PoA+8NMLPWu+OHz1dgYIAzpNz12Hb9urbh8vUnQI/R9WfMI5BAtiEQGBAoN4cekMslblOPkEMS9Q+4/teSRFSdS9B/YnAZBaoaitGHhtdhcqUuJLk57KDE6r4ZMZSkpZEACfx9BDBpRchq9xe7a8nkEsYzhMmo3QNljJOCZ6/PGOP0G/vQ86G2nYfpt+nXavAGpLaLGuaESas7w98weDgyYpZnISNtXdtgTHaiCO1wHTxtd+3L3bK7c77Wsbr2nxFRhPYQCZ4M43M3xmsVRNaxvHGOVl+pnz31bXet8F4y/xOTO3PHD6LJEk6pj2nXb+p2fH19CdBjdH35sncS+NsIeOPbZfxRN//ETIiKip8MmZ9W3Ak03z7bTT4y1A0bkQAJpCDgjc80OsQE1EzaNHQIX3R4NP0WHx5dfJatb/Q9tudGEiABEshBBDL2FW8OOmGeCgmQgD0BTIaQC4QfGgmQQM4gAIGDsB780EiABEiABOwJuPct27fnFhIgARIgARIgARIgARIgARLIcQQojHLcJeUJkQAJkAAJkAAJkAAJkAAJZJYAhVFmibE9CZAACZAACZAACZAACZBAjiNAYZTjLilPiARIgARIgARIgARIgARIILMEKIwyS4ztSYAESIAESIAESIAESIAEchwBCqMcd0l5QiRAAiRAAiRAAiRAAiRAApklwHLdmSXG9iSQgwngXidx8XHJdztPut+Jn97TBHcux72KeF+THHzxeWokQAIkQAIkkMsJUBjl8jcAT58EXAlAFBV/a6o4qtYWh94IEveQj4+8KokbvpHI/04XcSSoOHLdA8tJ90jJE5jH9u7yqffgaxIgARIgARIgARLwNQIURr52RTgeEriBBBwOh5woXVOiwmMk0KGSJ1FFT6Le7rXxs5KnybPir04kv0BVRnAm6XOiiieHBuQGnTwkMWNfkqC8QbajL1OmjDRucrfcWfdOI6COHDkq//3hvxJ6PtTs0659W6levbpz/4iICNm3b5/s/mWPcx0XSIAESIAESIAESOB6EaAwul5k2S8JZEsCiXLhSoyqnzySNy5BhVCiBPr7S6KqnwQ9H394i2JUFeXRR7Qu5/GTqDiRcyX/IaVUVNlZzVtqyvBRw6VA/vxy/vx5E5JXr3496dipg7wzcLAcPnRYmjRrKnXr1ZVzZ89JnjyBUrJkSdPd/HnzZf7cBXZdcz0JkAAJkAAJkAAJeIUAhZFXMLITEsg5BFrWvFnKFS8khfIGSkAef8mraihA4+c0ik70pagOSvIUJSRKdHyCCqN4OXkmQo4aN5J7Dj17vWRE0bix42X50uWmUdt2beTNt9+ULt26yMB+A826s6fPSPeuPczyP2r+Q4YO+0iefOpJ+eqLryUuDkemkYBvErj1tlvlqHpBo6PxjQGNBEiABEggOxJgVbrseNU4ZhK4jgQC/fJKTFSiROkjRud4MZGaZxTjJ/HxfhIZq8/6wHrM/+Kik9rlDbAPoStQoIDUqlVLdu/e4xRFGP6K5Stl5887pXjx4m7P5sjhI7Jr5y5T+KFosaJu23AlCfgKARQuada8mRQsWNBXhsRxkAAJkAAJZJIAPUaZBMbmJJDTCcRGJ8gVFF7QyLhCOtmLEX/JE5BoQul0tYbWqSCK1dwiXROp1RmMOFLPkZ3V+EcNs2nTho1pmgwa8E6addaKIkWLCPYNDw+XSxcvWav5TAI+SeBY8DEJCAiQFq1ayIb1GyQiPMInx8lBkQAJkAAJ2BOgMLJnwy0kkCsJxKgiCghwaB6Qv0oifwmAENKwuUSkEGmOkckz0tdR+oiPdUiUto/TfCQ7K1OmtNkUEnLSPOfLl0/GfzpO/DR3CZao4qvPa2+Y5fIVysukqZ9pcYYAqVSpoinSsHDBF8nlw00T/iIBnySAELpDvx2SvHnzSKvWrWTJ4iU+OU4OigRIgARIwJ4AhZE9G24hgVxJIF5FjiMwQeJVHMVqWg/KcweoGtIadIaH6iVxqKcoVgVNQoJDRYu21Wc7O3funNlUunQp8xwfHy/r9Rt1fxVGCD2qUrWKswQ4KtFt37ZDihUrJlWqVJYd23fI3Nlz7brmehLwKQJBQUFSo0YN2bNnr0+Ni4MhARIgARLIGAEKo4xxYisSyDUEEvSvQqyfeoziVAqp6AkIUq+Rlu1WHaRFF5KEkinTDUGkK+BhcsQniSZ3kI4d+90UTnjwoQdl9ao1mqsUL1+oFwieo5atWkhoaKjmMyUlrIdfDpfZM2ebbiqo96h+g/pSvUZ1CT4a7K5rriMBnyEAMd++YzvZocL++IkTPjMuDoQESIAESCDjBJJiWTLeni1JgARyOIHwiGjNj4iRS5FRcjkyWi6F6SM8WsKvRMtl3YZnvL6ky2FXtM3VGImI1BLfNgax881X30jValVl7CdjpV2HdnLf/Z1k5JiRUqFCBfl+yQ9u95w6ZZop692rdy+327mSBHyJQButsrhp42b5/ffj+kWBvQfVl8bMsZAACZAACaQkQI9RSh58RQK5nkBAfr1nkSNRS3RrgYUAvZcR8os0kA5ZRPgmRX1JkqDFGBL9NZROPUX+GnaHct6ebP68BcZr9OTTT8obb/YxTWNjY2XunHmy6OtF5nV8XMpy3KhKt3rVaml9b2u54846vNGrJ8DcdsMJfLvoW82X088F3Ko0EiABEiCBbEnAr2a1W/hXPFteOg6aBFISOHzskOjnOeXKTL6KjIqU6CErxE9Lz/n7BehDJZGKHrz2M6F0+uci+TlRt2EO6NAYu8Qoh+T7qJ3eq6iAxyOiahdu3OqvFR3OnjnLogoeaXFjbifgjc90bmfI8ycBEiCBzBCgxygztNiWBHI4gcCAQLk59IBcLnGbeoQckhgYYBKLElF1LkG9QnAZBaoaitFHAPKOdL1GDd0cdlBidd/0zOFwyJkzZ9Jrxu0kQAIkQAIkQAIk8LcTSH8m87cPiQckARK4UQQCAwMl9rO+kgdl55Kr0Hkai8omNT8jirAvjQRIgARIgARIgASyKwHOZLLrleO4SeA6EEAJ7bx58wp+aCRAAiRAAiRAAiSQmwiwKl1uuto8VxIgARIgARIgARIgARIgAbcEKIzcYuFKEiABEiABEiABEiABEiCB3ESAwig3XW2eKwmQAAmQAAmQAAmQAAmQgFsCFEZusXAlCZAACZAACZAACZAACZBAbiJAYZSbrjbPlQRIgARIgARIgARIgARIwC0BVqVzi4UrSSB3E0jEnVs9GG76SiMBEiABEiABEiCBnESAwignXU2eCwl4gQBEUa9Xe0nXbl0Ey9bD3MxV+9+wboMM+eBDiYqM8sLR2AUJkAAJkAAJkAAJ+AYBhtL5xnXgKEjAZwhACHXv0U3gFTp//rycO3dOwsLCzPPp06elTLkyMnrsKMlfIL/PjJkDIQESIAESIAESIIGsEqDHKKsEuT8J5DAC6iMyoginBZEUHh4uBQoUkLi4OImOjpbQ0FDp0KGDjBk3Wt564+10PUcBAQHS49895Pjx47J86fIUtB5/8nG5eOGirFq5Stq1byvVq1dPsR0vfvj+v/Lnn3+mWZ/VFcNHDZeIiAgZOmRoVrvy2v64wS54gTWNBEiABEiABEjg7yVAYfT38ubRSCBbELByiAoWLGhEEibs+fPnl8KFC8ulS5cEr5vf09x4jvq+9R+JvBppe16BgYHy0MMPGpEV8meIHNh/wNm2Xft28seJE0YYNWnWVOrWqysXVHi52vLlK1xfem05X1CQ1/ryVkcdO3WQ3q/1lmefelYF6AVvdct+SIAESIAESIAEMkCAwigDkNiEBHIbAUsY4Tlv3ryC/CKIIbyuUKGCrFu3Tm666SapXqO6DH5vsPTv29/pZbJjhX37D+wn/+7xkq2X6ezpM9K9aw+7LjyuL1asmAn5c9eoaLGicjnssrtNmVoHFhB6kZFJQjBPnjyGz9WrV932g+NGhEcYfm4b2KzMm0nRhmtTqHAhCb8c7rZHCFqM2eFwpNlepEgRwfjdbUvd2I5xkI4Xni6LS+r9+JoESIAESIAEsgMBCqPscJU4RhL4mwlYwgiHRfgcxADCuyCQsFy+fHkzkcak+p4WzY03yHUfu+GWLFlSer7cU8aNGWfXJNPrO93XSR59/BEpW7asCfP75utFsmTxEtPPffd3kkceS9p25swZ+e7bxfL9/32f5hhPP/u0CeV74dkuZhvyp2bNnSXTJk+V3379TcZPGC+//XZIbr3tVoGnadnSZXLx4kV5/InHBeJo+7btMmLYSCMMkH/lSHBI0aLFpEqVykZ0jBs7XjZt2JTmuK4rMFaEHMKmzZimYYfLjOiqc0cd6d6lh+EPxlOmTxF43mZM/9yM6+cdO6V+g3qCa3FIxzjhk4ly9OhR0w+E68uvvCy1a9cyYYMY96wZs831uuWft8irr/eWGjVqSFRUlKxZvUamTZkuMTExZl/XX3aMIbh69e4lTZs1Me8LeAM/HT9BKlSsIH3efF1GDh8lP+/42XSFc2vbro10ea4rBZQrXC6TAAmQAAn4DAEWX/CZS8GBkIDvEMAEHA94EpCHg2d4A5BzFB8fL1euXEkhhpCXlJ59sfBLOXjwoBEgdze+223zfPnzGYEDkYNHqdKl3LazVt7T4h4zuUd43/Rpn8uZM2fl5V49Bf23aNnChKVd0JC0qSpwzp09J71UJLS6t5W1u/O5WNGiUliFhWVBeYPEWheUL58RHfXr15MvFnwhO3Si37FTR3nyqSdl/rwFsnrVamnYqKG0Tu632E3FpE6dOhIcHCzz5s43gqZL1xesrm2fDxw4KDu27zDbZ8+cLUv/t0z2q9AoVaqU3NWwgVlf+9baUrlyJcPRGler1i2NqJk7Z55U1G1Dhn5gcsLgrRo67CMpV66szJwxS3bt3GWE3BOa1wWD9w4eoDGjxuo5rJH2HdurwGlqtrn+8sT4sScelZatWsjC+Qtl0meTpZoKMVQ03L9/vxlDq9ZJrOFN3MgXaQAAFn1JREFUurftvRISEkJR5AqXyyRAAiRAAj5FgB4jn7ocHAwJ+AYBy/sDjwDCx/AaBRgQsgWvER6WeMroiBM0jGvksFEyaepn8rp6EyCSUlvx4sXVUzPTufrChQvyzJPPOl+nXkCeE4TboAHvmPC8pf9bKvc/cJ+GzYXJw+opQuGIwYMGq0ckWpb+uExmz58tzZs3kzUqBDJrEBeL1Bu1ft16adjwLvl20Xfy9ZdfG48RBEDZcuWcXR7//biMUm8JDKLg6WeeMkIPVf3s7Pdjv8ue3XukmY5vy+YtcurkKTl56qR62F6SFq1ayuZNW4wIiVeOKFZx8803m66W/rhUpkyaapaRn/XGW2/IP//1TylUqJARPrN03Lt/2W36hlhs3aa1fPnFVyZfDJ4ieATnzZ0nC1TkuQuF88QYx4BBMO/etVu6rOtiXiOkb+uWrSpQG0k+FZbwtEFozpw+w2znLxIgARIgARLwRQIURr54VTgmErjBBCxhhAkvvEMovACRgYkzQsfgNUJhBngcMmMIZ5vwyQTpN6CfvPFmHyOuXPdHefAh73/oXBWtgsaTVaxUQU6GnHTmLGF8X6lYgfWpVFFOntRtyX1AACAErWLFip66tN0GjxMM/cDC1EsFQ4gheLhaiB7XMnhJYAhBzKzhXlHr9b5R8EYVKVrEiKZtW7eZfClLGB09Euzs9siRpBA6hLIVTfaAde3eVfCwzDp/hLx1f7GbDBo80Gzav2+/jB45Rr1uZ6ym5tkT44sXL5mcsy56zys8UNr982kzZMP6DRpuuNyMF940eLwiVYRtWL8xRd98QQIkQAIkQAK+RCDz/6l9afQcCwmQwHUhYAkjeIjgKbIKMEAIxcbGGi8AxJLVLjODWLtmnebE1NfJfmuz2wkt421ZbEysHDl8xHqZ7vOff4TIbbffqsItnxFAKAKAfvfs2WMEU63atc3YMWYIuvLly8nhQ4fT9JuQmCAF9HwgPuDtKFmqZJo2mVkBQZkVCwz4608z8oLad2gnr2q1OuQRLV+2LEXXVatVdb6uUrWKWYa36Yp60mD9/9Nf9u7ZZ5ZRMMMa28EDB6RH1xfNucKT9PwLzwlC45Cj5GqeGIPVR8nlzu+se6f8u+eLJrQRwuiXXb8YodROxw4P1ro1a52i0rV/LpMACZAACZCArxD467+vr4yI4yABErjhBCzBg5A5GLwiEBZIzIdYgtCAlwRhUtdin02YpOKogRYo+Cuv51r62bx5szRp2lje//B9Wb92gzRucrcRXUM//Dg5lOtueX/IeyZ3B2IMwmCLhnilNkz+YX3eeF22aSGFBx/snLrJ3/IaHhjY088+JT8s+UGQd4TiD8ePnzDeF9xDaufPu1KMBUUbkAMWrR6Zhx992Hj2UIQhKCiv8dK81fdtDfn7SvKp8Hv2uWcEnqERw0fKnAVzJPjoMfnmq2/EkezxCtcKerjOn02ZaMqFD+w3UDwxhiernuZeTZs63VTfw8Csynh47yxftkKeez4pFBIeJBoJkAAJkAAJ+DIBCiNfvjocGwncIAKWMIIAQg4PPDGYfCNfBoIIuSnIB7LaeRqmlZOE3BjLEPL27jvvythPxjjD0OJVfGXWkCtUunRp6fzgA/Jan1eNR+Lrr76WTRs3Gc8Iijfc98D95v5Il9W7sVCLJ1g3mXUdDwooNG3eVEO+7lJx1ViQI2RZfFxSmJzDkfSc4EgwfbuGz6Gv+Pik8Vvtrf2tcMCY2LTV3qw21jMquB1WjxnyehISEo0wwjaMr3uPbrJyxao0ZbUhnB5+5CEjaE6qp+jT8Z+aawaH0ZD3PjBV41A5DtcKeV0IoYN4mTxxsnTTPhFKhyp6237aJou/W2yEL8IkIYZhnhgjVLGMFsl4RfuH4fhjR481y/i1Qu9BBTEGnu48dc6GXCABEiABEiABHyDgV7PaLVmL+fCBk+AQSIAERA4fOyT6ec4yCkySDwcfMpN/eCggiCBukCODyTXEEooyQCzBu4DQrDtvrysB/gFZPnbqDjp06mBKPKdeb72GV2XN6rVmXAiDc3fPIIy5cJHCZpsVRmbtn/r5et6PB9Xh+vbvm/qQztfHgo85w9gQuoj7CuEBxv20ghwKGXR/oYczBwghdJOnTpKPPxpmvGNo5654Ag4Azx48fe62gxtymSwhhPaW4HXlhXV2jCGk0NZd/+iPdm0EvPWZvrajcy8SIAESyH0E6DHKfdecZ0wCHglooW69R84MTczvLiVKlDCeIUx67R5zZs3RPfw89nmtG69euSqh50Ntd8e9hGAYm90NXLHNCu+y7Sh5g7t7+KS3T0a3x6mnzdO5hF0Kc3YF8QlD1bd5C+ea4hffqwhMXRjB2gGixlXYWOutZ6tghPXa9dkdGzBLbZ4YQzzTSIAESIAESCC7E6DHKLtfQY6fBJIJeOvbZUyATfibFiRQxeGZr3oR/P38jTfC8jJ43oFbM0MAXiDcPBW5P7gPkatgwTbc/PXw4cMZFn6ZOTbb3ngC3vpM3/gz4QhIgARIIHsQoMcoe1wnjpIE/jYCEDjIJcIP7cYSgBcIVfzcGbYhJ4lGAiRAAiRAAiTgHQL+3umGvZAACZAACZAACZAACZAACZBA9iVAYZR9rx1HTgIkQAIkQAIkQAIkQAIk4CUCFEZeAsluSIAESIAESIAESIAESIAEsi8BCqPse+04chIgARIgARIgARIgARIgAS8RoDDyEkh2QwIkQAIkQAIkQAIkQAIkkH0JsCpd9r12HDkJXDcCrmWh3R2EpbndUeE6EiABEiABEiCB7EyAwig7Xz2OnQSuAwGIol6v9pKu3bqkuKkr7m0E27Bugwz54EOJioy6DkdnlyRAAiRAAiRAAiRwYwgwlO7GcOdRScBnCUAYde/RTeAVOn/+vJw7d07CwsLM8+nTp6VMuTIyeuwoyV8gv1fPwdw7Se+flBELCgoS3OA0I1aoUKGMNMtyG/DK6JiyfDB2QAIkQAIkQAIk4HUCFEZeR8oOSSB7E0iURCOKMNGHSAoPD5eoqCiJjY2Vq1evSmhoqNzT4h4ZM260V8RRvnz55MOhQ+T7H5fIxyOGpgsPAmrugrkyZvyYdNvecWcdWbT4G3nyqSfSbZuVBo8+/qh8u+Rb+eHH76VI0SJZ6Yr7kgAJkAAJkAAJ3CACFEY3CDwPSwK+TACiCI+CBQtKsWLFBOKlSJEiUrJkSeMV8ff3l+b3NDeeowIFC2TpVG6vc5s0uKuBbNqwSSZNmJRuXwjp279vv/x28Nd02168cEl+/fVXCQkJSbfttTYAi6effVouXrggI0eMYojhtYLkfiRAAiRAAiRwgwlQGN3gC8DDk4AvErCEEZ7z5s0rmPzDU4NQsQoVKsi6detk3759Ur1GdRn83mDjWcrIeaCP1B6Vm26+2ez6xcIv5cSJP9LtBl6sDzXHadJnk1O0xdhSh8398ccf8sZrb8qmjZtTtHU3DqsBwvQKFMi42INoLJA/v8m9WrNqjcTFxVldGWHpKbwOYhP7Z8TQFuPOrHk618DAQCN47frMnz+f4OHOPI0H75mMMsQ1s2Pk6RjuxsR1JEACJEACJJAVAiy+kBV63JcEcigBCCLLoqOjBRNoTPjhrcFy+fLlxeFwmEn1PS2aG2Hkuo+1L57LlSsr4yeMl4MHDkqt2rXMPr8f+13eHfyeNG3aRF7o+oJpPnHSBFm/foOMGj7KdXe3ywijO3H8uHw6foIRFq9osYgmzZpKfhUZB9WTNGXSFDly+IiUKl1K0O+4MeNNe7txnD93XgoXLiy9eveSps2amHM8sP+A6R/iys7KlCkjEyZ9ajY/8tgj0rZ9W3n+mRekWrVq0vOVnlKr1r8kOiZGtm7eIhM/naghidHyyKMPy/Ndnpc9e/bKXeopmztnniycv9DuEHLLP2+RV1/vLTVq1DAhjWtWr5FpU6ZL79dekTp31JHuXXqYawP+U6ZPkZA/Q2TG9M9tmeNcIVpeevkl9fo1U+GTX44fPyETxn8qB/QaYXzPPP+sbFy/Ue5t21oSHAmyccMm+WTcJxKj52I3HmyDqMS1aNq8mRHUv+zcJePHfiIX1JuW2iCqX+7VU2rfWtv0u1kZwWOIcE13x5j5+Sz5fNZ02aLtJnwy0XSHfd/74F2ZMnmqQJTSSIAESIAESCArBOgxygo97ksCOZQAJtl4YJIaERFhniMjI40Aio+PlytXrqQQQ8hLsrMgFSv45r/R3Y1k8Xf/Jz/+70epWq2qdOjYQfbt3S+bNyV5c2bNmCXf/9/3dt2kWI8Qv5uTPU19+/WVNm3byKoVq2TWzNlGiA0d9pEUL17cTM5xbAgBT+NA54898ai0bNXCiBR4o6rpxB3V+TwZ+MyZNcc02f3Lbpk1Y7YULVrU5EpVqFDebFu5fIW0vre19BvQz7QrqB4SCAgIxhmfz5RdKh48Wf+B/Uw445hRY2W1Tv7bd2yv4q2p7FfhVqpUKbmrYQOzO0RC5cqVVBgeTPdcH370IWmnIm7l8pUyU7kXK1ZU+g8a4BwfPGAN7qovc2fNlbVr1kqr1i2NEEMDu/Fg21t935S27drK8qXL5YsFXxjhNmToB9iUwm666Sb5ePjHUknHO3f2XFm1crW0bt1KRdUrpp27Y+D9cyz4mLTUdvBIwVrf28oI2r0qMmkkQAIkQAIkkFUC9BhllSD3J4EcSMDy/sCLgkkoXkNcIKQOXiM8LPGU0dOHZwSTZdjtdW5PmnjrpHjv3n1GOGzetEXOnDmT0e5MO4yt4d0NVTCslkkTk/KT4I1CMYc6d9wuhw8fSdOf3TisMDyE6u3etVu6rOuSZt/UKyAa16xeq6KhtxEqGAcKU0CMvTf4fdn20zazC7wyrdu0NoLI6uPdQe/KqVOnrZe2z7gGKH4Bz928ufNkwbwFApHqH+AvPdXr06JVSxWXW4yoi1cv3qqVq5yi0e5cv1u0WJYvW2FC2HDeTdRzd8stNVOEv40aMVp+2fWLGRdEaOMmjWXs6HFGiLgbD8LhkHcWHBysTJK8N1WqVpFmKuLgWXO9trj+RbVIxQfvDZGtW7aaY/yqnr7AwKRQQbtzRgGQevXrGTH409ZtRiD+vONnCT0fasuPG0iABEiABEggowQojDJKiu1IIBcRsIQRRAK8Q5jYozodJuSYAMNrZBVmyCiWkyEnnU0R7lWmbFnn62tdKFu2jARq3k3w0WBnF9ZyhYoV3Qoju3F8/eU3Jn+qS7cuggfKlH8+bYZs0PC+zFilShVN8+CjR527BaunA56UcuXLOdedPp0xEYhwwe4vdpNBgweafVF4YvTIMUZorNd7SsFrgrytZhq+tk3FwuWwy05hZHeud9a9Q/q82ceIHOeAUi0gFNGyo8q3foP6xnNlN56goCQvTvXq1WXCZ0nhhdb+xUsUTyGMLEZHjvx1DIhKy+yO8dPWn+Ty5XAjBmNj44wAXbZ0mbUbn0mABEiABEggSwQYSpclfNyZBHImAcsbBA+RCUPT0C8IIlSowzO8DFhvtcsIBYgsb9uZM2fFkeCQylWqOLuuXKWyWXYVBc6NumA3DoTFfTRkqDz+yBMybOhwU+gAuT2ZNasCXpWqVZ27VtExwct2Ru8DlVk7eOCA9Oj6onTr0t3kI916260m7A/9QBTgeryqHit4qZYvSykS7M4Vwg85Yn1ee0Me6NTZbQhjterVnEOtWrWKRKrXCvezshvP2bPnzDkiVLJju07m8XDnR6Tr891MfpmzM134448/zUvkTVmGUDmIL5jdMZDnBo9Yw4Z3yX0P3GfGs+2n7VYXfCYBEiABEiCBLBGgxyhL+LgzCeRMApbHCJN5GCakmIAjwR5iCSFN8BpltKLa9aKE8ez6eZfJl4lQj1a4hrY90Pl+M4nfs2dPpsaH/BiEaU2bOl0iwiPMkMPVO5FZ27d3n/GsvfFWHyM4ChYqaPKpdv680xRfyEx/8ATNWTBHPWLH5JuvvhGHMoeFJ4/vt19/M4UT4C3C/aV2KouMGK4f8pxqaB5V3Xp1peP9ndLs1rff2/LD9/+VEiVKSMNGDY3nrHCRwrbjQagf8qWQOxYRcUVOnTwpDz3ysHrhysvTTz6jBSmqyoBBA2X+vPmyeeNm44ns8+br8tUXZaSoCm7ca2rjho3q5TtsewwMEvlLKBCBwhWLvl5k3odpBs8VJEACJEACJHANBCiMrgEadyGBnE7AEkaYQCOPBpNoeFRQ+hmCCDkmKG5gtfPEIz4uaTLvcCQ9o22c9mG9trZ76sPTthHDRmphg/9I54c6m/GcOnVKQ81Gm7wT5LbAMGbrONZxsd51HMjHQXjfK1qZDnby5CnNqRlrlj39SkxMyrmCMICFhl6Q99/9wBQSsDwzEEXDPx5htmMsEHR23hzTKPkXhNnkiZOlW4+kUDp4x5C3tPi7xc5mCEHrrttXavEJeIFg6Z3rjOkzTRGFnloVDvvAk4Uy7K52QivVdeve1Xjkdmmu0SfjPjXvAU/jwbVA4QQIFxjCL4cPGyE4D+SDFSiQXwqqp/HixYsmB+vV11+Vf/f8t2kLITv5symmradjoEogCkzUqlVLli1bbvblLxIgARIgARLwBgG/mtVu8X58izdGxj5IgAQyReDwsUOin+dM7eOuMSbfh4MPmYk7vBAQRPAcoUw3hBDEEpLjIZbgRcIE/87b60qAf1LivLs+M7quQ6cOmovTxrb5D0t+EHhJJk2dpGWbt8rI4SOdba0iERAdWTHkTuGckE8FGzCovyn7bdfnh+9/ZCb67raDEfoCM3eGynR9+/d1t8msQxU2qzQ1vEdRkVEp7pME/v1UiNzduJF0f6FHijwe206TN+Ba4lzBCx5By1BK/OlnnpIObTua7bj2FgurDZ7djcfajmuB90vq/SCsLfFmtQUjjMUSltZ6PHs6hmu7nLrsrc90TuXD8yIBEiABbxOgx8jbRNkfCWRzAlqoW++DM0MT/rubMCp4hjC5t3ugXDX28YZdvXLVY4UxeBqmzZhmPFfr161PcUg78ZGiUQZeQAi62sWLl0z4oOs6axmiISo6ynqZ5jk9kQaPlaeKamGXwpx9pg7rQ57XvIVzTWGM71UwulZ9c+7kYQHXE4U1PJmn7anH49oProW765FaFGEfT4w8HcP1eFwmARIgARIgAW8QoMfIGxTZBwn4AAFvfbuMCTMm/AkaIqZqyPOZ6Tf9/n7+RjhkJKzOc2fpb8UxkO/y66+/mupr6e+Rc1vAW4Sb0SLfCLk9uG7esNKlS0vpMqWF9wbyBs2s9eGtz3TWRsG9SYAESCD3EKDHKPdca54pCWSIAMQHQp7w42uGyT9KNtOSCmKsXbPO6yjOnj0reNBIgARIgARIILcRYLnu3HbFeb4kQAIkQAIkQAIkQAIkQAJpCFAYpUHCFSRAAiRAAiRAAiRAAiRAArmNAIVRbrviPF8SIAESIAESIAESIAESIIE0BCiM0iDhChIgARIgARIgARIgARIggdxGgMIot11xni8JkAAJkAAJkAAJkAAJkEAaAhRGaZBwBQmQAAmQAAmQAAmQAAmQQG4jQGGU2644z5cESIAESIAESIAESIAESCANAQqjNEi4ggRIgARIgARIgARIgARIILcRoDDKbVec50sCJEACJEACJEACJEACJJCGAIVRGiRcQQIkQAIkQAIkQAIkQAIkkNsI/D+rmSIc0huaJgAAAABJRU5ErkJggg=="
+    }
+   },
+   "cell_type": "markdown",
+   "id": "ef686e6f",
+   "metadata": {},
+   "source": [
+    "![filestructure.png](attachment:filestructure.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6a24b7a",
+   "metadata": {},
+   "source": [
+    "## Modules:\n",
+    "\n",
+    "1. Create, Load or Visualize your database\n",
+    "    1. `create_db_tables`: Create your database (uses the data model)\n",
+    "    - **Note:** After you create your database you can log into it from the commandline to explore it.\n",
+    "        - type: `mysql -u root -p` into the command line.\n",
+    "        - Then enter your username and password that you used when installing MySql.\n",
+    "        - Then choose your database. For example:\n",
+    "            - `use nf_research_tools;`\n",
+    "        - Look at the tables:\n",
+    "            - `show tables;`\n",
+    "        - Look at a specific table:\n",
+    "            - `describe AnimalModel;`\n",
+    "        - Can write queries:\n",
+    "            - `SELECT * from AnimalModel;`\n",
+    "    2. `update_db_tables`: Add data to your database (uses the manifests)\n",
+    "        - Can use the same commands as above to inspect your database.\n",
+    "    3. `create_schema_viz`: PNG showing the database structure as a visual (stored in output folder specified).\n",
+    "    \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d8cf506e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports\n",
+    "import argparse\n",
+    "\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from schematic.db.rdb import RDB\n",
+    "from schematic.db.sql import SQL\n",
+    "from schematic.utils.io_utils import load_json\n",
+    "from schematic.utils.sql_utils import sql_helpers\n",
+    "\n",
+    "from create_load_sql_db_nf import sql_create_load\n",
+    "from sql_query_nf import sql_query, parse_variables"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e209698f",
+   "metadata": {},
+   "source": [
+    "### Enter all variable information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3ab63d08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "args = {\n",
+    "    # path info:\n",
+    "    'path_to_configs': '../../schematic_package_docs', # Path to folder containing config files\n",
+    "    'data_dir': '../tests/data', # Path to folder where rdb.model.jsonld\n",
+    "    'rdb_data_dir': '../tests/data/rdb_data', #Path to folder that contains manifests and csvs (organized above)\n",
+    "    'output_path': '../tests/data',  # Path to folder to store all outputs \n",
+    "    \n",
+    "    # filenames\n",
+    "    'rdb_jsonld_filename': 'nf_research_tools_test.rdb.model.jsonld',\n",
+    "    'query_csv':'nf_joins_for_synapse.csv',\n",
+    "    'column_types_csv':'NF_column_types.csv',\n",
+    "\n",
+    "    # synapse arguments:\n",
+    "    'save_to_synapse': True,\n",
+    "    'save_local': False,\n",
+    "    'table_id_type': 'Staging table ID',\n",
+    "    'synapse_project_folder': 'syn26434836',\n",
+    "\n",
+    "    # sql query:\n",
+    "    'name_of_query': 'Investigator',\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78f509ce",
+   "metadata": {},
+   "source": [
+    "## Creating, Loading or Visualizing your database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6317c5bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Choose which function(s) to run\n",
+    "create_db_tables = False\n",
+    "update_db_tables = False\n",
+    "create_schema_viz = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7ac17cf7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: [2022-03-02 16:18:09] py.warnings - /Users/mialydefelice/Documents/schematic_a/schematic/scripts/create_load_sql_db_nf.py:58: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.\n",
+      "  var = yaml.load(f)\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,408 INFO sqlalchemy.engine.Engine SHOW VARIABLES LIKE 'sql_mode'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW VARIABLES LIKE 'sql_mode'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,409 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,412 INFO sqlalchemy.engine.Engine SHOW VARIABLES LIKE 'lower_case_table_names'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW VARIABLES LIKE 'lower_case_table_names'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,414 INFO sqlalchemy.engine.Engine [generated in 0.00137s] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [generated in 0.00137s] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,418 INFO sqlalchemy.engine.Engine SELECT DATABASE()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SELECT DATABASE()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,419 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,421 INFO sqlalchemy.engine.Engine SHOW FULL TABLES FROM `nf_research_tools_test`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW FULL TABLES FROM `nf_research_tools_test`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,423 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,427 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `AnimalModel`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `AnimalModel`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,428 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,436 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,437 INFO sqlalchemy.engine.Engine [generated in 0.00133s] ('nf_research_tools_test', 'donor', 'donorId', 'nf_research_tools_test', 'donor', 'donorId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [generated in 0.00133s] ('nf_research_tools_test', 'donor', 'donorId', 'nf_research_tools_test', 'donor', 'donorId')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,451 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Donor`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Donor`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,452 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,458 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,459 INFO sqlalchemy.engine.Engine [cached since 0.02349s ago] ('nf_research_tools_test', 'donor', 'donorId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [cached since 0.02349s ago] ('nf_research_tools_test', 'donor', 'donorId')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,464 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Antibody`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Antibody`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,465 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,469 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Biobank`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Biobank`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,471 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,475 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,476 INFO sqlalchemy.engine.Engine [cached since 0.04102s ago] ('nf_research_tools_test', 'resource', 'resourceId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [cached since 0.04102s ago] ('nf_research_tools_test', 'resource', 'resourceId')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,479 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Resource`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Resource`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,481 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,489 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s), (%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s), (%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,490 INFO sqlalchemy.engine.Engine [cached since 0.05459s ago] ('nf_research_tools_test', 'geneticreagent', 'geneticReagentId', 'nf_research_tools_test', 'antibody', 'antibodyId', 'nf_research_tools_test', 'cellline', 'cellLineId', 'nf_research_tools_test', 'animalmodel', 'animalModelId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [cached since 0.05459s ago] ('nf_research_tools_test', 'geneticreagent', 'geneticReagentId', 'nf_research_tools_test', 'antibody', 'antibodyId', 'nf_research_tools_test', 'cellline', 'cellLineId', 'nf_research_tools_test', 'animalmodel', 'animalModelId')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,502 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `GeneticReagent`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `GeneticReagent`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,503 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,506 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `CellLine`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `CellLine`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,507 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,512 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,514 INFO sqlalchemy.engine.Engine [cached since 0.0781s ago] ('nf_research_tools_test', 'donor', 'donorId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [cached since 0.0781s ago] ('nf_research_tools_test', 'donor', 'donorId')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,517 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Development`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Development`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,519 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,526 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s), (%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s), (%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,527 INFO sqlalchemy.engine.Engine [cached since 0.09137s ago] ('nf_research_tools_test', 'resource', 'resourceId', 'nf_research_tools_test', 'investigator', 'investigatorId', 'nf_research_tools_test', 'publication', 'publicationId', 'nf_research_tools_test', 'funder', 'funderId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [cached since 0.09137s ago] ('nf_research_tools_test', 'resource', 'resourceId', 'nf_research_tools_test', 'investigator', 'investigatorId', 'nf_research_tools_test', 'publication', 'publicationId', 'nf_research_tools_test', 'funder', 'funderId')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,538 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Investigator`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Investigator`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,539 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,543 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Publication`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Publication`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,544 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,550 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Funder`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Funder`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,552 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,555 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Mutation`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Mutation`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,556 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,561 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,562 INFO sqlalchemy.engine.Engine [cached since 0.127s ago] ('nf_research_tools_test', 'mutationdetails', 'mutationDetailsId', 'nf_research_tools_test', 'animalmodel', 'animalModelId', 'nf_research_tools_test', 'cellline', 'cellLineId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [cached since 0.127s ago] ('nf_research_tools_test', 'mutationdetails', 'mutationDetailsId', 'nf_research_tools_test', 'animalmodel', 'animalModelId', 'nf_research_tools_test', 'cellline', 'cellLineId')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,573 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `MutationDetails`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `MutationDetails`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,574 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,580 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Observation`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Observation`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,581 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,586 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,587 INFO sqlalchemy.engine.Engine [cached since 0.1512s ago] ('nf_research_tools_test', 'resource', 'resourceId', 'nf_research_tools_test', 'investigator', 'investigatorId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [cached since 0.1512s ago] ('nf_research_tools_test', 'resource', 'resourceId', 'nf_research_tools_test', 'investigator', 'investigatorId')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,598 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `ResourceApplication`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `ResourceApplication`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,599 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,604 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,605 INFO sqlalchemy.engine.Engine [cached since 0.1697s ago] ('nf_research_tools_test', 'resource', 'resourceId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [cached since 0.1697s ago] ('nf_research_tools_test', 'resource', 'resourceId')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,608 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Usage`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Usage`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,609 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,615 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,616 INFO sqlalchemy.engine.Engine [cached since 0.1805s ago] ('nf_research_tools_test', 'publication', 'publicationId', 'nf_research_tools_test', 'resource', 'resourceId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [cached since 0.1805s ago] ('nf_research_tools_test', 'publication', 'publicationId', 'nf_research_tools_test', 'resource', 'resourceId')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,628 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `Vendor`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `Vendor`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,630 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,632 INFO sqlalchemy.engine.Engine SHOW CREATE TABLE `VendorItem`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - SHOW CREATE TABLE `VendorItem`\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,633 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,637 INFO sqlalchemy.engine.Engine \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - \n",
+      "                    select table_schema, table_name, column_name\n",
+      "                    from information_schema.columns\n",
+      "                    where (table_schema, table_name, lower(column_name)) in\n",
+      "                    ((%s, %s, %s), (%s, %s, %s));\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 16:18:09,638 INFO sqlalchemy.engine.Engine [cached since 0.2029s ago] ('nf_research_tools_test', 'resource', 'resourceId', 'nf_research_tools_test', 'vendor', 'vendorId')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 16:18:09] sqlalchemy.engine.Engine - [cached since 0.2029s ago] ('nf_research_tools_test', 'resource', 'resourceId', 'nf_research_tools_test', 'vendor', 'vendorId')\n"
+     ]
+    }
+   ],
+   "source": [
+    "if create_db_tables:\n",
+    "    sql_create_load(args['data_dir'], args['rdb_jsonld_filename'], args['path_to_configs']).create_db_tables()\n",
+    "\n",
+    "if update_db_tables:\n",
+    "    sql_create_load(args['data_dir'], args['rdb_jsonld_filename'], args['path_to_configs']).update_db_tables(args['rdb_data_dir'])\n",
+    "\n",
+    "if create_schema_viz:\n",
+    "    output_path = sql_create_load(args['data_dir'], args['rdb_jsonld_filename'], args['path_to_configs']).create_schema_viz(args['output_path'], args['rdb_jsonld_filename'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "04bdbf91",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsQAAAVbCAYAAAAmwrybAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdf1RVdb7/8ScQ6oDdC2hiIN8RKy3RGIGuDP7Cm5oT4/jNSAj1q17MbOyHo2uyacoL18YcGdFJKypXSnzT9IuCJGgEip0lSP5CDReLEvPmj6hGEE4EHdDvH95zBjj7oCg/VF6PtVwL9o/P5703BW82e7+20+XLly8jIiIiItJFOXd2ASIiIiIinUkNsYiIiIh0aWqIRURERKRLU0MsIiIiIl2aGmIRERER6dLUEIuIiIhIl6aGWERERES6NDXEIiIiItKlqSEWERERkS5NDbGIiLSJLVu24OTkpH+34L8tW7Z09n8+Ip3qjs4uQEREbi+bN2/u7BKkFaKiojq7BJFOp4ZYRETa1NSpUzu7BGkFNcQiumVCRERERLo4NcQiIiIi0qXplgkREbnpnT9/npdffpnjx48zYMAA/vjHP/LQQw/d8LhVVVWUl5dz6tQp6urqmDRpkt02p0+f5vnnn7d97uPjw6xZsxg+fPgNz9/aOu+7774Om1OkK9EVYhERuan9/PPPPPzww/zbv/0be/fu5dVXX+UPf/gDNTU1Nzz28ePHWblyJYGBgQQHBxtuU1VVRVVVFevWrWPdunVMmTKFRx55BIvFcsPzt7ZOEWkfukIsIiI3tW3btuHt7c0zzzwDwNChQ3nrrbf4xz/+gaurK8uXL8dkMtHQ0EBycjImk4nc3FzOnTuHi4sLq1at4t5778Visdhtm5iYSFFREd7e3gwYMIDHH3+cl156iaNHj+Lt7W1LzHB1deWuu+4CYOzYsbi5ufHzzz8D2I3p4+NDdHS0rWFPSUnB1dWVJUuW8MUXX9CvXz8GDRrEwoUL7fbt168fmzZtsqvfWmdeXh7h4eEd/0UQuc3pCrGIiNzUSkpKmDhxIgCFhYU8++yzvPvuuxQWFpKTk4PFYiE7O5v58+cTHx+P2WzGYrGQlZXF1KlTSU5OBjDcduHChYwfP55+/fpRWVnJ9u3b6d27NyaTiYkTJ3L48GEAiouLmTVrFjNnzuShhx5i9uzZuLu7G45ZVlbGjBkz2LFjB2PGjGHTpk2kpaXxwAMPkJ2dTd++fSkvLzfcFzCs31qnmmGR9qErxCIiclPz8vLixIkTAAwaNIhnnnmGjRs32q6slpSUEBMTQ319Pe7u7gCEhIQA4OfnR2FhIQCZmZmG2za2a9cu/vCHPwAwZ84cANt9y3FxcVy+fJl9+/YRHx/PX/7yF8Mx3d3dycjIIDk5me+//57JkydTUFDASy+9BMC4cePYsWNHi/UY1S8i7UcNsYiI3NQefvhh/v73v3P27Fl8fX35l3/5F0wmE8OGDSMoKIghQ4Ywb948Tp8+zYEDB6ioqMDZ+cofQC9fvmwbx2jb5oYMGUJpaSlBQUGsX7+ewMBAXF1d+cUvfkH//v0B8Pf3509/+hMNDQ2GYyYlJREaGkpsbCzz588HYNiwYZw4cYKAgABMJtNV6zGqX0Taj26ZEBGRm1pAQABLlixh0qRJREREMHToUB5++GEApkyZws6dO5k2bRqRkZH4+/s7HMdoW39/f/bu3cuXX34JwPTp09m4cSNRUVF8/PHH/OpXvzIcy9PTk+LiYsMxR44cyfr164mNjaWyspL09HSioqL44IMPCA8PJzs7mzvuuKNVtVvrtDbTItK2nC7r108REWkDW7ZsISoqql2vap49exYfHx+cnJzslvfu3Zvu3btf0xiNt/35559xcXHBxcXFtk11dTV33nlnq+pqPKbZbMbJyQl3d3eqq6s5deoU7u7u9O/fn7Vr19KzZ09iY2NbVbtRnW3BycmJzZs36w2D0qXplgkREbll+Pr6tmr5tWzbrVs3u21a0wwbjdmzZ88mY3l6ejJ79mycnZ1paGhg27ZtDvd1xKhOEWkbaohFRETamZ+fHzk5OdTX13PHHfrRK3Kz0T3EIiIiHUTNsMjNSQ2xiIiIiHRp+lVVRETa1BNPPNHZJYiItIquEIuISJtKTU3lzJkznV2GXMWZM2dITU3t7DJEbgq6QiwiIm3uD3/4g2K8bnLWmDwRUUMsIiLtICoqSs2WiNwy1BCLiEib2rx5c2eXIK2gX1xE1BCLiEgb060StxY1xCJ6qE5EREREujhdIRYRkU7x9ttvc/nyZQBGjRrF0KFDr7pPdnY2dXV1TJo06brm/Oqrr3j55Zf5+uuvGT16NHPmzOHcuXNUV1czefLkax7neurIzMxkw4YNXLx4kYiICF544YUm41RVVVFeXs599913PYcmIjdAV4hFRKTDffvtt2zevBk3Nzfc3Nyu+Q1ugYGBBAcHX9ecly5d4tFHH2XSpEmYTCamTJnCk08+yalTpygrK2vVWK2to6KigoSEBN588002bNhAQUEBn332WZNxjh8/zsqVK1tVh4i0DV0hFhGRDvfVV18xduxYQkNDGThwIM7Ozrz33nvs27ePiooK3NzcWLZsGYcOHSInJ4d9+/Zx/Phx8vLyqK2tpVu3bmRmZnL+/Hnq6uoYMWIEhYWFhIWFER8fz/LlyzGZTDQ0NJCcnEy/fv3Yt28fgwcPZsaMGQCEhYWRlJREQUEBAGazmSVLllBUVIS3tzerVq2ib9++bNq0idzcXM6dO4eLiwurVq3i0KFDtjqar+vbty9Llizhiy++oF+/fgwaNIjJkyfz008/4eTkhI+PD2vWrOHixYu245k5cyaJiYkUFRXx6aefsn//frv6RaT96AqxiIi0m4aGBiwWCw0NDU2Wf/XVV2zZsoXVq1cTFhbGoUOHqKiooEePHmzfvp25c+fyzjvvYDabOXnyJIWFhQBUVVVRWVmJ2WymqqqK3NxcAgICcHV1JS8vj/z8fNavX4/FYiE7O5v58+cTHx8PwK5duxg3blyTOoYPH46HhwcA6enp+Pj4sHv3bh577DHef/994EqjbLFYyMrKYurUqSQnJzepo/m6tLQ0HnjgAbKzs+nbty/l5eXcf//9REdHM2rUKEJCQnjrrbfw9va2jQOwcOFCxo8fT319vWH9ItJ+1BCLiEi7Wbp0KcHBwbz44otNlkdGRvL555+TlJTEa6+9xqpVq4ArV20BgoOD2bt3LwATJ07Ezc3Nbuzw8HAAPDw8GD58OABeXl589NFH5OfnExMTw0cffUR9fT0AvXr1srs1YufOnXzzzTfAlYZ5woQJAIwZM4bdu3fbtgsJCQHAz8+PioqKJmM0X5ednW07DmsD/v333zNnzhxKSkrYunUrZ8+etR1zc5mZmYb1i0j7UUMsIiLtJi4ujmPHjtndG5uRkcHBgweBK1eR+/TpA0BJSQkABw8exM/PDwBnZ+MfVd27d7d97OTkBMDly5cZNmwYkZGRbNy4kYSEBCIiIgAYP348WVlZnDt3DoCysjJeffVVvL29AXjwwQdt8x85csTW1DauwfoQYGPN1w0bNowTJ04AYDKZADh06BDx8fFcvnyZX/7yl8ydO5cDBw4YHldQUJBh/SLSfnQPsYiIdLjhw4czffp0Bg4cSHV1NX/9619JS0sjPT2dw4cPc+7cOVJSUjhy5Eirx54yZQorVqzAZDJRWlpKUlISAEOHDmXx4sX85je/oVevXhQXF/Pee+9x4cIFfvzxR2JiYpgzZw5paWnU1tZe9wNuUVFRzJs3jzfffBOLxcKIESOYMGECH3zwASEhIQwdOpTTp0/zl7/8heLiYtt+/v7+7N27l4iICNatW2dXv4i0H6fLRr/uioiItNKWLVuIiooyvIrqyD/+8Q969eoFwIoVK/D19eWRRx7By8vL4ZXha3X27Fl69+7d5Eqy1ZkzZ7j77rtxcXGxW3fhwgW8vLyue95jx47h7u5O//79Wbt2LT179iQ2NhaAmpoaqqurbVelm/v5559xcXHBxcWlxfrbkpOTE5s3b9YLVaRL0xViERHpNNZmGK7cAuHq6krv3r3bZGxfX1+H61pKbbiRZhjA09OT2bNn4+zsTENDA9u2bbOts8bMOdKtWzfbxy3VLyJtSw2xiIjcFF544YXOLqFN+Pn5kZOTQ319/TXnK4tI59JDdSIiIu1AzbDIrUMNsYiIiIh0aWqIRURERKRLU0MsIiIiIl2aGmIRERER6dLUEIuIiIhIl6ZHYEVEpFPs2rWLoqIiRo0axYgRI65pn+zsbOrq6pg0aVI7VyciXYmuEIuISIfLzMzk9ddf5/777+fVV1/FZDJd036BgYEEBwe3c3Ui0tXoCrGIiHS4mpoa3n77bQYPHszRo0c5duwYJSUl7Nu3j4qKCtzc3Fi2bBmHDh0iJyeHffv2cfz4cfLy8qitraVbt25kZmZy/vx56urqGDFiBIWFhYSFhREfH8/y5csxmUw0NDSQnJxMv379SE1NbTKWiIiVrhCLiEi7aWhowGKx0NDQ0GT5E088weDBg3n44YdJSkriscceo6Kigh49erB9+3bmzp3LO++8g9ls5uTJkxQWFgJQVVVFZWUlZrOZqqoqcnNzCQgIwNXVlby8PPLz89m0aRMWi4Xs7Gzmz59PfHw8gN1YIiJWaohFRKTdLF26lODgYF588cUmyy9fvgzAjh07ePbZZ3n11VcBCAsLAyA4OJi9e/cCMHHiRNzc3OzGDg8PB8DDw4Phw4cD4OXlxa5du8jPzycmJoaPPvqI+vp62z6OxhKRrk23TIiISLuJi4sjLi7ObvncuXOZM2cOw4cPZ8SIEXz99dcAlJSUAHDw4EH8/PwAcHY2vnbTvXt328dOTk7AlUZ78ODBjB49mnnz5nH69GkOHDhg287RWCLStakhFhGRDjdv3jyef/55fH19qaysJDExkaysLNLT0zl8+DDnzp0jJSWFI0eOtHrscePG8frrr2MymSgtLSUpKakdjkBEbidOl61/txIREbkBW7ZsISoqitb8WPnuu+/o06cPACtWrMDX15dHHnkELy+vG76ae/bsWXr37t3kSrLYc3JyYvPmzUydOrWzSxHpNLpCLCIincbaDMOVWyBcXV3p3bt3m4zt6+vbJuOIyO1PDbGIiNwUXnjhhc4uQUS6KD1dICIiIiJdmhpiEREREenS1BCLiIiISJemhlhEREREujQ1xCIiIiLSpakhFhEREZEuTbFrIiJyU3jmmWc4d+5ck2WPPvooTz/99HWPmZ2dTV1dHZMmTbqm7Xfv3k11dTW7du1q81pE5OalhlhERG4K8fHx1NfX89JLLzFq1CgiIiJwd3e/oTEDAwNpaGi45u3/+7//m4qKinapRURuXmqIRUSkw23atInc3FzOnTuHi4sLq1at4t577wXA3d0dLy8vfHx8sFgsLF26FJPJRENDA8nJyezfv5+cnBz27dvHyy+/TGZmJufPn6euro4RI0ZQWFhIWFgYy5YtIy8vj9raWrp162Y334ABA4iOjqampgaAlJQUW33WN+g1ruXSpUtMnTq1yfaurq4sWbKEL774gn79+jFo0CAWL17cwWdTRG6U7iEWEZF209DQgMVisbtKazabsVgsZGVlMXXqVJKTkw33z8nJwWKxkJ2dzfz584mPj8dsNnPy5EkKCwsxm81UVVWRm5tLQEAArq6u5OXlkZ+fzzfffENVVRWVlZWG85WVlTFjxgx27NjBmDFj2LRpU4vHYrR9WloaDzzwANnZ2fTt25fy8vI2O3ci0nHUEIuISLtZunQpwcHBvPjii3brQkJCAPDz86OiosJw/8zMTPLz84mJieGjjz6ivr4egIkTJ+Lm5gZAeHg4AB4eHgwfPhwALy8vqqurW5zP3d2djIwMIiMj2bFjB7W1tS0ei9H22dnZhIWFATBu3LhrOSUichNSQywiIu0mLi6OY8eOsXLlSrt1zs5XfgRdvnzZ4f5BQUFERkayceNGEhISiIiIaLIvQPfu3W0fOzk52cZsPm7z+ZKSkggNDSU1NZUhQ4Zc9ViMth82bBgnTpwAwGQyXXUMEbk5qSEWEZGb1pQpU9i5cyfTpk0jMjISf3//Nht75MiRrF+/ntjYWCorK0lPT2/19lFRUXzwwQeEh4eTnZ3NHXfo0RyRW5HT5ZZ+NRcREblGW7ZsISoqqsUrvtfr7Nmz9O7du8nV4LZgNptxcnLC3d2d6upq7rzzzlZtf+rUKdzd3enfvz9r166lZ8+exMbGtmmN7c3JyYnNmzczderUzi5FpNPoV1kREbnp+fr6tsu4PXv2tH18tWbYaHtPT09mz56Ns7MzDQ0NbNu2rV3qFJH2pYZYRETkOvn5+ZGTk0N9fb1ulxC5hekeYhERkRukZljk1qaGWERERES6NDXEIiIiItKlqSEWERERkS5NDbGIiIiIdGlqiEVERESkS2uzhtjJyUn/uvi/LVu2tNV/TiJym8vOzubjjz9us/Gqqqr48ssvATh06BBPPvkkP/30k239s88+S319fZvNJyK3lzbNiVmwYAG//vWv23JIuUVERUV1dgkicgsJDAykoaGhzcY7fvw4KSkpJCUl8d1335GVlcXSpUtZtmwZALt37+bSpUttNp+I3F7atCH+9a9/rVc/dlFqiEWkNfLy8qitraVbt27k5uZy7tw5XFxcWLVqFT169GDRokXU1dUREhLCK6+8gsViYfny5ZhMJhoaGkhOTmb//v3k5OSwb98+Bg4cSFFREXl5eQA8+eSTfPLJJ0ybNo2AgADbvJcuXSI6OpqamhoAUlJS2LVrF5mZmZw/f566ujpGjBhBYWEhYWFhLFu2zHDufv36dcZpE5F2onuIRUSk3TQ0NGCxWOyuBldVVVFZWYnZbMZisZCVlcXUqVNJTk5m69athISEkJ6ejp+fHzU1NeTk5GCxWMjOzmb+/PnEx8djNps5efIkhYWFLFy4kPHjxxMeHg6Aq6srb731Fs888wyXL1+2zVtWVsaMGTPYsWMHY8aMYdOmTZjNZqqqqsjNzSUgIABXV1fy8vLIz8/nm2++MZxbRG4vaohFRKTdLF26lODgYF588UWH24SEhABXXoNcUVHB9OnTOXjwICEhIZSVleHm5kZmZib5+fnExMTw0Ucf2e4HnjhxIm5ubobjDh8+nMDAQNatW2db5u7uTkZGBpGRkezYsYPa2loAWyPt4eHB8OHDAfDy8qK6utrh3CJy++gy75r8+uuveeWVV/jiiy/w9fXl6aef5ne/+x0AqampeHt7M2rUqA6ppaqqivLyck6dOkVdXR2TJk3qkHlFRDpaXFwccXFxLW7j7Hzl2oz1Sq7JZOKNN97A09OTmJgYDhw4QFBQEEOGDGHevHmcPn2aAwcOYDabbfs6smzZMkaMGEFlZSUASUlJhIaGEhsby/z5823bde/e3faxk5OTrZ7Lly8bzi0it5cucYX4p59+YuzYsYSFhfHZZ58xf/58Xn75ZXJycoArf0L79ttvO6ye48ePs3LlSgIDAwkODu6weUVEbgUeHh5ER0ezcOFCampqCAwMZMqUKezcuZNp06YRGRmJv79/k338/f3Zu3cvJpOpyfI777yT1157jfPnzwMwcuRI1q9fT2xsLJWVlaSnp1+1nqvNLSK3PqfLjW+uupGBnJzYvHnzTflQXVZWFu+88w7bt2+3LVu/fj0HDhzgrbfeYsWKFezdu5cLFy7Qp08fEhMT6d69e5OHOhYvXmz4UEVqaqrtoY4BAwawevVq/P39Wbt2LR4eHmRkZDR5eMPT05PHH3+coqIiJkyYQGhoKI8//jhLliyhqKgIb29vVq1axZ49e+weNLn33ns76xRe1c389ReRjrFlyxaioqJoix8rly5dory8nLvvvrvJ8rNnz9K7d+8mV3Stfv75Z1xcXHBxcWlxbLPZjJOTE+7u7lRXV3PnnXdeU00tzX0r0/dvkS5yhTg3N5eIiIgmy8aNG0d+fr7tc29vbwoKCoiNjeXdd9+1e6gjIyPD8KGKxg91jB07lq1btwLw4YcfMnDgQLuHNwDbwx9BQUG2KxQ+Pj7s3r2bxx57jPfff9/wQRMRka7C2dnZrhkG8PX1ddiQduvW7arNMEDPnj1xd3cHuOZm+Gpzi8itrUs0xEOHDuXUqVNNlh09epTQ0FDb5+PHjwdg9OjRFBQU2D3UsWfPHocPVVgf6oiJiSE9PZ3S0lL8/PxsjXTzhzea27VrFxMmTABgzJgx7N69G7B/0ERERERE2l6XaIgnTZpEeno6p0+fti378MMPbQ/VAZw8eRK40iiHhYXZHurIz8+nuLiYhoYGIiMj2bhxIwkJCU2uOFsf6ujTpw9eXl4kJCQwa9Ys28MbqampDBkyxGF9Dz74ICUlJQAcOXKEsLCwJuO20V0tIiIiImKgS6RM9OrVi+eee44hQ4YQFhZGZWUl4eHhTJw40bbNJ598QnFxMVVVVaxevZqzZ88SHR1NQEAANTU1xMfH89RTT2EymSgtLSUpKclwrhkzZrBgwQKSkpJwdXUlPj6e/Px8amtrSU9PZ+HChbaHP2pqaggODiYmJoY5c+aQlpZGbW0tK1euJDc3t6NOj4iIiEiX1iUeqrOyWCx8/fXX+Pn50aNHD7v1lZWVeHh42D43eqijtQ9VOHp4w+jhjwsXLuDl5XW9h9epboWvv4i0r7Z8qE46jr5/i3SRK8RWrq6u3HfffQ7XN26GwfihDl9f31bN2bNnT9vHjR/e6Natm922t2ozLCIiInIr6xL3EIuIiIiIOKKGWERERES6NDXEIiLS4bKzs/n444/bbLyqqiq+/PJL4Epq0OTJk5v8W758+VX3u955n3vuuSbLSktLeeutt657TBHpeG16D/GOHTv4f//v/7XlkCIichsKDAykoaGhzcY7fvw4KSkpJCUlUVlZSV1dXZM0IOuLOFra73rU1dWxZ8+eJssuXrzIiRMnrms8EekcbdoQf/nll5w5c6bJCy/k9nbmzBn279/f2WWIyC0mLy+P2tpaunXrZvea+h49erBo0SLq6uoICQnhlVdewWKxsHz5ckwmEw0NDSQnJ7N//35ycnLYt28fAwcOpKioiLy8PO68807c3Nzo379/kzk3bdpkN1diYqJtvx9++ME23uHDh+3my8zMJDU1FbhyFTotLQ0fHx8Aqquree211/j888/x8vIyfMueiNy82jxlIjQ0VFeJuxBrzJKIiJGGhgYuXbqEs7Nzk5jJqqoqampqcHNzs72mPiUlheTkZHr37k1ISAh//OMfSU5Opqamhr1792KxWMjOzmbbtm3Ex8czYsQITp48SWFhIUeOHCElJYXw8HAOHTrE3r17bS85AnjllVcwm812cy1cuNC234YNG2zj5eTk2M333nvv8fTTT/POO+9gMpkIDAzk+++/B2Djxo14eHiwZ88e4uLi+OGHHzr8XIvI9Wvzhjg1NRUnJ6e2HlZERG5BS5cuZdu2bYwfP56VK1cabtP4NfWFhYUsWLCA3//+94SEhBAREYGbmxuZmZmUlJQQExNDfX297RaIiRMn4ubmZjfmmDFj2LZtW5Nl7733nt1czVnHczRfXl4eKSkp5OTkNNlv9+7dvPTSSwD8+7//O1u2bGnNaRKRTtamDXFERAR/+MMf2nJIuUXoKrGIGImLiyMuLq7FbZq/pt5kMvHGG2/g6elJTEwMBw4cICgoiCFDhjBv3jxOnz7NgQMHMJvNtn2vVfO5HK03mq+srIwFCxawc+dOu5c7DRs2jJKSEoYNG8axY8daVZOIdL42bYgHDhyoN910UWqIRaSteHh4EB0dTUBAADU1NQQGBnLfffcxc+ZMTCYTpaWlJCUlcfz4cds+/v7+7N27F5PJhJubG3v27LFdDYYrV6GDg4Pt5mq8X2NTpkyxm+/ZZ5/lxx9/5P/8n/8DwH/+538yaNAgAKZNm8a0adPYtm0bZrOZe+65pz1OjYi0ky716mZpP/r6i0hbvrr50qVLlJeX2z2cdvbsWXr37k337t3t9vn5559xcXFpcq/ytWhpv5bmM/Ltt9/St2/fVs3f2fT9W+QmyiFOTU21+w29PVmzJ68nC/PQoUOsWbOmybKWxsnKymL37t3XXauISFfj7OxsmNTg6+vrsDnt1q1bq5vhq+3X0nxGbrVmWESuaPOH6q5XWVlZm1xVuFbW7Mn4+PhWZ2F+9913HDlypMmyljI1v/76a4cZmCIiIiLSuTq8ITabzSxZsoSioiK8vb1ZtWqV7TfqDRs2kJiYSJ8+fUhMTKR79+5NsigXL15slwvZr18/UlNTbdmRAwYMYPXq1fj7+7N27Vo8PDzIyMigpqYGgJSUFDw9PW3Zk05OToSGhvL444/b1bVnzx67zMp7773X8LhaytS0+v777/mP//gP/v73vzNgwID2P9kiIiIiclXtestEQ0MDFoulyZXT9PR0fHx82L17N4899hjvv/++bZ23tzcFBQXExsby7rvvsnXrVkJCQkhPT8fPz4+MjAxbLuT8+fOJj48HrjTZ1uzIsWPHsnXrVgA+/PBDBg4cyIwZM9ixYwdjxoxh06ZNACxcuJDx48cTFBREZWWlYV2NMyunTp1KcnKyw2OtqqqisrLS4T7l5eVERkaydOlSNcMiIiIiN5F2bYiXLl1KcHAwL774om3Zrl27mDBhAnAlJ7LxvbXjx48HYPTo0RQUFDB9+nQOHjxISEgIZWVl7Nmzh/z8fGJiYvjoo4+or6+37WvNjoyJiSE9PZ3S0lL8/PxsjXRkZCQ7duygtrbWsFZHdTXOrKyoqLim4zbaZ82aNfzwww+2txqJiIiIyM2hXRviuLg4jh071iSM/cEHH6SkpASAI0eONHmT0MmTJwE4evQoYWFhtizK/Px8iouLaWhoIDIyko0bN5KQkEBERMQ/D+R/siP79OmDl5cXCQkJzJo1i6SkJEJDQ0lNTWXIkCEOa3VU19UyK40Y7RMfH8+rr77Kc889d83jiIiIiEj76/B7iGNiYpgzZw5paWnU1tY2aZY/+eQTiouLqaqqYvXq1Zw9e7ZJFmV8fI+plX8AACAASURBVDxPPfVUk1xIIzNmzGDBggUkJSXh6upKfHw8+fn51NbWkp6ezsKFC23ZkzU1NQQHBxvWlZub6/A4MjIymmRczp07t8XjdnFxITo6mvXr15ORkcHvfve7Vp45EREREWkPnZZDfOHCBby8vOyWV1ZW4uHhYfvcKIuytbmQZrMZJycn3N3dqa6u5s477wSMsycd1SUtU46liLRlDrF0HH3/FunEHGJHTWfjZhiMsyhbmwvZs2dPW+yZtRkG4+xJNcMiIrcea7Y8wM6dOw1z4TMzM3niiSeYMGECf//73+32u5rrya0XkVvDTZNDLCIicr2s2fJJSUmcOXOGn3/+ucn6iooKEhIS2LJlC/X19SxcuJBhw4bh4uJi2+9qWsqbF5FbmxpiERHpcNZM+i+++IJ+/foxaNAg7rnnHlumfEFBgWFm/eTJk3n//fcpKyvj97//PQcOHGDr1q1ERkYyYMAA8vLygCtXg7dt28a//Mu/8Le//Q2LxcJPP/2Ek5MTPj4+rFmzhosXL7J48WKKiorIy8vjhx9+sM1/9OhRoqOjm2TYt5Q37yijXkRuDTfNq5tFROT2Y5RHD5CWlsYDDzxAdnY2ffv2pby8vEmmvKPM+qFDh/LZZ5+Rm5tr2z4rK4t3332X8ePHEx4ebpsjNzeXJ554guTkZO6//36io6MZNWoUISEhvPXWW3h7e9sy6cPDw5vMX1ZWZpdhf7W8eRG5dakhFhGRdmOURw9X7se1xluOGzfOttyaKe8oG/43v/kNn332GQcPHuTFF18kLy+PsrIyBg8e3GR865je3t5cuHCB77//njlz5lBSUsLWrVs5e/ZskzeJNp/f3d29xQz768moF5GblxpiERFpN0Z59ADDhg3jxIkTAJhMJttya467o2z40NBQjhw5AlxpXt9//327Zhiwe/D60KFDxMfHc/nyZX75y18yd+5cDhw4YLefdf6rZdhfT0a9iNy8dA+xiIh0uKioKObNm8ebb76JxWJhxIgRTdY7yqx3cXHh7rvvJjAwkLvvvpvKykoeffRRW7Z84+a6sQkTJvDBBx8QEhLC0KFDOX36NH/5y1/o37+/4X4jR460y7CfMWNG+5wMEel0nZZDLLcXff1FpDU5xMeOHcPd3Z3+/fuzdu1aevbsSWxsrN12rcmGN8qWb66mpobq6mq8vb2vup+jDPvbjb5/i9xEt0ykpqY6/M2+PVizJ683V9Ioz9LI9RyXtabG+Zityco8dOgQTz75JD/99JNt2bPPPkt9fX2r6hARaS+enp48/fTT/OY3v7Hdq2ukNdnwRtnyzbm5uTVphlvaz1GGvYjcfm6ahrisrIxvv/22w+Y7fvw4K1euJDAwkODg4Fbta82zfPPNN9mwYQMFBQV89tlnhttez3FZa7LW2Ljea/Hdd9+RlZXF0qVLbct2797NpUuXWlWHiEh78fPzIycnh6ysLHJzc/nXf/3Xzi5JRLqwDr+H2Jo92TxbEmDDhg0kJibSp08fEhMT6d69O4sWLaKuro6QkBAWL17M8uXLMZlMNDQ0kJycTL9+/UhNTbVlRw4YMIDVq1fj7+/P2rVr8fDwICMjo0mWpKenJ4mJiRQVFeHk5ERoaCiPP/64XV179uwxzJosLy83zLNMSUnh0qVLzJw5k08//ZRjx44ZHtfnn39OZmYm58+fp66ujhEjRlBYWEhYWBjLli2zZV1mZGTY8jHXrFlDUVERn376Kfv3729yDvbv3287/uPHjwPw5JNP8sknnzBt2jQCAgKAK6/Bnjp1apNzsWvXrhZrsVgshudcRKQt3HGHHmURkc7XrleIjfInHWVLwpV4nIKCAmJjY3n33XfZunUrISEhpKen4+fnR0ZGBhaLhezsbObPn098fDxAk+zIsWPHsnXrVgA+/PBDBg4caJclCdiyJ4OCgqisrDSsy1HWpKM8y+rqasxmM3DlPrWLFy8aHpfZbKaqqorc3FwCAgJwdXUlLy+P/Px8vvnmG1vWZeN8TOvH9fX1dueg8fFbubq68tZbb/HMM8/Y7uczytW8Wi05OTmG51xERETkdtGuDbFR/qSjbEmA8ePHAzB69GgKCgqYPn06Bw8eJCQkhLKyMvbs2UN+fj4xMTF89NFHTe6JtWZHxsTEkJ6eTmlpKX5+frZG2lGW5NXqMsqavJY8y8a1NT8uwBYe7+HhwfDhw4Er98pVV1e3eE4zMzMNz4H1+BsbPnw4gYGBrFu3DsBhrmZLtTiaT0REROR20a4NsVH+pKNsSYCTJ08CcPToUcLCwjCZTLzxxhvk5+dTXFxMQ0MDkZGRbNy4kYSEBCIiIv55IP+TCdmnTx+8vLxISEhg1qxZV82SvFpdRlmTjvIse/TowY8//gjA/v37HR4XNM3IdHJyss1xtaezg4KCDM+Btc7mli1bxpo1a6isrHR4LlqqxdF8IiIiIreLDr95y1G2JMAnn3xCcXExVVVVrF69mrNnzxIdHU1AQAA1NTXEx8fz1FNPYTKZKC0tJSkpyXCOGTNmsGDBApKSknB1dbXLkly4cKEts7Kmpobg4GDDunJzcw3Hd5Rn6evry3/8x3+QnZ3NpUuXGDlypOFx5eXlXdO5apyrec8997B3714iIiJYt25dk3NgvW/YyJ133slrr73G5MmTGTlyJK+//nqrcjWnTJnCzJkzr3rORURERG5VnZZD7ChbsrKyEg8PD9vnly5dory8nLvvvtu27OzZs/Tu3dvuTUSOOMqSNMqebE3mpVGepXV589sXmh/XtWpcY+OPW3sOrK43V/Nq8ynHUkRak0MsNw99/xbpxNg1R01n86bR2dm5STMM4Ovr26pG0FGWpFH2ZGsyL43yLK3Lm7ueZhia1tj449aeA6vrzdW83vlERG7E7t272b59+zVvf7XMdqNs+JbmKCwsZPLkyVy4cMG27ODBg3bLHMnKymryrIyI3JxumhxiERGR5v77v/+bsrKya97+apntRtnwLc3x7bffYjKZ2LZtm23Z+vXrMZlMDh/Sbuzrr7/mm2++ucbqRaSzqCEWEZEOd+bMGaKiovjf//t/89prrwFgsVhYunQpEyZM4OGHH+bMmTO27Y3Wmc1mnn32WUaNGkVkZCQNDQ0kJiby6aefsmfPHqZOncpvf/tbfvvb39pSguBKNvyvf/1rJk+ebHvouaX5f/vb35KamgpcuY3v8OHDPPjgg7bPm8+TmprKvHnzGDp0qG3s77//nkmTJlFWVmY4j9E+ItJx1BCLiEi7McqjB+xy5mtqalrMPTdat337dnr37o3JZGLixIkcPnzYltnu5+dnmEEP9tnwLc0BcNddd3H58mW+++478vLyGD169FXz3Rtnw5eXlxMZGcnSpUsZMGCA4TxGefIi0nHUEIuISLsxyqMH7HLm3dzcWsw9N1q3a9cufve73wEwZ84cHnroIdv2jnLXwTgb3tEcVpGRkWzdutX24ODV5mmcDb9mzRp++OEHfHx8WpzHKE9eRDqG3pkpIiLtJi4ujri4OLvl1px5T09PYmJiOHDgAEFBQQwZMoR58+Zx+vRpDhw4YHv7p9G6kydPUlpaSlBQEOvXrycwMNA2vjV3PTY2lvnz5zeZ2ygb3tEcVlOmTCEyMpK6ujqCgoKuOk/jbPj4+Hjc3Nx47rnn2Lx5s8PjdJQnLyLtT//3iYhIh/Pw8CA6OpqFCxdSU1NDYGAgU6ZMYefOnUybNo3IyEj8/f1t2xutmz59Ohs3biQqKoqPP/6YX/3qV7b8dg8PD9avX09sbCyVlZWkp6fbxvrkk0948sknWbFiBbGxsS3OYdWrVy969OjB2LFjmxzHyJEjHc5j5eLiQnR0NJWVlWRkZLQ4j4h0jk7LIZbbi77+ItLaHGKjnHloOffcaF3zTHVrZvtPP/3kMHe9pWz4tsq6v5rrzZNva/r+LXIb3zJhsVj44x//iL+/P2azmT//+c+2dU899RRr1qyhR48e1zTW6dOnef75522f+/j4MGvWLIYPH264fVVVFeXl5dx3331kZ2dTV1fHpEmTbuyARERuM0Y583Al99wRo3XNG9Bu3boBV3LXHW3TUjZ8S/MbaWmelrR2HhFpP7ftLRMlJSWcPHmSf/u3f+Pzzz9vsi4nJ6fJwxJXU1VVRVVVFevWrWPdunVMmTKFRx55BIvFYrh94xzMwMBAgoODr/9ARERERKRddfgVYovFwvLlyzGZTDQ0NJCcnEy/fv24dOkS0dHR1NTUAJCSksKPP/7IokWLqKurIyQkhMWLFxvuazabWbJkCUVFRXh7e7Nq1Sr+9re/ceLECfbv3++wljNnzjQZ/5VXXjGsD8DV1ZW77roLgLFjx+Lm5mb7s1zzuhMTEykqKiIvL4/y8nJqa2vp1q0bubm5nDt3DhcXF1atWkXfvn1ZsmQJX3zxBf369WPQoEEsXry4nb8CIiIiItJYu14hNsqfdJTzaJTl2DynMjMz03Df9PR0fHx82L17N4899hjvv/8+CxYsYMyYMYSGhjqsrzU5mMXFxcyaNYuZM2fy0EMPMXv2bNzd3Q3rtuZghoeHU1VVRWVlJWazGYvFQlZWFlOnTiU5OZm0tDQeeOABsrOz6du3L+Xl5e341RARERERI+3aEBvlTzrKXzTKcmyeU5mTk2O4765du5gwYQIAY8aMafLe+F69evHTTz81PWhnZ9zc3FqVgzlgwABbfNCiRYvYsmWLw7odCQkJAcDPz4+Kigqys7NtkT/jxo27oXMtIiIiItenXW+ZMMqfdJTzaJTl2Dyn8oEHHiAyMtJu3wcffJCSkhIefPBBjhw50iRX8t577+XEiROcP3+eu+++m4KCAry8vHB2dr7mHEyAX/ziF/Tv3x8Af39//vSnP9HQ0NBi1mVz1oxJ6xPYw4YN48SJEwQEBGAymW7sZIuIiIjIdenwe4inTJnCzJkzMZlMlJaWkpSUBFzJcoyPjyc/P5/a2lrS09P5r//6L6KjowkICKCmpobnnnuOp556ym7fmJgY5syZQ1paGrW1taxcuZKLFy8CV5rQpUuXMnToUAICAiguLiYtLQ34Zw6mdfzAwEDuu+8+w/qa8/T0pLi42LDu6Oho9u7de9UmNyoqinnz5vHmm29isVgYMWJEW51mEREREblGnZZDbJS/aJTlaJRT6Si78cKFC3h5eRnOV19fz9mzZ/lf/+t/4eTkZFt+PTmYzRnVbX3gzsXFxeF+x44dw93dnf79+7N27Vp69uzZJCT+VqIcSxFpbQ6x3Bz0/VukE3OIjfIXjbIcjXIqHWU3OmqGAe644w5++ctf2i2/nhzM5ozqtuZgtsTT05PZs2fj7OxMQ0MD27Ztu+Y5RURudbt27aKoqIhRo0Zd81/IbjTb/auvvuLll1/m66+/ZvTo0cyZM4dz585RXV3N5MmTr3mc66kjMzOTDRs2cPHiRSIiInjhhReajNM4w15EOtZtm0N8K/Dz8yMnJ4esrCxyc3P513/9184uSUSkQ2RmZvL6669z//338+qrr17zcxQ3ku1+6dIlHn30USZNmoTJZGLKlCk8+eSTnDp1irKyslaN1do6KioqSEhI4M0332TDhg0UFBTw2WefNRmncYa9iHSs2/ZNdbeSO+7Ql0FEupaamhrefvttBg8ezNGjRzl27BglJSXs27ePiooK3NzcWLZsGYcOHSInJ4d9+/Zx/Phx8vLybNnumZmZnD9/nrq6OkaMGEFhYSFhYWHEx8cbZtbv27ePwYMHM2PGDADCwsJISkqioKAAwDDTvm/fvmzatMkuR/7QoUOtypifPHmy7VXSPj4+rFmzhosXL9qOZ+bMmbYM+08//ZT9+/fb1S8i7UdXiEVEpN0Y5dEDPPHEEwwePJiHH36YpKQkHnvsMSoqKujRowfbt29n7ty5vPPOO5jNZk6ePElhYSFAk2z3qqoqcnNzCQgIwNXVlby8PPLz81m/fr1hnvyuXbvsIi6HDx9ue42zUaY9YJgj39qM+fvvv5/o6GhGjRpFSEgIb731Ft7e3rZxAFuGfX19vWH9ItJ+1BCLiEi7Mcqjh3/GT+7YsYNnn32WV199FcAWmxkcHMzevXsBmDhxIm5ubnZjh4eHA1cSg4YPHw5ceZbko48+MsyT79Wrl92tETt37uSbb74BWs60b54j39i1ZMx///33zJkzh5KSErZu3crZs2dZtWqV4TlzlIcvIu1HDbGIiLSbuLg4jh07Zndv7Ny5cyksLOQXv/gFI0aMsOW0l5SUAHDw4EH8/PyAf2a4N9c4BciaHnT58mWGDRtGZGQkGzduJCEhgYiICADGjx9PVlYW586dA668IfXVV1/F29sb+GemPWCXad88R74xRxnzgO3e6EOHDhEfH8/ly5f55S9/ydy5c205980FBQUZ1i8i7Uc3r4qISIebN28ezz//PL6+vlRWVpKYmEhWVhbp6ekcPnyYc+fOkZKSwpEjR1o99pQpU1ixYoVdnvzQoUNZvHgxv/nNb+jVqxfFxcW89957XLhwgR9//NEw0/56GGXMT5gwgQ8++ICQkBCGDh3K6dOn+ctf/kJxcbFtP39/f/bu3UtERATr1q27ah6+iLSdTsshltuLvv4icj05xN999x19+vQBYMWKFfj6+vLII4/Y3ih6I1rKkz9z5gx33323YVZ8S5n216KljPmamhqqq6ttV6Wba5xh35o8/Buh798iN9EV4tTUVLy9vRk1alSHzGfNezx16lSrsyRPnz7N888/b/vcx8eHWbNm2e5ha85isfDHP/6RkSNHEhkZecO1i4jcLqzNMFy5BcLV1ZXevXu3ydgt5cm3lNpwI80wtJwx7+bmZng/tFXjDPvW5OGLyI25aRrisrKyDn270fHjx0lJSSE+Pt7u6eerqaqqoqqqii1btgBQVFTEI488wvfff4+rq6vd9iUlJZw8eZLVq1e3Se0iIrejF154obNLaBPWjPn6+nrFaorcIjr8/1RHOY8AGzZsIDExkT59+pCYmEj37t1ZtGgRdXV1hISEsHjxYsNsydTUVFtO5YABA1i9ejX+/v6sXbsWDw8PMjIyqKmpASAlJQVPT09b3qOTkxOhoaE8/vjjdnXt2bPHLl/y3nvvBcDV1ZW77roLgLFjx+Lm5saPP/7ImjVr7Or729/+xokTJ/j4448pKipqsn7//v222g8fPmx4fEYZmH379uWll17i6NGjeHt783//7/8lISFBuZUiIjcJNcMit452TZkwyp90lPMI4O3tTUFBAbGxsbz77rts3bqVkJAQ0tPT8fPzIyMjwzCbsXFO5dixY9m6dSsAH374IQMHDmTGjBns2LGDMWPGsGnTJuCfeY9BQUFUVlYa1mWUL2lVXFzMrFmzmDlzJg899BCzZ8+moKDAsL4FCxYwZswY7rjjDrv1jWvPyclxeHzN69i+fTu9e/fGZDIxceJEVqxYodxKERERkevQrg2xUf5kSzmP48ePB2D06NEUFBQwffp0Dh48SEhICGVlZezZs8dhNqM1pzImJob09HRKS0vx8/OzNdKRkZHs2LGD2tpaw1od1eUoe3LAgAHExcURFxfHokWL2LJly1WzIx2tt9be0v7N69i1axe/+93vAJgzZw7fffedcitFRERErkO7/j3H2jA2Zs15fPDBB+1yHk+ePAnA0aNHCQsLw2Qy8cYbb+Dp6UlMTAx33XUXkZGRzJs3j9OnTzfJcLQ+jdynTx+8vLxISEhg1qxZJCUlERoaSmxsLPPnz3dYq6O6HGVP/uIXv6B///7AlaicP/3pTwQGBjJkyBDD+uBKtmTz9Waz2TaH0frmx2etY8iQIZSWlhIUFMT69esBHJ4bEREREXGsw29wainn8ZNPPqG4uJiqqipWr17N2bNniY6OJiAggJqaGuLj43nqqaeums04Y8YMFixYQFJSEq6ursTHx5Ofn09tbS3p6eksXLjQlvdYU1NDcHCwYV25ubnXfFyenp4MGjSIlStXOqxvypQpzJw5s8n648ePt7jekenTp/PMM8+QlpaGxWJh3bp1zJ49W7mVIiIiIq3UaTnEjnIeKysrbe+VB7h06RLl5eXcfffdtmWtzWY0m804OTnh7u5OdXU1d955J9A07/FqdbXG1eq70fWNNT6e1u7blpRjKSLXk0MsnU/fv0U6MXbNUdPZuBmGK7cKNG6GofXZjD179rR93Lh5bJz3eLW6WuNq9d3o+sYaH09r9xURuZ1cS758a3Pk27NOb29v/vznP7NmzZom60tLS8nJyeH3v/99h9Uk0tUpE0ZERG4L15Iv39oc+fasc+nSpezZs8du/cWLFzlx4kSH1CIiV6ghFhGRDmfNpP/iiy/o168fgwYNYuHChXZZ7CaTyTAP3mKx2G1rzZf39vZmwIABPP74403y2jdv3gwY58j//PPPAHZj+vj4EB0d3STL3tXV9Zpqd5Qjb61z4sSJtvNRXV3Na6+9xueff46Xl5fdX0ZFpH21a+yaiIh0bUZ59ABpaWk88MADZGdn07dvX8rLyw2z2B3lwRtta82X79evH5WVlXZ57YcPHwaMc+Td3d0NxywrK7PLsr/W2sE4R95a54gRI2znY+PGjXh4eLBnzx6GDh3aQV8dEbFSQywiIu3GKI8eIDs72xZvOW7cOMBxVrtRHvzVct8Bu7z2hx56CDDOkXc0pru7u12WfWtqd1R/c7t377ZdMf73f//3az/BItImdMuEiIi0G6M8eoBhw4Zx4sQJAgICMJlMgHEWe0VFhWEefEu57VbN89oDAwNxdXU1zJFvaGgwHNMoy/5aa7dylGff/HyUlJQwbNgwjh071oozLCJtQVeIRUSkw0VFRfHBBx8QHh5OdnY2d9xxB1OmTGHnzp1MmzaNyMhI/P39He5vtK01X/7LL78EruS1b9y4kaioKD7++GN+9atfGY7l6elJcXGx4ZgjR45k/fr1xMbGUllZSXp6+g3Xbq1z//79tmXTpk3j7bff5oknniAzM/M6z6qIXK9OyyGW24u+/iLSmhziY8eO4e7uTv/+/Vm7di09e/YkNjYWaF2eevNtjfLlm+e1t3bM5ln2p06duuHajeoE+Pbbb+nbt+8119oW9P1bpIvfMlFVVaUMSBGRTuDp6cns2bNxdnamoaGBbdu22da1Jk+9+bZG+fKtaYaNxmyeZd8WtRvVCXR4MywiV3Tphriurk4ZkCIincDPz4+cnBzq6+u5445b60fRrVy7iBjr8P+Tz5w5w6JFi6irqyMkJIRXXnmF6Oho/uu//ouBAwfy97//nT59+gDYZTcOGDDALg8yNTWVffv2UVFRgZubG8uWLcPV1dVuDqPMysZ/0lIGpIhIx7uVG8pbuXYRaapdH6ozyp/cunUrISEhpKen4+fnR01NDeHh4aSmpgJXshjHjx9vmN1olAdZUVFBjx492L59O3PnzuWdd94xnMNRRqSVMiBFREREuqZ2bYiN8ienT5/OwYMHCQkJoaysDDc3N6ZOncr27ds5efIk3t7e9O7dG7DPbjTKgwRseZDBwcHs3bvXcI6rZVYqA1JERESka2rXhjguLo5jx46xcuVK2zKTycQbb7xBfn4+xcXFHDhwwHaLwvLly5kxY8Y/i2uW3WjNg0xNTWXIkCG27UpKSgA4ePAgfn5+hnMEBQURGRnJxo0bSUhIICIiokmt1gxIQBmQIiIiIl1Ih98A5eHhQXR0NAEBAdTU1BAYGAhcuXL89NNP2yU+NDZy5Eji4+PJz8+ntraW9PR0fvvb35Kens7hw4c5d+4cKSkpVFRU2M1x3333MXPmTEwmE6WlpSQlJTUZe9q0aUybNo1t27ZhNpu555572vU8iIiIiMjNocMb4vDwcEaPHk15eXmTB9d69erFzJkz6dGjBwBPPfWUbd3YsWMZO3YsAL/+9a+b5EG+/fbb/PnPf+aRRx7By8vLdlW5+RzdunVj+/btdhmRX3zxBXDltozPPvusUzIgRURERKTzdMojss7Ozk2a4c2bN5OSkmJ31dZI8zzI7t274+rqarvv2NEcVlfLiFQzLCLSMd5++23bLXGjRo26pgeas7OzqaurY9KkSe1dnoh0ITdFZkxUVBRRUVHXte8LL7zQxtWIiEh7+/bbb9m8eTOzZs0Crj3CLDAwsElykYhIW7gpGmIREelavvrqK8aOHUtoaCgDBw7E2dmZ9957zy5X/tChQ+Tk5LBv3z6OHz9OXl4etbW1dOvWjczMTM6fP09dXR0jRoygsLCQsLAw4uPj7XLn+/XrR2pqapOxRESs2jVlQkREujajPHq40hBv2bKF1atXExYWxqFDhwxz5c1mMydPnqSwsBCAqqoqKisrMZvNVFVVkZubS0BAAK6uruTl5ZGfn8+mTZsMc+ebjyUiYqWGWERE2o1RHj1AZGQkn3/+OUlJSbz22musWrUKsM+VB5g4cSJubm52Y4eHhwNX0ouGDx8OgJeXF7t27XKYO+9oLBHp2nTLhIiItJu4uDji4uLslmdkZODr68uYMWNoaGigT58+gH2uPPwzk745a1oQgJOTE3Alt37w4MGMHj2aefPmcfr0aQ4cOGDbztFYItK1qSEWEZEON3z4cKZPn87AgQOprq7mr3/9K2lpaXa58keOHGn12OPGjeP11193mDsvItKcGmIREelw99xzDwUFBfzjH/+gV69etuXNc+WtL2+yapxRb/XXv/7V9nFaWhqAYe68NdFCRKS5m6YhTk1Nxdvbm1GjRnXIfFVVVZSXl3Pq1KlWZ1o+88wznDt3rsmyRx99lKeffvqa5rzvvvuuq2YRkdtN42bYUa789bpa7ryIiNVN0xCXlZXZAto7wvHjx0lJSSE+Pr7VmZbx8fHU19fz0ksvMWrUKCIiInB3d7/mOfXnOxERe8qVF5HO0uENsdlsZsmSJRQVFeHt7c2qVatsb4fbsGEDiYmJ9OnTlVLFAQAAIABJREFUh8TERLp3786iRYuoq6sjJCSExYsXXzVbcsCAAaxevRp/f3/Wrl2Lh4cHGRkZ1NTUAJCSkoKnpyeJiYkUFRXh5OREaGgojz/+uF1de/bsITc3l3PnzuHi4sKqVau49957bQ9/uLu74+XlxV133WVX1/vvv4+npye///3vmTx5MomJibY58/LybE9Hi4iIiEjnatfHbY3yJ9PT0/Hx8WH37t089thjvP/++7Z13t7eFBQUEBsby7vvvsvWrVsJCQkhPT0dPz8/MjIyrpotOXbsWLZu3QrAhx9+yMCBA5kxYwY7duxgzJgxbNq0CYCFCxcyfvx4goKCqKysNKzLbDZjsVjIyspi6tSpJCcnGx5nTk6OXV0LFy7knXfe4YUXXiA4OJiBAwfa5lQzLCIiInLzaNeG2Ch/cteuXUyYMAGAMWPGsHv3btu68ePHAzB69GgKCgqYPn06Bw8eJCQkhLKyMvbs2XPVbMmYmBjS09MpLS3Fz8/P1khHRkayY8cOamtrDWt1VFdISAgAfn5+VFRUGO6bmZlpV1fPnj157rnn+OCDD/jTn/50vadQRERERNpZuzbEcXFxHDt2jJUrV9qWPfjgg7acySNHjthC2AFOnjwJwNGjRwkLC8NkMvHGG2+Qn59PcXExDQ0NREZGsnHjRhISEoiIiPjngfxPtmSfPn3w8vIiISGBWbNmkZSURGhoKKmpqQwZMsRhrY7qso7b0v3NQUFBdnWZzWbefvttoqOjWbFiRavOm4iIiIh0nA6/hzgmJoY5c+aQlpZGbW1tk2b5k08+obi4mKqqKlavXv3/2bv3qKrq/P/jT1DQQCdgFAxkFMdLjRgjnJYmoliZNo45KQKijBpeu2k4rppsHM9kTiMjWl4zv15ixMFQLokpclExsFJTlMahxNHUpGxAIDwIyu8PfmfPuewDhzvo+7FWa8k++/PZn33Yn82nvT/7tbl69SqhoaEMHDiQ8vJytFots2fPrjNbMjw8nIULF7Jp0ybs7OzQarVkZ2ej0+lITEwkMjISLy8vjhw5Qnl5OX5+fqrtSk9Pt2qfJk6cyPTp043a9eqrrzJv3jyef/55hgwZwrhx45RtZmVltViahhBCCCGEqJ1NdRNFO9jY2BAXF0dwcLBV6//3v//FxcXFbHlxcTFOTk7Kz3fv3qWwsJCHHnpIWWaaLVmXsrIybGxscHR0pLS0lK5duwJw+/ZtOnToQIcOHepslzWsaZfaNu8F9f39CyHuPbt37yYkJKRFE4NE48n5W4hWjF2zNOg0HAxDzZQFw8Ew1D9bskuXLsq/9YNhAHt7e6vbZQ1r2qW2TSGEuN80Jnu+PpnuqampFrPmMzIyKC0t5de//jWvvPKKstzd3Z0ZM2YwZMgQq9tU23Ykg16Itq/N5BALIYS4fzQme74+me4+Pj4Ws+YvX75MUVERffr0oaSkhN27dwNw+vRpxowZww8//ICdnZ1VbaptO5JBL0TbJwNiIYQQrcI0e97Ly4vQ0FCj3Hg7Oztef/11zpw5g5ubG3FxcUaZ7v7+/mY58MePH1ey6d988010Oh3h4eFmdRuys7Oje/fuAIwaNQoHBwdu374NYFY/YJSR/+abb3L48GF0Oh1PPvmk2Wf69mZkZLBp0yajNhw4cEA1776srMxov//xj38QFRVllsMvhGgazZoyIYQQ4v6mlkevZ5o9X1BQYJYbn5SURLdu3cjKymLs2LGcOnXKKNNdLQfeMJu+pKSE4uJi1boN5eXlMWPGDKZPn85jjz3GzJkzcXR0VK3fNCO/vLxc2Y7aZ/r2/uIXvzBrg6W8e9P9XrlypWoOvxCiaciAWAghRLNRy6PXM82ed3R0NMuNP3DgAM8++ywAs2bN4rHHHjOqQy0HHv6XTa+nVrehPn36sGzZMpYtW8aiRYuU6RNq9Ztm5Btup7bPLLVBLe/edL+///57izn8QojGkykTQgghmo1+kKnGNHtenxsfERHBiy++CIC3tzf5+fn4+vqybds2fHx8jOrw9fXF29ubefPmcenSJb744gvKysqUDHk9tboNPfDAA/Tu3RsALy8v/vjHP3Lnzh3V+vUZ+c7OzoSFhfHFF18o9dT2maU2qOXdm+43QFBQkFE7hBBNRwbEQgghWoVp9vx//vMfs9z4Xbt2MX/+fBISEqisrGT69Olcv35dyXRXy4E/e/as2baGDx9uVvfzzz9vsW3Ozs7k5eWp1l9aWmqUke/j48Pp06eBmqQk089u3LjBkSNHmDx5Mtu2bTNqQ3h4uOr2p02bZrTfW7ZsYebMmXXm8AshGqbVcojFvUV+/0KIhuQQm2bPW8qNN/w3mGe6W5MDb6lua5jWr5aRr6f2mb69t27dqlcbTNepbw6/NeT8LUQbukLcmEzKhtDnQl68eNFidqQl8+fP59q1a0bLOnbsyIwZM+pVj9758+fZs2cPS5YsUZbNnj2btWvX0rlzZ7P19XmXI0eOlGxLIUS7Zpo9byk33nTgaJrpbk0OvKW6rWFav1pGfm2f6dtb3zaYrlPfHH4hhHXazIC4MZmUDaHPhdRqtRazIy3RarVUVVXx+uuvExAQwLhx4ygrKzM60dVHUVERn3/+udGytLQ0iw9N6PMuJdtSCCGEEKLxWnxAXFZWxtKlSzl9+jRubm6sXr2aHj16AOaZlJ06dTLKc3zttdfM8iB79uxJfHy8kjnZp08f1qxZg5eXF+vWrcPJyYnk5GSj3EdnZ2clF9LGxoahQ4cyadIks3ZlZmaq5kO6uroCNU8Mu7i44O7uTlxcHDqdDnt7e1JSUvjuu++oqKjA39+fzz77jGHDhrFixQoqKytVMy0t2bVrl1kbTp48iU6nIzk5Wcni7Nu3r1n2pRBCCCGEqFuzxq6p5U8mJibi7u5ORkYGzz33HFu3blU+M82kNM1zTE5OVs1hNMycHDVqFHv27AFg586d9O/fXzV7Up8L6evrS3FxsWq7LOVDqtFnUJaVlVFSUkJ6ejoDBw7Ezs6Ow4cPk52dzbfffquaaVkbtTbot2WYxamWfSmEEEIIIerWrANitfzJAwcO8PTTTwMwcuRIMjIylM9MMylN8xwzMzMt5jDqMyfDwsJITEwkPz8fT09PZSBtKXuyrnap5UPWJTAwEKiZGzdkyBAAXFxcKC0tVc20/PnPf86tW7eM6rC1tVXyK61pQ23Zl0IIIYQQwrJmHRAvW7aM3NxcVq1apSx79NFHOX/+PABffvklw4YNUz4zzaTU5zlmZ2eTl5fHnTt3CAoKIjY2lqioKMaNG/e/Hfn/OY6urq64uLgQFRXFjBkzlNzH+Ph4vL29LbbVUrvU8iHrYvj0r42NjVK+uroaX19fs33o27cvX331Fd999x0AOTk5uLi4KNu2pg2m35VkVAohhBBCWKfF5xCHhYUxa9YsEhIS0Ol0RoNl00zKq1evGuU5arVaZs+eXWcOY3h4OAsXLmTTpk3Y2dmZZU9GRkbi5eXFkSNHKC8vx8/PT7Vd6enpTb7/apmWtra2vPXWWwwaNIiBAweSl5dHQkJCnXXp9yErK0s1+1IIIYQQQtSt1XKI//vf/+Li4mK23DSTUi3Psb45jJayJ01zLGtrV1NT24eqqiquXr3KL37xC+XKcl0M96G2XMzmJjmWQoiG5BCL1ifnbyFaMXbN0qDTNJNSLc+xvjmMlnIfTXMsa2tXU1Pbh44dO9KrV6961WO4D7XlYorWZe3/4Ii2QQZ09w595rzktQshatNmcoiFuNctXLiQxx9/vLWbIWqRk5PDmjVrWrsZoglJXrsQwhoyIBaihTz++ONyS7IdkAFxy/jggw/49NNPKSoqwsHBgRUrVnDy5EklUz4nJ0c1s37Xrl0Ws97feOMNszL6zPnDhw/j7+9vlgN//PhxZZtnz55t7a9FCNFKmjVlQgghxP1NLY8eat7Q2blzZ5KSkpgzZw7vv/++Uaa8pcz62rLe/+///s+sjGFeu1oOvOE2hRD3LxkQCyGEaDZqefR6+nhLPz8/jhw5AvwvU762zHpLWe9paWkWywCqOfCG2xRC3L9kQCzEPaqkpISXX3652er++uuvSU1N5eOPP25QWXF/UMuj19Nnv584cQJPT0/gf7nrtWXWW8p679+/v8UygGoOvOE2hRD3L5lDLMQ9qqKigszMzGapW/+gklarNbsVbm1ZechJJCYmcurUKa5du0ZMTAxffvml8lltmfWWjBs3jpUrVxqV6dy5s5LXrpYDL/OGhRAgA2Ih7gu7du0iPT2da9eu0aFDB1avXs2iRYtYs2YNXl5erFu3DhcXFyZPnmz20BHAokWLqKioQKPR8OabbyoPKtnY2DB06FAmTZrE0qVLOXfuHD179mTAgAEsXryY0NBQysvLAYiJicHZ2Vkpu2/fPjIyMowegDp27Jg84HQfWbJkCWPGjFHezGn4QqGePXty4MABs2z42bNnK//+29/+pvxb/zKjJ554wqzMmTNnlLz2pKQkoxx4Pz+/5txFIUQ70WbuE8XHx5OVldVi22vMLd/58+czYcIEo//ef//9ZmqpEI1XVlZGZWUl+/fvJzg4mB07djBq1Cj27NkDwM6dOxk7dqzqQ0d79uxBo9GQmJiIp6cn5eXlyoNKvr6+FBcXk5CQwCOPPEJqaio9evSgsLCQgoICwsPD2bdvHyNHjmTXrl0AStni4mKzB6DkAaf7R6dOnbCzs6Nbt261TlloSDa8aRl7e3ujFzB5eHhY/WInIcT9oc0MiAsKCrh+/XqLbe/s2bOsWrUKHx+fel8h0Gq1bNy4kQcffJDf/va3bNy4kdDQ0GZqqRBNQ6PRAODp6UlRURFhYWEkJiaSn5+Pp6cnLi4uqg8dTZs2jRMnTqDRaCgoKFB9+Cg1NVWZr/nUU08B4OjoSHJyMkFBQezbtw+dTmdUxtJDU/KA0/1hwYIFEkMohGgzWnzKRFlZmWq2JMD27duJjo7G1dWV6OhoOnXqZHSr9rXXXjO7nduzZ0/i4+OV26x9+vQxug3s5OREcnKyxdu2prd8DduVmZlpdpu5b9++uLq6AjV/8F1cXHB3dyc0NJS//OUv9O/fn3fffZekpCR+8YtfGGVsenl5UVlZqboPQjQ3/VU4/VvYXF1dcXFxISoqihkzZgA1Dx15e3szb948Ll26xBdffEFWVhbvvfcezs7OhIWF8cUXX5jVPXjwYL766isGDhyo3OnZtGkTQ4cOJSIighdffNGsjP6hqUcffdToASh5wEkIIURLa9a/PGr5k5ayJQHc3NzIyckhIiKCzZs3m92qTU5ONrudCxjdZjW9Ddy/f/9ab9vqb/mqtUvtNrMlgYGBxMfHAxAbG4tGozHL2ARUb0kL0VrCw8PZv38/Y8aMAWDixIl88sknTJ06laCgILy8vHByciI0NJTIyEjKy8vx8fHBy8tLeVAJICQkhA8//JDAwEBSU1Pp2LEjw4cPZ9u2bURERCh9DFDKenp6snXrVqZMmcL777+vDMqFEEKIltasV4jfeust9u7dy+jRo5UnhA8cOKDkUY4cOZLNmzfzxhtvADB69GgARowYwd///ncSEhJ44YUX0Gg0jBs3jh9//JHz588TFhZGVVUVjo6Oyrb0t1nDwsKYOHEizz77LJ6ennh6evLBBx+wY8cOfvjhByZMmKDaVrV2hYSEGN1mrm1eY3BwMM888wwhISG4ubnRrVs3vL29gZqMTf0+pqSkWNwHIZpS9+7dOXfuHGD8INKoUaMYNWoUAJMnT2by5MnKZ05OTmYPHUFNnywsLOShhx4CwN3d3ehBpdzcXNasWUPv3r1Zt24dXbp0YfTo0Tz++OPY2Njg6OhIaWmpWdkpU6YYPQDVp0+f5v9ihBBCCBPNOiBetmwZy5YtM1pm6TYpwIULF4CaJ4KHDRtmdqu2e/fuBAUFGd3O1dPfZjW9DVzXbdu62mV6m9kSFxcXHnroId555x3Cw8O5ePGiasam2i1pIdoaDw8Po59tbW2VwbCevb298m9nZ2dmzpyJra0td+7cYe/evQB06dJFWadr166qZRvy0JQQQgjRlFp8DnFt2ZIHDx4kLy+PkpIS1qxZw9WrVwkNDWXgwIGUl5ej1WqZPXu2UYakmvDwcBYuXMimTZuws7NDq9WSnZ2NTqcjMTGRyMhI5bZteXk5fn5+qu1KT0+v175NmzaNuXPnsnbtWt577z2zjE1ANQdTiPbO09OTtLQ0qqqq6NhR0hyFEEK0LzbVdV36tLYiGxvi4uKsfmrYNCdSr7i4GCcnJ+Xnu3fvGt2qBcxu59alrKzM6Lat/krV7du3lVu+dbXLGpmZmXz88cdER0ezcuVKPDw8jDI2DdV3H9q6+vz+L126xJIlS3j++ecZNWqU8qape1l9+4doHbt37yYkJKTOO0JCnXx/7ZOcn4RoxRdzWBp0Gg6GQf1Wrent3LpYc9u2rnbVJS4uzujtW4YZm2rquw/3kh9//JELFy7w5JNP0qdPH2bMmMGMGTOUaSVQE+NVUVHB+PHjm3TbJSUlFBYWcvHixXrXry/br18/q9ZdsmQJa9euVZZ99913bNiwgRdeeKFBbRfiXjd//nyuXbtmtOw3v/kNc+fObVB9DTmPZGRkUFpayoEDB5q0LUKItk3ubTaRkJAQQkJClJ8XLFjQiq1p23x9fcnJyeH8+fNs376ddevWsWzZMp544gnCw8OZPHkyPj4+9X4lsDVa6pXDaq9NTk1N5d///nezvU5ZNN4DDzzQ2k24r2m1Wqqqqnj99dcJCAhg3LhxjXrwuCHnkcuXL1NUVNTkbRFCtG0yIBat5uGHH6Z79+4cPXqUb7/9ls2bNxMREcGCBQvw8/Nj5MiR9O3bt12/cri0tJTly5cDcPz4cW7fvt3yX7SwyvHjxyUTvAWVlZXx+uuvc+bMGdzc3IiLizPLeO/evXud2fNvvPEGKSkpfPfdd1RUVODv789nn33GsGHD8PHxQafTMX36dNXXl/fp08esr+up5c3fvXuX4OBgo/Xt7OzMziGvvfZaC3+bQojGkgGxaFXffPMNOp2Op556iqeeekp5ADE6Opr09HR69eqFq6srBw4cICUlxeiVw3/4wx/YuXMnKSkpRvnOe/fuRavV4u3tjUajYfHixezYsUN55XBMTIzZK4ejo6N54403jF45PH78eKKioti1axcvvPCCUlb/yuHo6Gh2797N1q1bcXd3V33lcGxsrDINyMHBAWdnZz766KPW+KpFHSZPnsyVK1dauxn3nDt37nD37l1sbW2NntdISkqiW7duZGVlsWXLFk6dOsVjjz1mVFatX3/wwQdG2fM7d+6kpKSE9PR05s6di52dHYcPHyYwMJCOHTvy85//HDB+fXlMTAw7duxg+vTpZn29trckqp0bunbtanYOEUK0P/JKKNEqVq9eTUBAAImJicycOZOAgAAuXryIu7s7r732GsuXL2fRokX06tWLM2fO4OHhwdatW8nNzWXKlCnt5pXDGRkZjB07FoCf/exnXLhwARsbG/mvDf6nf7GOaFpvvfUWfn5+Ss673oEDB3j22WcBmDVrltlgGFDt13qG/S0wMBCoeQZlyJAhQM3zIPrsaz3T15fX1ddNqa2vdg4RQrQ/coVYtIpXX32VV199lXnz5jFv3jx+/etfm63j6enJgAEDePbZZ+natStr167l8OHD/Otf/8LGxoY///nPbf6Vw4MHD1byqPv06YOnpyfPP/98g7830bzy8/M5fvx4azfjnqKWRw/g7e1Nfn4+vr6+bNu2DR8fH3x9fY3WqS233bC/Gab16FNrqqurzdIuTHPlrc2p11NbX+0cIoRof2RALFqV/upcbTp37sycOXPo168fW7ZswdPTk40bN/LPf/6TH374gZ9++onx48cza9Yso3zn0tJSoxxrHx8fbty4YZQ/HRISwrx581i/fj2VlZX4+/szfPjwWrOrR44cydatW40yq48ePara9qlTpzJ16lQArly5gr+/v0QbtWG7d+9u7SbcN6ZNm8b8+fNJSEigsrKS6dOnm63T3Lntan29tv9hVVt/165dZucQIUT702o5xOLe0tK//9u3b3Pw4EFiYmJISEiga9euymuIAwIClCtGajnWhvnTubm5ODo6Gr1yOCIiwqrs6vpkVkv/aB8kR7dxGvL9GfYvS5ozt91SX7d2/YsXL6qeQ9oTOT8J0UavEOtzIB944AGLGZLx8fG4ubkREBCgLNNnTupPVPryI0eOrDU/9tKlS7zyyivKz+7u7syYMUOZi2aqMVm2omnY29szfvx4xo8fz9WrV/nHP/7B5s2b2bx5M35+fsyZM4cpU6bQtWvXdvXK4ebOX+7Xr1+9t1Gf/OWTJ0/y97//na1btyoRZi+99BJr1qyRN9gJVXUNQKF5c9st9XVr17d0DhFCtC9t8qG6y5cvU1BQgI+PD35+fqrrFBQUcP36daNl+vVNy589e9boFdGmSkpKKCkpYcuWLWzZsoWJEycyZswYKisrVdfX11db+0TL8fDw4LXXXuPrr78mKysLPz8/Xn31VVxdXQkODiYtLc3iFSv9K4f3799Peno6Dz74YAu33lhzHVOGfaC+26ir/xj6/vvv2b9/P2+99ZayLCMjg7t379avwUK0E23tHCKEaJgWv2RjmB956tQp1YxJvcOHD6PT6QgPD1fNity+fTvR0dG4uroSHR3NiRMnjJ4S1pdPTk7m9OnTHD58mE2bNvGXv/yF/v378+677+Lq6oq3tzd2dnZ0794dgFGjRuHg4IBOp2Pq1KkW82j1Wbb29vZm+ZY9evSQbMoWZmtry/Dhwxk+fDgrV64kLi6OzZs3M3r0aPr378/zzz/PjBkzcHNzMyvbVq5e6o9ZtWOqb9++TJgwwSiDuWvXrly+fNnq/OXDhw9TWFiITqezOoPZsKxGo2Hp0qUWM5hXrlzJlClTOHjwIFOnTmXgwIHKvt29e9esbn2cnlqG7IoVK6isrKz1HCFEW9FWziFCiIZp1ivEd+7cobKy0uhNQYb5kYYZky+++CJardaofElJCcXFxUr24759+xg5ciS7du0CwM3NjZycHCIiIti8ebOyvmn5yMhIRo8eTWBgIIGBgUq8UmxsLKNHjwYgLy+PGTNmMH36dB577DFmzpxJYWGh6nb19emzbA3zLYODg9mxY4eSb5uamkqPHj0km7KFPfjgg8yZM4cTJ05w7tw5nnvuOf7+97/j4eHB6NGj+eijjyzeAdD7/vvvWb58OYGBgfTt25df//rXzJo1i+zs7CZpo1r/0B+zascUoGQwA+zcuZOOHTua9aE9e/ag0WhITEzE09NTyV/W9wH9NtSOUbW+Zlg2MTERd3d3MjIyeO6559i6datRnwaws7Njw4YNzJ8/3+jKvFrdZWVlSobswIEDlQzZ7Oxsvv322zrPEUIIIURTaNYBsaX8SX1+ZG0Zk4YsZUXqB7MjRowgJyfHqjYFBweTlJTEhQsXcHNzo1u3bkBNJJY+HmjRokXs3r27XhmVpvmWkk3ZdgwcOJB33nmHK1eusGvXLjp37syUKVP4xS9+wYIFC4zeLKeXkpLCgAEDWLt2Lf3792fWrFn85je/ITc3F39/f+bOndvoV0tb6h96pscUQFhYmFEGc05OToPyl6F5M5iHDBmCj48PW7ZsUZZZqru2DFlrzxFCCCFEYzTrPR5L+ZP6LMjaMiYNWcqKvHDhAgBnzpxR/rDXxcXFhYceeoh33nmH8PBwZfkDDzxA7969AfDy8uKPf/wj69evtzqj0jTfUrIp255OnTopSRRXrlxh586dvP/++7z33nvKg3hhYWH861//YtKkSYSFhbF+/Xrl4TCAFStWkJiYyNSpU3FwcGD16tUNbo+l/qFnekxBzetkXVxciIqKYsaMGVy/fr1B+cvQ/BnMK1aswN/fX7lrY6nu2jJkrT1HCCGEEI3Rqg/VTZw4kU8++YSpU6cSFBSEl5eX6nrDhw9n27ZtREREUFxcTGJiIgAHDx5kypQprFy5staYG31+rP6P/rRp09i7d2+tT9k7Ozvj7Oysul3T+tSEhITw4YcfEhgYSGpqqswva2N69uzJa6+9xjfffMMnn3xCnz59eOWVV/Dw8OD3v/89/v7+bNmyxWgwrPe73/2OTZs2sXbtWv7973+3eNvDw8PZv38/Y8aMUe1DTk5OhIaGEhkZqeQvqx2zaseoWl8zLBsWFsbWrVuZMmUK77//vvJiFDVdu3Zl+fLlfPfdd4Dlflwba88RQgghRKNUNxGgOi4urkFlr1y5Uq3T6Wpdp7S0tLqsrKy6urq6uqSkRFleVFRk1TYqKiqqq6qqqqurq6szMjKqX331VavKWdquYX1qzpw5U/3NN99UV1VVVa9Zs6Z6y5YtVm2vvWrM77+t+OGHH6q1Wm21jY1N9f79+2td9+7du9UeHh7Vb7/9tlV1N/f3Y9qH7ty5U33t2jWjdUyPWUvHqNoxb1r2xx9/bFA7LfWnulhzjmgKcXFx1U14WrzvyPfXPt0L528hGqtNXLa0JmPSUlakk5OTVdvQ58fGxcURExNj9RuPrMmjVSPZlO1Pt27dGDFiBNXV1cr8XUtsbGzw9fVVXsvc2kz7kK2tba35y1C/DGbTsg3NYK5v5qtec+bQitZRV751XZ/r8+onTJhASkoK27dv5+bNm4wbN44FCxY0W6a3EOLe1CYGxC0pJCSEkJCQZt+OPpuyqqpKpku0I/qHtqz5ndnb23P79u3mblKzkWNUtKazZ8/WenGirs8vX75MUVERRUVFREVFsXv3bqqqqoiMjGTw4MH4+Pg0+sFXIcT9Q/4KNjMZaLQvvXr1AuD8+fM8/vjjta77r3/9i2effbYlmtWs5BgVraGufGv955mZmWzcuNEsD16vsLCQW7duYWNjg7u7O2vXruXmzZtKprdOp1MyXHKMAAAgAElEQVSiNi9cuEBCQgK/+tWvJN9aCGGkTb6pTojW0q9fPwYMGGAUF6bm008/5auvvmLcuHEt1DIh2ie1vG2gznxr/eeenp6qefB6Dz/8MKGhoQQEBKDRaNiwYQNubm5K3vbcuXM5dOgQQUFBDBs2DB8fH8m3FkKYkQGxaFapqal8/PHHTV5vSUkJX3/9dYPq15e15K233mLbtm28++67vPzyy2afHzp0iGeffZZnnnmG4cOH17vtQtxP6srbBsv51lB3NvYPP/zArFmzOH/+PHv27OHq1atmcYiHDx8mJiZG+R9dybcWQpiSe6WiWTXXPD79/EKtVlvv+uuamzh58mT+/e9/8+qrr+Lg4IBGo8HLy4vi4mLS09P54IMP6Nq1K//4xz+aYleEuKfVlbcNlvOtoe5s7JMnT5KWlkZUVBS9evVizpw5aLVaZTpTQUEBCxcu5JNPPqFz586A9Rn4Qoj7hwyIRZO5fv262TL9PD57e3vS09O5du0aHTp0YPXq1SxatIg1a9bg5eXFunXrcHFxYfLkyWZz+wAWLVpERUUFGo2GN998U5lfaGNjw9ChQ5k0aRJLly7l3Llz9OzZkwEDBrB48WJCQ0PN5h7qy+7bt4+MjAyjeYvHjh0jLS2NTz/9VHkBx/z587l16xZQc7WqX79+DBs2rMFJC0IIzPKtZ82aRUJCAjqdjlWrVtG5c2eOHDnCnDlz2LZtG9nZ2eh0OhITE4mMjFTqefrpp/nwww/RaDQMGjSIS5cu8fbbb5OXlwfASy+9xE8//cTvf/97AP785z8zceJEpk+fTlZWFvn5+VanDgkh7l0yIBZNpqKiwmxZSUkJ5eXlODg4UFlZyf79+4mJiWHHjh2MGjWKPXv28Ic//IGdO3eSkpJiNLdv7969aLVavL290Wg0LF68mB07dlBeXk5kZCQxMTH4+vpSXFxMQkICjzzyCNHR0bzxxhsUFhZSUFBAeHg448ePJyoqil27dvHCCy8oZYuLi3F3dyc6Oprdu3ezdetW3N3duXDhAp999hk//fQTvXr14vTp06xevZpbt26xdOlSli1bxo0bN1rhGxbi3uHu7s6ZM2fo0KEDHTp04MCBA/z3v/81+h9N/eezZ8/GxsYGR0dHSktLAYxeChMbG0t5eTmlpaW4ubkBKFeZFyxYoLr9pKQkrl69Srdu3YzeliiEuD+1mTnE8fHxLfqK48bMQZ0/fz4TJkww+m/SpEnNMle2rVu9ejUBAQEAbNiwgYCAAC5evKi6rj7b19PTk6KiIsLCwkhMTCQ/Px9PT09cXFxU5/ZNmzaNEydOoNFoKCgowMHBwazu1NRU5Q/gU089BdQ999DSvMWxY8cabaNjx46cOHFCyTN94oknGvx91aW551w3ZBt1zbk2XVdt3nV+fj4bNmywepvi/mBvb0+HDh2Un03vuug/79KlC46OjoDl/GoHBwdlMGwtDw8PGQwLIYA2NCAuKChQveXeXM6ePcuqVavw8fHBz8+vXmW1Wi0bN27kwQcf5Le//S0bN27kr3/9a73ruRe8+uqryv/IzJ8/n6ysLIuv17W1rTncqqurAXB1dcXFxYWoqCjlao+vry9BQUHExsYSFRXFuHHjyMrK4r333iM7O5u8vDzV+X6DBw/mq6++AlDao597GB8fj7e3t1kZ/bxFwGjeor6dpvXr183NzbXuy2mAhhyP1tAf7w3ZhmHZulRUVJCZmWm2/ObNm8rvRwghhGhrWnzKRFlZmVneZI8ePQDYvn070dHRuLq6Eh0dTadOnYzmjr722muq2ZHx8fHKvM8+ffoYzUt1cnIiOTnZ4jxS0zmohu3KzMw0m/fat29fXF1dgZorkC4uLri7uxMXF6fMlU1JSeG7776joqICf39/PvvsM4YNG8aKFSuorKy8Z/MvbWxs6l0mPDychQsXKnP41Ob2lZaWEhoaysCBAykvL8fHx4cbN25w5MgRysvL8fPzIyQkhHnz5rF+/XoqKyvx9/dn+PDhaLVas7mH+rmLI0eOZOvWrUbzFo8eParazqlTpzJ16lT27t1LWVkZv/zlLxv1XVlS25zrvn37MmHCBKPju2vXrly+fNnqOdeHDx+msLAQnU5n9bzruvJiDeddG6YDlJaWsnz5cj7//HNcXFzM3pwnhBBCtBXNeoVYLX9SLW9Sz83NjZycHCIiIti8eTN79uxBo9GQmJiIp6cnycnJqtmRZWVlyrxP/bxUgJ07d9K/f3/VDEt9xqV+Dqpau8rKypR5r8HBwcpgQ40+87KsrIySkhLS09MZOHAgdnZ2HD58mOzsbL799tt7Ov9S/1ILQ7Nnz2bBggXMnj1beUJ81KhRrFu3DqhJdLh69apy29TJyYmkpCRWrlzJsWPH8PPzIzAwkPT0dJYsWcL+/fuxt7dX5h9u27aNBQsW8OOPP7JmzRrS09MJDg5mwIABjB49mgMHDvDee+8pc5Thf3MXg4ODOXDgAOvXrychIYE+ffowY8YMXn31VQC6d+/OuXPngJppHkePHmXt2rV88sknSvsbQ61/GB5Hasee6fHdsWNHs+PJtN/o51zrM1/129DPu05NTaVHjx5G864N+0tdebGG/c9QbGwsTk5OZGZmMmjQoEZ/X0IIIURzadYBsVr+ZG15k6NHjwZgxIgR5OTkmM0dzczMtJgdqZ/3aTovVT+QtjSPtK52mc57tUZgYCBQM7gbMmQIUDM3rrS0VPIvrWQ6t8/W1tbsCqPh/ENnZ2fmzp3LM888o/y+AYtzDw3L1ictQn83oynUlc+qduyZHt85OTkNmnMNzTvvGiAjI4OxY8cCzTvvWgghhGisZp0yoZY/WVve5IULF4CaJ4uHDRumzB11dnYmLCyM7t27ExQUpJodqZ/3aTovta4My7raZTrv1RqGAzn9NILq6mqqq6sl/7KZeHp6kpaWRlVVVbt5FXFd+axqx57p8X39+nWz48m031g6xvTzrgcOHGg279pSf6mrn5jWf/78eQYPHtys866FEEKIxmrxkYNa3qTewYMHycvLo6SkhDVr1nD16lWjuaNarZbZs2fXmR1pOC/Vzs6u1nmk+jmoau1KT09v8v2X/Mvm1V4Gw41heHyXlpbWa861YZKLtfOuQ0NDa82Lbe1510IIIURj2VTX59JnbRXZ2BAXF0dwcLBV65vmTeoVFxfj5OSk/Hz37l0KCwuNbpfXNzuyrKzMKMNSf+v89u3bSgZmXe1qavda/mV9f//3m+b+fkyPJ7V+Y3q85+bm4ujoSO/evVm3bh1dunQhIiJCtb+Ylq1PP7l+/XqTTjVpTrt37yYkJKRed4TE/8j31z7J+VuIVnwxh6U/poaDYVCfO+rh4VGvbXXp0kX5t+k8Umvb1dTquw9C1Mb0eLI059qQs7MzM2fOxNbWljt37rB3715Avb+Ylm2teddCQM3Dp4WFhfTr16/W9ebPn8+1a9eMlv3mN79h7ty5zdk8IUQ7dO/fXxZCqGqP866FgJps7JiYmDqnnGm1Wqqqqnj99dcJCAhg3LhxykO2QghhqM28mEMI0TpkMCxaw4QJE5S3Wq5bt47Y2FgqKyt56623ePrpp3nyySe5cuUKZWVlvPTSSwQEBBAUFMSdO3eIjo7m0KFD7Nu3j8jISJ544gmmTJnC9evXiY+PZ968eQwaNAhXV1fc3d2NMuMffPBBQkNDyc/PB+Ddd9/liSeeYMaMGUyYMIEpU6Zw8eJF1bYIIe5dMiAWQgjRbNTytsE8U3vs2LGqOe1JSUl069aNrKwsxo4dy6lTp5Rs7OLiYqtzsQ0FBgYSHx8P1ORlazQaOnfuTFJSEnPmzOH999+/pzPjhRDmZEAshBCi2VjK2zbN1HZxcVHNaT9w4ADPPvssALNmzeKxxx5T6qhPLrah4OBgkpKSuHDhAm5ubnTr1k2JEPTz8+PIkSOSGS/EfUbulQohhGg2lvK2TTO1AdWc9gsXLpCfn4+vry/btm3Dx8dHqaM+udiG9K8Sf+eddwgPD+fixYucP38egBMnTuDp6SmZ8ULcZ+QKsRBCiFYRHh7O/v37GTNmDFCT0/7JJ58wdepUgoKC8PLyYtq0acTGxhISEsLHH3/Mr3/9ayVH3tPTk61btzJlyhTef/99ZWBtjWnTprF3717Gjx8PQGJiImPHjmXhwoUsWbJEtS1CiHuXXCEWQgjRKiZPnszkyZOVn52cnEhKSjLL1U5OTjbKkHd3d+fMmTN06NCBKVOmGOVi9+nTx2w7GzduNFv285//nOnTp9O5c2cAlixZwpgxY3BxcVGuMKu1RQhxb2ozV4jj4+ON3qLV3EpKSvj6669JTU3l448/rnfZl19+2WhZfn4+GzZsaMomivtQQ45Ha+iP94Zsw7CsNVJSUpg8eTJPP/007777br3b2pTU+ipIf23rPDw8zAaghhnyUJONrX9RTH3z4+Pi4li1ahWRkZEAdOrUCTs7O7p162Y23UKtLUKIe0+buUJcUFDQom830udYarVas6ef61JRUUFmZqbRsps3b/LVV181ZRPFfcjHx6fex6M1DHNb67sNazNfAYqKioiKimL37t1UVVURGRnJ4MGDGTFiRGOa32BqfRWkv97vQkJCCAkJUX5esGBBK7ZGCNEWtPiAuKysjKVLl3L69Gnc3NxYvXq18iar7du3Ex0djaurK9HR0XTq1IlFixZRUVGBRqPhtdde45133iErK4s7d+6wY8cOevbsSXx8PGlpaXz66af06dOHNWvW4OXlxbp163ByciI5OZny8nIAYmJicHZ2Jjo6mtOnT2NjY8PQoUOZNGmSWbsyMzNJT0/n2rVrdOjQgdWrV9O3b19lX0pLS1m+fDmff/658pCGEI1x+PBhdDod9vb2qsfehAkTjI7vrl27cvnyZaM+ARj1mzfffFM53g8fPkxhYSE6nU455s+dO0fPnj0ZMGAAixcvJjQ01Ki/GJbVaDRm/eTYsWNK//voo4+4desWNjY2uLu7s3btWm7evEloaCh/+ctf6N+/P++++y6urq4AZvvYp08fs+3Hx8fz6aefUlRUhIODAytWrMDLy4srV67UeX4wvLIn/VUIIYQlzTplQi1/MjEx0Sw3Us/NzY2cnBwiIiLYvHkze/bsQaPRkJiYiKenJ8nJyaq5kIa5k6bZlv379yc8PJx9+/YxcuRIdu3aBaDkWPr6+lJcXKzarrKyMiorK9m/fz/BwcHKYEMvNjYWJycnMjMzGTRoUHN+leIepNY/SkpKKC4utnjsmR7fHTt2NOsTpv2mvLxcOd4DAwOVbSQkJPDII4+QmppKjx49KCwspKCgwKy/GJa11E/0/e/hhx8mNDSUgIAANBoNGzZswM3NzSz3dfTo0ar7qLb9oqIis4xYwOrzg570VyGEEJY064BYLX/SUm4kwOjRowEYMWIEOTk5TJs2jRMnTqDRaCgoKCAzM9NiLqQ+d9I021L/hzIoKIh9+/ah0+lU22qpXRqNBqh5zW1RUZFRmYyMDMaOHQvAE0880ajvStx/LOWz6qkde6bHd05OjlmfMO03lvJYU1NTlZiqp556CgBHR8da+0tdua8//PADs2bN4vz58+zZs4erV6+yevVq1dxXtX20tH3TjFigXucHkP4qhBDCsmYdEC9btozc3FxWrVqlLNPnRgJGuZEAFy5cAODMmTMMGzaMrKws3nvvPbKzs8nLy+POnTsEBQURGxtLVFQU48aN+9+O/P8HIUyzLTdt2sTQoUOJj4/H29vbYlsttUtfr9r85sGDBytlcnNz6/8FifuaWv8wpHbsmR7fvr6+Zn3CtN9Yyk8dPHiwMo9W/0BrXf2lrn5y8uRJtFot1dXV9OrVizlz5vDFF1+Y5b5a2kdL2zfNiNW32drzg35/pb8KIYRQ0+JziMPCwpg1axYJCQnodDqjwcDBgwfJy8ujpKSENWvWcPXqVUJDQxk4cCDl5eVotVpmz55NVlYW+fn5Fh/yCQ8PZ+HChWzatAk7Ozu0Wi3Z2dnodDoSExOJjIxUcizLy8vx8/NTbVd6enqt+zJ16lSmTp3K3r17KSsr45e//GWTfldCqDE8vktLS5k+fbpRnygtLTXqNz4+Pty4cYMjR44YJbmEhIQwb9481q9fT2VlJf7+/gwfPtysv4SGhipl1frJ0aNHlTqffvppPvzwQzQaDYMGDeLSpUu8/fbbQM0V3blz57J27VqL+6a2/d/+9rckJiZy6tQprl27RkxMDFAT0VWf84P0VyGEEJbYVDdRtIONjQ1xcXEEBwdbtb5hbqSh4uJinJyclJ/v3r1LYWGh0QMw9c2FLCsrw8bGBkdHR6Msy9u3b9OhQwcluqe2dtXm+vXryoOB96v6/v7vN839/Zj2CbV+Y3q85+bm4ujoSO/evVm3bh1dunQhIiJCtb+Ylq2rn5SXl1NaWoqbm5uyLDMzk48//pjo6Oha98V0+xs3bsTDw8MsI9bSftZ1fqitv+7evZuQkJAWTby5l8j31z7J+VuIVoxds/TH1HAwDDW3VE2fBvfw8KjXtrp06aL82zDL0t7e3up21eZ+HwyL1mfaJ9T6jenx7uzszMyZM7G1teXOnTvs3bsXUO8vpmXr6icODg5Gc5fj4uKsjm4z3b5hRqyphpwfpL+2HQcOHOD06dMEBATg7+9vVZnU1FQqKiqUN8zVV0pKCtu3b+fmzZuMGzeOBQsWKHWOHDmSwsJC+vXrp1r23LlzLFmyBKjJLn7sscdYsGCB6t8SNSUlJbXW31j5+fmkpaXxwgsvNEv9QtzL2syLOYQQLcvT05O0tDT2799Peno6Dz74YLNtKyQkhH379tGzZ896l12wYIFcuboHpaSk8Ne//pWHH36YP/3pT1a/mMnHxwc/P78GbVOfk71+/Xq2b99OTk4OR48eVeo8e/asxTn9AD/++CMAW7Zs4fXXX+fs2bPMnj3b6u3XVX9jSb62EA3XZl7MIYRoHR07ymlAtLzy8nI2btzIr371K86cOUNubi7nz583y5w+efKkknN99uxZo6zulJQUvvvuOyoqKvD39+ezzz5j2LBhaLVa1cz6wsJC1ZxsfZ3JycmcPn2aQ4cOcfz4cbPyAJ07d6Z79+50796d7du307t3b3766Seio6PN1jfNyv7yyy+VTO8bN24o+5WTk2OW771w4UKz7O6goCCz/XrwwQclX1uIJiBXiIUQQjQbtbxtgMmTJ/OrX/2KJ598kk2bNvHcc8+pZk4b5lyDcVZ3SUkJ6enpDBw4EDs7Ow4fPkx2djbbtm1TzaS2lJOtr1OfuV1VVVVrprWera0tgwYNIioqSnV906zsefPmKZnehvullu+tlt2dlpZmth3J1xaiaciAWAghRLOxlLetf/Bu3759vPTSS/zpT38C1DOn9TnXpgIDA4GaZ0+GDBkC1Mxv/+c//6maSW0pJ9tUSkpKrZnWhvTTFNTWrysTXL9favneatndau2SfG0hmobcKxVCCNFsli1bxrJly8yWz5kzh1mzZjFkyBD8/f35z3/+A6hnThsmixgyTBKxsbEBagbagwcPpl+/fsybN49Lly4pWdz66RdRUVFKTrZWq+XZZ581qtfX1xdvb2+z8qYyMjKorKxk7Nix3L5922x9fVa2s7MzYWFhODs7G5XX75c+3/vRRx9V8r3VsrvV2vXNN99w/vx5Bg8eLPnaQjSCDIiFEEK0uHnz5vHKK6/g4eFBcXEx0dHR7N+/3yxz+ssvv6x33RMnTmTlypVmmdSWcrLz8vIAlHz6cePGsWXLFtVM6/T0dIYNG4atrS0PPvggH330ET/72c/M8sDBPCv7d7/7Hc8884zZA4SW8vlNs7snTpxotp0hQ4ZIvrYQTaDVcojFvUV+/7WT76d9kBzdxmnI9/f999/j6uoKwMqVKy1mTjeEpUxqtZxsPcPM7fpm3qutb5qVrZZ/r2ea720pu1ttO43Jw5fzkxAyhxioeUjj5ZdfNlqWn5/Phg0bWqlF4n6VmprKxx9/3OT1lpSU8PXXXzdoG4Zl6/KnP/2Jf/3rXwBcvnyZiRMnUllZCcChQ4cs5hDHx8dbFbulb3t92iTaNv1gGDDKnG7sYBhqMqnVBrMODg6qg2GoydzWD1Ytla/P9kyzsg3rN2U4GI6Li2PVqlVERkZatR3J1xaicWRADFRUVJCZmWm0TPIcRWtoTMZqbQzzT+u7jfpkp1ZXV3Po0CEAPvnkE44dO0ZOTg4ACQkJqg9GARQUFHD9+vU667c2L1a0T5I5/T+Nye4WQtRfi88hjo+PV7IXT506pZoVaZrduHDhQrOMxh49ehATE8Pdu3eZPn06hw4dIjc3l169ehllO77++uucOXMGNzc3/vGPfxAVFaWaLQlQWloqeY6iVRlmrKanp3Pt2jU6dOjA6tWr6du3LxMmTGDNmjV4eXmxbt06unbtyuXLl42OacCo/7z55ptER0cr+aeFhYXodDomTZrE0qVLOXfuHD179mTAgAEsXryY0NBQysvLAYiJiTEqq9FozPrisWPHlD733nvvsWnTJl555RUOHjyIVqvl4MGDjBgxgk8//ZQlS5ZQWVlp1u8Btm/fTnR0NK6urkRHR9OpUyez/ahPXqwQQghhrWa9QqyWP2mYvaiWqQjm2Y2xsbFmGY1QM4AtKysDauaE3bx506j+pKQkunXrRlZWFmPHjmXlypW1ZktKnqNoSWr9wzBjtbKykv379xMcHKwMGkeNGsWePXsA2LlzJx07djQ7pk37T3l5uZKvGhgYqGwjISGBRx55hNTUVHr06EFhYSEFBQWEh4ezb98+Ro4cya5du4zKquWlGva5YcOGcerUKaqqqrhy5QozZszgyJEj3Lx5k6qqKjw8PCz2ezc3N3JycoiIiGDz5s2q+9HQvFghhBCiNs06ILaUP6nPXrSU9Wia3Xj06FGzjEZThjmRhtmO+jidWbNm8f3339eaLSl5jqIlWeofehqNBqh5xXJRURFQ8zR6YmIi+fn5eHp6kpOTY3ZM15V9qpeamqpkvj711FMAODo6kpycTFBQEPv27UOn0xmVUctLhf/1uU6dOtGrVy/++c9/MnToUB544AG6dOlCUlISo0aNAixnvI4ePRqAESNGkJOTY9V+1CcvVgghhLCkWadMWMqf1D8sYSnr0TS70cbGxiyjEWpeoXnjxg0Ajh8/zgMPPGBUv7e3N/n5+fj6+rJt2zYAgoKCLGZLDh48WPIcRYux1D/09Mex4RP7rq6uuLi4EBUVxYwZM7h+/bpZHzLtP5YyVAcPHsxXX33FwIEDlQfaNm3axNChQ4mIiODFF180K6OWl2rYVoAnn3wSrVbLu+++C9REXS1fvpy//e1vgHq/Lygo4MKFCwCcOXOGYcOGWbUf1ubFCiGEELVp1RxitUxFMM9uXLduHS+88IJZRuOTTz7J888/T2pqKnfv3mX48OFG9U+bNo358+eTkJBAZWUlW7ZsYebMmarZkgBTp06VPEfR5oWHh7Nw4UI2bdpEaWmpWR8qLS016j8+Pj7cuHGDI0eOGCU5hISEMG/ePNavX09lZSX+/v4MHz4crVZLdnY2Op2OxMREQkNDlbJqealHjx41ap9+QKx/i9iYMWNYvHixcoVYrd8XFBRw8OBB8vLyKCkpYc2aNVy9etVsP06fPg1YlxcrhBBCWKtN5BBbk90I5hmNeuXl5RZvC0PNXOOuXbvWuj1DjclzvF9JjmXtmvv7MT2m1fqPaf5pbm4ujo6O9O7dm3Xr1tGlSxciIiIoKyvDxsYGR0dHpe+YlrXUFxvTZoDi4mKcnJyUn9X2Q21/6psXa4nkEDeOfH/tk5y/hWgjb6rz8PAwW2aa3QhY/ANc22AYMBoMW9qeIRkMi/bG9JhW6z/29vZGPzs7OzNz5kxsbW25c+cOe/fuBaBLly7KOvq+Y1q2sYNhtTYDRoNhUN8PPcM21dWnRduTmppKRUUF48ePb5L6SkpKKCwspF+/fkDN/PLt27dz8+ZNxo0bx4IFCxpVf1O3VwjRtrSJAbEQouV5enqSlpZGVVUVHTvKqUC0LB8fH6OElcY6e/YsMTExbNq0iaKiIqKioti9ezdVVVVERkYyePBgRowY0WbaK4RoW+SvoBD3ORkMi9ZQW+Z2586dzTKo1fKrjx8/rmRg9+/fX8nL7tGjB7du3cLGxgZ3d3fWrl3LzZs3+eCDD/j0008pKirCwcGBFStW0LNnT7N6nZycjDLs4+LilPaGhYWp5mibtlcI0b7IX0IhhBDN5s6dO9y9exdbW1ujVxaXlJQoz3/oM7djYmLYsWMH3bp1Q6PRsHjxYnbs2EF5eTlHjhxRMqf37t2LVqvF399fycD+8ssviYmJUR7mDA0NJSAggC5dujB+/HgiIyMpKiqic+fOJCUlkZmZyfvvv8/IkSPN6g0MDFQy7Lds2cKpU6eU9hrmaOvX9/b2NmtvXVP5hBBti7y6WQghRLOpK28bzDO31TKoLWVO6zOwDf3www/MmjWL8+fPs2fPHq5evcrq1asBlKhAPz8/jhw5olqvaYb9Y489ptSttr612d9CiLZLrhALIYRoNnXlbYN55rZaBrVa5nRZWZlRBrbeyZMnSUtLIyoqil69ejFnzhy0Wi0BAQGcP38egBMnTuDp6ala74ULF4wy7H18fJS61dZXa6/hIFoI0fbJgFgIIUSbYppF7+PjQ79+/czyq8+ePauU0WdTZ2Vl8fTTT/Phhx+i0WgYNGgQly5d4u233+bYsWMkJiZy6tQprl27RkxMDL169TKr9/HHHzfKsJ8+fTonT54E1HO01bK/hRDtiwyIhRBCtLjZs2ebLRs1apTyApcRI0YYZVDb29uTlJRklDnt5+enlHV3d+fMmTN06NABW1tbYmNjKS8vp7S0FDc3NwCOHTvGkiVLGDNmDC4uLsrVZdN6AZKTk40y7A3bq7F2bBwAACAASURBVLa+aXuFEO1Li88hTk1N5eOPP27yektKSvj6668btA3Dstas+/LLL5stz8/PZ8OGDVZvU4imona8y/Eo2jtLGdQeHh4WX8Bib29v9OCeg4ODMhgG6NSpE3Z2dnTr1s1sqoVavaYZ9rWtX1tmthCi7WvxK8TNleVomEFZ320Ylq1LRUUFmZmZZstv3rzJV199Va82C9EU1I53OR6FMNfYl3MIIe5dLT4gri17sm/fvkyYMIE1a9bg5eXFunXr6Nq1K5cvX64z8zE6OlrJoCwsLESn0zFp0iSWLl3KuXPn6NmzJwMGDGDx4sWEhoZSXl4OQExMjFFZjUbD0qVLOX36NG5ubqxevZpjx44pWZcZGRnKvpSWlrJ8+XI+//xzXFxc5OqAaLSysjKz469Hjx7Ex8crx2BOTo5RRuqkSZO4ffs2EydOlONRCCGEaIBmnTJx584dKisrja5elZSUUFxcTFlZmZI9GRwcrAx0R40axZ49ewDYuXMnHTt2VDIfX3zxRbRaLXv27EGj0ZCYmIinpyfl5eVERkYyevRoAgMDlW0kJCTwyCOPkJqaSo8ePSgsLKSgoIDw8HD27dvHyJEj2bVrl1HZxMRE3N3dycjI4LnnnmPr1q2UlZUpWZeGYmNjcXJyIjMzk0GDBjXnVynuQWr9Q+34A4yOwaSkJCUjdezYsZw7d47i4mI5HoUQQogGatYBcV35k6bZkwBhYWEkJiaSn5+Pp6cnOTk5Dc58TE1NVTInn3rqKQAcHR1JTk4mKCiIffv2odPpjMocOHCAp59+GoCRI0cqV4TVsi4zMjIYO3YsAE888US9vx9xf1PrH5aOP/jfMWiakdq7d29AjkchhBCioZp1QLxs2TJyc3NZtWqV+sZNsicBXF1dcXFxISoqihkzZuDr60tQUBCxsbFERUUxbtw4JfMxOzubvLw8vvjiC9X6Bw8erMyjzMrKAmDTpk0MHTqU+Ph4vL29zco8+uijSk7ll19+qQyo1bIuBw8erKybm5tr1XcihJ5a/7B0/MH/jkFvb2/y8/MB2LZtG5cvXwbkeBRCCCEaqk3GroWHh7Nw4UIl39GazMcbN24oGZR6ISEhzJs3j/Xr11NZWYm/vz/Dhw9Hq9WSnZ2NTqcjMTGR0NBQpWxYWBizZs0iISEBnU7HqlWrOHr0qGo7p06dytSpU9m7dy9lZWX88pe/bKmvSNyj1I4/U9OmTTPKSB07diy3bt2S41EIIYRoIJtqw8uzjanIxoa4uDiCg4ObojozppmPd+/eNct8vH37Nh06dFBid3Jzc3F0dKR3796sW7eOLl26EBERQVlZGTY2Njg6Oio5k6Zl//vf/+Li4mJV265fv06PHj2aeI/bl+b+/bd39f1+rDn+DDNSDcnx2HC7d+8mJCSEJjot3nfk+2uf5PwtRBu9QqzGw8PD6Ge1zEd7e3ujn52dnZk5cya2trbcuXOHvXv3AtClSxdlHf2AwrSstYNhQAYfoslZc/xZykiV41G0B/Hx8bi5uREQEFDvsvv376dz585Gc+UbU19tUlJS2L59Ozdv3mTcuHEsWLCA1NRUKioqGD9+fJNuSwjRetrNgLghPD09SUtLo6qqio4d7+ldFUKIdqWgoKDBV5L/85//4Ojo2GT1WVJUVERUVBS7d++mqqqKyMhIBg8e3Gx5+kKI1nNfjBJlMCyEEG3P9u3biY6OxtXVlejoaLy8vMxy4u3s7Ixyt+Pi4pTyP/zwA88//zzvvvuuan1ubm5mud6ZmZlmGfi9evXinXfeMcq779mzJ4WFhdy6dQsbGxvc3d1Zu3YtN2/eVPL0dTod8fHxAFy4cIGPPvqI/fv3m9UjhGj7WvzVzUIIIe4fannbem5ubuTk5BAREcHmzZtVc+JNc7dPnToFQGFhIUFBQbz11lv06dNHtT5LufKmGfhpaWlmefcADz/8MKGhoQQEBKDRaNiwYQNubm5K1v3cuXM5dOgQQUFBDBs2jO+//161HiFE2ycDYiGEEM2mtjz60aNHAzBixAhycnJUc+JNc7cfe+wxANauXcuNGzdwd3e3WJ+lXG/TDPyUlBSzvHuouQI9a9Yszp8/z549e7h69SqrV6822ofDhw8TExPDli1bLNYjhGj7mnQuwerVq/noo4+askohhBDt2LJly1i2bJnqZxcuXADgzJkzDBs2TMmJj4iI4MUXXwT+l7vt6+vLtm3b8PHxAUCr1eLg4MDLL7+sTKMwrc/FxYXz58/z6KOPqubK6+cc+/r64u3tzbx587h06ZKSbX/y5EnS0tKIioqiV69ezJkzB61WqwzQCwoKWLhwIZ988gmdO3e2WI8Qou1rsgFxUFBQU1Ul2qGgoCA8PT1buxlCiHbk4MGD5OXlUVJSwpo1a/jPf/5jlhO/a9cuo9zt6dOnc/z4cTp06EBoaCjbtm0jOTlZtb4HHnjALNc7PT3drB0TJ040y7sHePrpp/nwww/RaDQMGjSIS5cu8fbbb5OXlwfASy+9xE8//cTvf/97ABYtWsTGjRvN6hFCtH1NlkMshLBMcj7bB8nRbZyGfH/FxcU4OTkpP6vlxIPl3O266gPrc+VN8+71ysvLKS0txc3NzZpdslhPWyXnJyHuk5QJIdqL+uablpSUUFhYSL9+/ZSyI0eOVJbVVubixYuSpSpanengVS0n3vTf9akPrM+VN82713NwcMDBwcGqOmqrRwjRdslDdUK0IT4+Pvj5+Vm9/tmzZ5XXO+vLGi6rrUx9tyWEEELcq+QKsRBtiD7f1N7e3iwrtW/fvly5coVFixZRUVGBRqPhyy+/5PTp0xw+fJjCwkJ0Oh3JycnKsm+//Za7d+8yffp0Dh06RG5uLtnZ2Zw+fRobGxuGDh3KpEmTzLJae/Towa5du1TbIIQQQtxr5AqxaHbHjh0jMTGxtZvR5qjls+rzTdWyUgH27NmDRqMhMTERT09P5s2bx+jRowkMDFTKRkZGKstKS0spKysDauZB3rx5U/nc19eX4uJi1axWwGIbhBBCiHuNDIhFo5WUlPDyyy8bLcvPz2fDhg1AzSBu7ty5lJaWtkbz2qza8lnBPCsVYNq0aZw4cQKNRkNBQUG95jVaykS1lNVqqQ1CCCHEvUYGxKLRKioqyMzMNFp28+ZNvvrqKwCWLFmCTqdTXq8qaixbtozc3FyL831Ns1IBsrKyeO+998jOziYvL6/OnNPOnTvz008/AXD8+HHVdR599FHOnz8PYJTVaqkNQgghxL1G5hC3UatWrWLChAlmczbj4+NJS0vj008/5ezZs1RWVvLOO++QlZXFnTt3lNvahvNMFy5cqDpHNCYmxmx+aa9evZT6c3JyeP311zlz5gxubm7ExcVx9+5ds+3po4VKS0tZvnw5n3/+OS4uLjz00EMAdOvWjT/84Q+sXLmSOXPm4Orq2rJf5j3EycmJ0NBQBg4cSHl5Ob/73e945plnyMrKUtbx8vLiyJEjZGVl8eSTT/L888+TmprK3bt3GT58uPJ5eXk5fn5+hIWFmWW1CiGEEPcTGRC3Ud98841yZc9QWVkZFy5c4LPPPgMgLS2NyspKUlNT2bt3L1qtFm9vbzQaDYsXL2bHjh3Exsbi7u5OdHQ0u3fvZuvWrbzxxhuUlpYqV/7080sN609ISKBbt25kZWWxZcsWTp06xY0bN8y2t2LFCgBiY2NxcnIiMzOTZcuWcePGDaXdkZGRbNiwgXfeeYfo6OgW+Abbp9mzZ5stGzVqFKNGjQIgMDCQESNGUFhYqPwPx5kzZ+jQoQMBAQFKGf2yDh06kJ6eTnl5udH0CsPPoWbahGlWq2FbDNsghBBC3GtkykQbs3r1agICAkhMTGTmzJkEBARw8eJFo3XGjh2rDG5SUlLIzs4mLCyMf/7zn1RVVZnNMz169KjFOaJ6hvNL9fUfOPD/2Lv3uB7P/4Hjr7LSyiGtKZGJ705fh0ZtCBMbmsMa6ywLNfJlGznOzEpbiyjmUMZKa8spKRUpJWuiOSVjflEbYoXvSn3W4tPh90e/z/2TPlFUn8r1fDx6PLg/931d7/um67o+130d4qUtSt3c3Hj99deV5qeQnJyMlZUVACNHjqyWvo6ODsuWLWPjxo3k5OQ0wJN6eqmrq0uNYQBNTU2pYVvbsQfHGiu7pq5rtQqCqhUVFXHp0qVHnpeeno61tTXW1tY4OjoSExNDRUVFvfLav39/tTIzIiKi2hsZQRBaB9EgbmbmzZtHamoq1tbWBAcHk5qaiomJSbVzFOM6AQYMGICNjQ3h4eH4+fkxbty4GuNM7969q3SMaG3jSxXp9+nTh6ysLABCQkI4ffq00vwU+vfvL+WTmZlZ495mzJhB9+7d8fLyeuLnJAjC0+tRa20r5OXlYWBgwPfff8/q1atZv34927Ztq1def/zxB9euXZP+npOTQ15eXn1DFgShmRMN4mZKTU0NNTW1R543adIkDhw4wOTJk7GxscHExEQaZ+rh4UFJSQkrV64kODgYR0dHNm/ezNSpUwF46623OHjwIG+//TanTp2qkbazszPh4eHY29sTExPDa6+9pjQ/hcmTJxMYGIitrS1xcXE10tPQ0MDb25sffviBjIyMx384giC0eNbW1tLbrw0bNhAeHo5cLsfb25vRo0fz1ltvkZubi0wmY86cOQwbNgwbGxvKy8vx9/cnMTGR2NhYPDw8GDlyJI6OjuTl5REREYG7uzt9+/YFoG3btnTs2JGuXbvSrVs3dHR0AKioqMDOzo7x48czfvx4CgoKlOalcOvWLSZMmEBOTg7btm1j8ODBWFtbk52djUwmqxEHwPbt23Fzc2Ps2LFMmDCBy5cvK71HQRBUT61STB9vFa5fv46+vr40wa2ioqLaOFOgxhhRhQfHlz6ouLi4xrapD+Z3v7y8PAwNDZWmVVlZyeuvv06XLl2IiYmp0721BmpqauzcuRM7OztVhyI8xK5du7C3txerajwmZc+vvLyciooK1NXVqw3TWbt2LWVlZSxYsIDBgwcTFxdHeno6x44dY8WKFURGRnLgwAEsLS25dOkSnp6ebN26FVNTU+7du0dYWBhDhw4lLy+PBQsWsGvXLi5fvoyRkRE//vgj0dHRJCYmMmfOHF555RVu3rxJfn4+x48fp0ePHly+fJnffvuNCRMm4Ofnh46ODh07dqyR14kTJ5DJZMTFxbFu3ToSEhK4ePEiwcHB7Nu3j6NHj9K3b98acSxdupQtW7bw888/ExoaSlhYGFlZWVhYWNS4xy1btqjin0siyidBED3ErUbXrl2rNU4fHGcKtY8RfdRatg82hpXld7/aGsNQVfD6+PgQGxtbY6k2QRBan9rW23ZyciIqKoqsrCyMjY3R09NTOkdB2VwGhdrW0L5/nsV7771HYmIiZ8+excfHh88++wyomtewb98+bGxsiI2NpbS0tNa81q9fz+3btzEyMgJg1KhRALz55pscO3asXmt5P2wehiAIqiNWmRCanOJV4ZIlSzh+/Hidhoa0BgEBAezevVvVYQgPIV5fNzxPT088PT1rHO/cuTN6enr4+flJw7gGDBhAnz59cHd358qVK5w4cYLs7GyysrIYMGAAISEhmJqaSmko1tDu169ftfkR98+zuF+3bt2knRuDgoIYNGgQrq6uzJ49G/j/eRMP5uXl5YW2tjYfffQRZmZmZGdnA1WrtVhYWKCnp6c0jvtjUfSaK7tHQRBUTzSIBZXw9fXljTfeYN++fVhbW6s6nEZnY2Oj6hCEOujWrZv4t2pCU6ZMYe7cuQQFBQFVcyJcXFxITU0lKyuLoKAgBg8ezKxZs9i7dy9yuRwXFxfy8vI4cuQIw4cPJzg4uNoa2j/99FO1PCIiIjh16hRqamr06dOH1atXAzB06FC8vLxIS0ujtLSUqKgotm/fXiOv48eP06ZNGxwcHAgJCWHfvn2oqalx/vx5ioqKWLt2Lc8++2yd1/JWdo+CIKieGEMsqIytrS2//fabtCauIAgtW0ONwVY2R+HBuQz37t2T1tKubX7Eo8hkMtTU1NDR0amWvrJ5Ew8qLCxEV1e32rH6xPGweRhNTYwhFgQxhlhQoa+++or/+Z//Yfv27aoORRCEZkTZHIUHG6j3r6X9uGtot2vXTlp14v70H9UYBmo0husbx8PmYQiC0PREg1hQmZdeeglnZ2c+//xz7t27p+pwBEEQBEF4SokxxIJKeXp68vLLLxMcHIy7u7uqw2m2KioqOHDgAAcPHuTq1avo6OjQv39/HB0d6dq1q6rDEwRBEIQWTfQQCyr1wgsv8OGHH7JixQpKSkpUHU6zdOnSJczNzXn33Xf55Zdf0NHRQSaTsWrVKnr27MnXX3+t6hAFQRAEoUUTDWJB5T777DOKiooIDAxs8LQTEhIaZQOQoqIiLl269FjpK66ti6ysLPr3788zzzzDr7/+yvHjx/niiy8YM2YMubm5fP311yxfvhxvb+/HuQ1BEARBEBANYqEZMDQ0ZM6cOfj6+lJUVNSgaZuammJmZtagaQKcO3eONWvWPFb6imvrwtPTE7lcTmJiIq+++ioAd+7c4cKFC2hqauLh4YG/vz/e3t5cvny53vchCIIgCIJoEAvNxJIlSygvL2ft2rWPdf2aNWuUNghTUlJITExk+/btuLm5MXbsWCZMmMDly5extrbm999/B2DDhg2Eh4cjl8vx9vaWNg/Jzc0lNzcXe3t73nvvPb788ksA/P39SUxMxNPTk8TERGQyGR4eHowePZrp06ezcuVKoGrsr52dHePHj2f8+PEUFBRI18bGxuLh4cHIkSNxdHQkLy8PqFo31d3dnT59+hAdHY2+vj7q6uosXryYESNG4OvrW+0eZ8+ejYGBAeHh4Y/17ARBEAThaScaxEKzoKury7x581i9ejW3bt2q9/WXL1/m77//rnG8qKiIwsJCZDIZcrmc/fv3Y2dnR2hoKCNGjGDPnj0A/Pjjj1hZWXHo0CHkcjkJCQnMnj0bLy8v9uzZg7m5OVFRURgbG1NSUoKHhwejRo1iwIABFBYWsnfvXl599VUSEhIwNDQkPz8fgJycHKZMmUJsbCzDhw9n+/bt0rWFhYUYGRmRnJzMxIkTCQ4OBqrWRs3OziY0NJSSkhK0tbUJDw9HV1eXw4cP07dv32r3qK6uzpAhQzh79my9n5sgCIIgCKJBLDQj8+bN49lnn5V2kqqLgIAAhg0bRlRUFNOmTWPYsGFSr++DzM3NATA2NqagoAAnJyeioqLIysrC2NgYPT094uLiSEtLw8nJiR07dlBWVoazszMnT57E3NycnJwctLW1a6SdkJAgbdf69ttvS8d1dHTYt28fNjY2xMbGUlpaKn0WHx/P6NGjARg+fDjJycnSZ1ZWVpSVlQFVDd7k5GSsrKwAGDlyZI3827dvT3FxcZ2fmyA0B4GBgWzatIlNmzZx7ty5Ol3zpPMC4uLisLW1ZfTo0axbt65amo8a3//rr79ibW2NtbU1dnZ2+Pn51WvJyPrMH3gcWVlZbNq0qdHSF4TWTDSIhWajXbt2LF68mG+++Ybc3Nw6XTNv3jxSU1OxtrYmODiY1NRUTExMlJ6rrl71312xi1bnzp3R09PDz8+PqVOnAjBgwABsbGwIDw/Hz8+PcePGkZqayjfffENaWhrnz5/nxIkTNdLu378/Fy5cACA1NVU6HhQUxKBBg4iIiKBPnz7VrunXrx8XL14E4MyZM1KDWhFrly5dAJDL5fTv3186NzMzs0b+v//+O926dXv0AxOEZiIvL4+dO3eira2NtrY2zzxTt1VAn2ReQEFBAX5+fmzcuJFt27Zx7NgxfvrpJynNR43v/+9//wvA1q1bWbJkCefOnePDDz+sc/71mT/wOBTzCwRBqD+xDrHQrPznP/9h7dq1fP3112zcuLHO16mpqaGmplbv/KZMmcLcuXMJCgoCYNKkSbi4uJCamkpWVhZBQUEUFxfj4OBA7969KSkpwdTUlNu3b3PkyBFKSkowMzPD3t4ed3d3Nm7ciFwuZ8iQIQAMHToULy8v0tLSKC0tJSoqCgcHB44cOcLw4cMJDg5m7969lJaW1qgou3fvTq9evSgoKGDy5MlMnjyZyMhIZDIZvXr1ks67du0aqamp0pALQWgJLl++zIgRIxg0aBAvvfQS6urqbNmyhaNHj1JQUIC2tjY+Pj6cOnWKQ4cOcfToUc6dO0dKSgqlpaVoamoSFxfHn3/+yd27dxkyZAjp6elYWFjg5eWFr68vqamplJeXExoaSrdu3cjPz+eff/5BTU0NIyMj1q9fz507d6Q09+3bR0ZGBomJiRw/frzG9QBaWlo8//zzPP/882zbto0ePXrw999/4+/vX+P83Nxc5s+fz927dzE3N+fMmTNkZGSQkpLC7du3pfs6duwYy5cvJyMjAwMDAwICApg7dy4rVqzgpZdeYt26dXTu3BkbG5sa99WxY0e+/PJLfvnlF/T09KQv0oIg1I9oEAvNipaWFsuWLWPOnDnMnz+fnj171um62pZsU9Z7M2LECEaMGAGAra0ttra20me6urpER0dz/fp19PX1pa1V33zzTfLz86XKxsjIiLNnz9KmTRvatGlDZmYma9eupUePHmzYsIF27doBMGrUKAYPHoyamho6OjoUFxfTvn176VpHR0f++uuvalu+KnqroWpJuhkzZpCRkcFPP/1EXl4ehoaG0uclJSW4uLjwwgsvVLsPQXhc58+fZ+/evWRlZQHw8ssvM2nSJGmVk/oqLy+noqICdXV1aatlqGoQ79q1iz///JOMjAw2btxIQUEBWlpaREdHc/jwYTZv3swrr7xCdnY26enpQNWwA8XY+qKiIpKSkpg5cyYaGhqkpKRgaWlJSEiINBcgMjISLy8vtmzZwiuvvIKDgwPDhg2jXbt2TJgwAQ8PDylNDw8PwsLCKCsrU3r9g9TV1enbty9+fn5UVFTUOF8x/2DhwoWEhoYycOBA9uzZg6WlJdu2bZPuKzIyEiMjI/z9/dm1axfBwcFYWloSERHB0qVLCQ8PJy4urtocB0U+5ubm0vwCT09Pbt++/Vj/ToLwtBNDJoRmZ/r06fTs2ZMVK1aoLIauXbtKjWGoPoRBQVNTU6rgO3XqxMyZM3nnnXekMcMK7dq1Q0dHB6ga6/vgtfc3hh80depUpk+fzsSJE3F3d+f333/n9u3b/P7774SEhNC/f38yMzPZs2cPmpqaDXPzwlOppKSEadOm0bdvX7799lsKCwspLCwkKCiI3r174+rq+lib53h7e2NmZsaiRYuqHbexseGXX34hKCiIL7/8koCAAABp6JCZmRlHjhwBqsbUKxu7b2lpCVR9kR04cCBQ9fu0Y8eOGnMBAG7duoWbmxsXL15kz549XL9+Xcr3fsrmEtRGMUxB2fmPmn+guC9l8wns7OyIjo4mOzsbAwMD9PX1lcb1qPkFgiDUjeghFpqdZ555hs8//xwXFxcWLVrEv//9b1WH9EjGxsYcOnSIsrKyOo+FrAs1NTU2b96Mvr4+q1evZvPmzdJnmpqa2Nra4uvrK8YPNzNFRUXk5+fz4osvkpCQwN27d5kwYUK1c65cucLHH38s/d3IyIipU6dKDbumjLNXr1689957pKamEhERwcSJE1FTUyMrK4vExEQ6d+7MrFmzuHnzJvv27avX8CRPT088PT1rHN+3bx9du3Zl+PDhlJeX07lzZwBprPzJkycxNjYG/n/8/4Pu/9KqiKmyspL+/fvz4osv4u7uzpUrV6Rx/4rhF35+frzwwgvMmDEDLy8v3n333WrpDhgwgD59+tS4/kHJycnI5XKsrKy4d+9ejfMV8w86deqEk5MTnTp1qna94r4U8wn69esnzSdQDH/w9fVlypQptcZ1+fJlLl68KH05FgTh8YgGsdAsOTo64ufnxxdffMHu3btVHU6dNWRj+H7Z2dm89tprhIeHc/XqVbS1tenTp4/U8yw0L+fOnSMsLIygoCBMTU0pLy+vcU5RURFFRUXs2rULgIyMDMaMGcOtW7fQ0NBo0jiHDh3K4cOH6d69O5MmTZI+v3PnDr/99huzZ8/G2NiYoUOHsnPnThwcHJ4474EDB+Ls7MxLL71EcXExK1euZO/evURFRXH69Glu3LhBWFgYZ86cqXfakyZNYtWqVdXmAgCMHj2a77//HnNzc/r27cuVK1f46quvOH/+PAAmJiYcOXKEcePGsXXr1hrXAyQlJWFhYYG6ujodO3Zk9+7ddOjQocbcA6jqub5//sF7773HO++8U23iLYCTkxNubm415hM4Ozszc+ZM1q9fL93Xg/kMHDiw1vkFgiDUnVqlYsq9IDQz0dHRTJw4kePHj/PGG2+oOhyVycvL44UXXmDLli188MEHqg6nxVqzZg3W1tb861//qnZcJpOxfPlyfv31V7p168bLL7/M4sWLkcvlNSYwpaamkpSUxI0bN2jTpg0BAQG88MILNc775JNPyMjI4LvvviM/P5/S0lLef/99lixZwtmzZzEwMODzzz9n4cKFJCQkAFBWVkb37t25dOkSmpqaNdI0MjLCwcFBGrYQFhZGp06dlMbv4eFRp9gXL15MRkYGurq6Ut7Hjh2rMUlrw4YNQNWY+6KiIg4ePKj0Ge/atQt7e3vqU63897//5bnnngNg1apVdO3alTFjxqCnp1drz3BdPTgXQKGkpITi4mIMDAxqXHPv3j1pbkBt19cnv4qKimrzD+5P/0EPzic4fPgwMTEx+Pv7PzKfB+cX1Ieamho7d+7Ezs7usa4XhNbgiUobW1tbaXa/+BE/9/80BGtrawYOHMgXX3zRIOm1VJs3b6ZDhw6isnpCtW3eUtumKso2aVG2wYuy8xSbr1haWkqbwyh2HUxNTcXKyooLFy5w/vx5pk6diouLC6+//jrTpk1DR0dHaZrKNnmpLf66xq6I88qVK9LY3Ydt3SWrgAAAIABJREFUAmNpaflYPbYPo2gMQ9UQCA0NDWl3xif14FwABW1tbaWNYag+vr+26+uT34PzD+5P/0H3N4Z37tzJmjVr8PDwqFM+j9sYFgShyhO/3x00aBDz5s1riFiEVuDYsWOPvf2yMt7e3owaNUqaPf60KSsrY8uWLbi5uaGlpaXqcFqkgIAAIiMjuXz5Munp6ejo6PD999+jWK86ISGBJUuWAFWbqsTGxgJVE6suXryIk5MTZWVl0vCU+zd4SU9Pr/W8B8XHx0tlpZubG+fOnaNnz554enpSWVnJ0aNH8fLy4quvvlKapmKTl9DQUG7duoW1tXWt8dc1doXi4mJpZZTk5GQpvZEjR0pDOgA6dOhAUVHRE/17PMwnn3zSaGm3NPb29tjb26s6DEF4ajxxg7hbt26i50qopiEbxG+//TYjR45k2bJl/Pzzzw2Wbkuxd+9e/vzzT2bMmKHqUFqsefPmMW/ePNzd3XF3d+e1116r9rliU5XevXtXG9upbAJTQUFBjQ1e6joBq0+fPmRlZTFgwABCQkLQ0dHh2WefpUePHgCYmJjw6aefUl5erjRNxSYvrq6uzJ49+6Hx1zV2hS5dunD9+nUpvdomaV25cgUjI6N6PX9BEISWQCy7JjR7X3/9NWlpaRw4cEDVoTS5jRs3Mn78eGrbfU+ou9qG89jb2/P9999jaWlJQkKCNDFy0qRJHDhwgMmTJ2NjY1Prv4Gy8xSTs+5vYDs7OxMeHo69vT0xMTG8/PLLNdLq1KkT58+fV5rm0KFDCQkJwdXVlcLCQqKiomqNv66xK+Ls3bs3+/btA2Dy5MkEBgZia2tLXFycdG5FRQW7d+/mrbfequMTFwRBaDmeaFKdYiOAlrQKgNC4HmdSTV28++67XL9+nZMnTzbYGOXm7sKFC/Tp06faGqVCw8vMzERHR4ce922q4urqKn1e14lVD55X2+QpxeYsdfFgmjKZDDW16pu8PCz+usR+7949Ll68iJmZGZ9//jnLly8Hak7SWr58Ob6+vpw9e7bWTToa6/dfaFxqamJSnSCIZdeA9PR0fHx8gKrJFk5OTowbNw51dfVa1xAFiIiIwMDAgGHDhtU7z/3796OlpSUWUq+jr776itdee409e/ZU2/SiNduwYQO9evXi7bffVnUorVqnTp2YNm0a6urqlJeXExkZWe3zrl271imdB8+rbaOUujaGlaWpGOd7fzoPi78usWtqatKvXz82btzIrFmzOHXqFHPnzmXAgAEUFhZy6tQpAgICOHDgAN9+++1j71gnCILQnIkGMVU9IQYGBvj5+SGTyZg2bRq3bt1i+vTpta4hCpCTk/PYPSF//PGHWEO2Hvr27YudnR3Lly9n4sSJtc7Sbi2Ki4v58ccfWbFiRYPMthdq11ibqjSVhop/xowZhIaGkpaWJg2fUHjjjTdISkp6Kie2CoLwdBA17f9p27YtHTt2pGvXrnTr1k1qrKakpJCYmIhMJsPDw4ORI0fi6OhIXl4eANu2bWPw4MFYW1uTnZ1NRUUFdnZ2jB8/nvHjx1NQUMD27dtxc3Nj7NixTJgwgcuXL0v53rp1iwkTJpCTk6OS+25JVqxYwaVLl9ixY4eqQ2l027Zto6ysTKw73IRaYmP4fk8a/+HDh0lLS+OHH37g6tWrxMfHEx8fz9WrV0lPTxeNYUEQWrWWXQM0oKioKC5evMjNmzfJz8+XxtEVFRVRUlJCVFQURkZG+Pv7s2vXLoKDg3nmmWcwMDAgLi6Offv28e233/Lhhx8yZcoUJkyYgJ+fH9u3b0dDQ0Na/zMsLIzQ0FC6dOlCfn4+NjY2rFu3jp49e6r4CTR/L774Ik5OTnh6emJvb9/iGzAPs3nzZpydnWts9SoIjaGiooIFCxYwbtw4xowZAyBtm9xS3L9d9oEDBygrK6s21G3WrFncuHGj2jVjx45l5syZTR2qIAjNkOgh/j/vvfceiYmJnD17Fh8fHz777LNqn98/sWn48OEkJycDMGrUKADefPNNjh07Jq0VamNjQ2xsLKWlpUD19T8LCgoAWL9+Pbdv3xbLGNWDl5cXV69e5YcfflB1KI0mKSmJ8+fPV1taSxAa03fffUdmZiYrV65UdSiP7dy5c9KWx7m5uVy9erXa515eXgQGBtKxY0fGjx9PYGBgg2xBLQhC69B6u9ieQLdu3ZDJZNWO9evXj4sXL9KvXz/OnDkj7eqUnZ0NwNmzZ7GwsKh1rVBl6396eXmhra3NRx99xM6dOxv7tlqFHj16MGXKFDw9PXFycqp14lJLtnHjRoYNG0a/fv1UHYrwFJDJZHzxxRe4u7vTu3fvJs33wS2ne/XqxaFDhzh69CjHjh1j+fLlZGRkYGBgQEBAAIaGhlhbWxMcHExOTg7/+c9/OHHihDTZtmfPnqSkpABVG6tERkbSoUMHVq9eTa9evQDQ0dFBT08PIyMj5HI53t7eNba4jouL488//+Tu3bsMGTKE9PR0LCws8PHxYcuWLRw9epSCggK0tbXx8fERyyIKQisgeoj/T0REBBYWFgwZMoQ9e/awevXqap87OTkRHByMo6MjmzdvZurUqQAcPHgQR0dHVq1ahaura61rhSrTpk0bHBwcKCwsrDGJRajd8uXLycvLIzQ0VNWhNLhr164RExMjeoeFJuPj48M///zTaFukl5eXI5fLa0xOVrbltEwmIzs7m/T0dGmYWnJyMhMnTiQ4OBiommD7008/kZSUJJ2/f/9+vv32W2m7bIWkpCRsbW1rLStq2+K6qKiIpKQkevfujYaGBikpKaSlpXHt2jUKCgrQ0tIiOjqaGTNmsHnz5kZ5boIgNC3RQwxYW1tL26A+6MMPP5T+HB8fz19//SXtN79o0SIWLVpEYWEhurq6QNU418GDB9dYK1RhxIgRjBgxoloeBw8ebOhbatW6d+/O9OnT+fLLL/nggw8euT5sSxIUFIS+vj4TJ05UdSjCUyA3N5d169bh7e2Nvr5+o+Th7e1NZGQko0aNkoY0QO1bZltZWaGtrU18fDyLFi0CqoapffvttyxdupR33nmHiIgIrl27xqJFi0hJSSEnJ4fp06dz6tQpKX3FcoUGBgakpaUpja22La4VjWpdXV0GDhwIgJ6eHsXFxQDSG0IzMzOWLl3aIM9JEATVEj3E9aRoDN9P0RhWaNeunVSw1mfNUaHuli1bxq1bt9i6dauqQ2kw9+7d47vvvmPmzJmtciiI0PwsXLgQQ0PDRn0j4enpSWZmZrXGMPz/ltNAtR39FMPLFMPUgGrD1AYNGsSZM2eAqsZzcHAw//73v2vkW5cvygMGDMDGxobw8HD8/PwYN25cjWsVGwFVVlZKQ94UcZ08ebLFTT4UBEE50UMstEhGRkZ8+OGHfPXVV0yfPp1nn31W1SE9sYiICP773/9WeyshCI0lPT2dnTt3EhkZqZK3LPb29ri7u7Nx40bkcjlDhgyp9rmTkxNubm7s3buX0tJSqUHdpk0bunTpgqmpKV26dKGwsJCxY8cq3S77USZNmoSLiwupqalkZWURFBQkTXp+mKioKE6fPs2NGzcICwur340LgtAsia2bhQbVlFu35uXl0atXL7766ivmzp3b6Pk1tuHDh/P8888TERGh6lCEVq6yspJhw4bxzDPPSJPQGkJ9fv8ftWW2wv3D1B6ltu2yH6Wu23MDrFq1iq5duzJmzBj09PRaxcY5YutmQRA9xEILZmhoyKxZs/Dx8cHNza3atrYtTVZWFqmpqRw4cEDVoQhPgR07dnDs2DHS09NVFsOjtsxWqGtjGGrfLvtR6ro9N1QNp9DQ0Gi0MdeCIKjGEzeI//vf/0o9xYLQ1EMXlixZwrfffktgYCALFy5s0rwb0tatW+nWrZs0EUgQGktpaSmffvopLi4u0vroqtBSt8z+5JNPVB2CIAiN4Inf9fzzzz/iFa8AwPHjx7l06VKT5qmvr8/s2bNZtWqVNAO8pZHL5YSFheHq6lrvV72CUF/+/v7cunULLy8vVYcCtPwtswVBaB0arCQS44gFW1tbcnNzmzzfxYsXExQUxPr161vkEkjR0dHcvHlTWttaEBrLzZs3WblyJUuWLBGrIwiCINynwRrEiqVphKfboEGDmjxPXV1dPvroI/z8/PjPf/5TYxm85u67777DysqKF154QdWhCK3cZ599Rvv27fHw8FB1KIIgCM3KEzeIn3vuObHtsCDJysri+PHjTZ7v/Pnz2bhxI+vWrWu0Hbcaw7Vr10hMTGTXrl2qDkVo5c6ePUtISAjbtm2T1kkXBEEQqjxxg/jZZ58VS7UIElU17Dp27MjcuXNZs2YNH330Ub1mpqvSd999h76+PhMmTFB1KEIrt3DhQkxNTXFyclJ1KIIgCM1Oy19AURD+z7x589DU1MTf31/VodRJRUUF27Ztw8XFBQ0NDVWHI7Ri+/btIzExkbVr17aKdXMFQRAaWossGRMSEoiJiWnQNLOzs7G2tq72s2/fvgbNQ6GoqKjJV2N4GrRr14758+ezbt06bt68qepwHungwYNcuXKFadOmqToUoRUrKyvj008/xdbWlmHDhqk6nIdKTk4mOjq6zuc/Tl2Qnp6OtbU1f/31l3Ts5MmTNY7dT1FmHzhw4LHqnqysLDZt2lTv6wRBaDotcr0bU1NTysvLGzTNwsJCZDIZ3333nXSssV67nzt3jrCwMIKCghol/afZnDlzCAgIYM2aNaxcuVLV4TzU1q1bGT58OK+88oqqQxFasY0bN3L58uV6NTRV5erVq3XaOlnhceqCvLw8UlNTiYyMxM3NDYCQkBBSU1MpLS1Veo2izDYzM+PevXv1yg/gzp07XLhwod7XCYLQdJqsQZybm8v8+fO5e/cu5ubmGBgYcPToUQoKCtDW1sbHxwcTExPkcjm+vr6kpqZSXl5OaGgourq6LFmyhLNnz2JgYMCkSZOQy+VoamoSFxfHn3/+yd27dxkyZAjp6elYWFjg4+OjNK3U1FSSkpK4ceMGbdq0ISAggH/9619A1XjoHj16SDHLZDI8PDzIyMjAwMCAgIAADA0NiYiI4NChQxw9epSlS5fWGsOXX36Jg4MDJSUlAISFhdGpUyf8/f3JyMggJSUFS0vLpvoneCro6OiwaNEili9fjoeHBwYGBqoOSan8/HxiYmKqfQEThIZWUFCAt7c38+bNk8q55kImk1Ur1++fnC2TyVi+fHm1svfw4cM1yu5Tp05RWlqKpqZmjc8MDQ1Zvnw5v/76K926dePll19m8eLFAIwfP56IiAjc3NyoqKjg9OnT9OvXj7KyMry9vavVGd26dZPK7Hbt2nHhwgUiIyPp0KEDq1evxsDAoEashoaGFBcX8+WXX/LLL7+gp6dHly5dVPWoBUGogwYfMlFeXo5cLq/xrX3Pnj2Ym5sTFRWFsbEx169fR0tLi+joaGbMmMHmzZsBOHToEHK5nISEBGbPno2XlxfR0dHo6+uTmpqKlZUVKSkpUo9uUVERSUlJ9O7dGw0NDVJSUkhLS+PatWtK05LJZMjlcvbv34+dnR2hoaFSjD///DPm5uaYm5vzxhtvEBUVhZGREcnJyUycOJHg4GCgqrDOzs4mPT39oTEcOXKEKVOmEBsby/Dhw9m+fTsAHh4ejBo1SjSGG4li6bXm3EMcGhqKtrY277//vqpDEVoxLy8v1NXV+fTTT1UWQ211woPl+unTp6XPlJW9ysruoqIiqS548LO9e/fy6quvkpCQgKGhIfn5+VL6zz//PJWVldy8eZOUlBTefPNNKisr+emnn2rUGfD/ZfbLL78MQFJSEra2toSGhtZaT4SHh6Orq8vhw4fp27dvYz9mQRCeUIM3iL29vTEzM2PRokXVjjs7O3Py5EnMzc3JyclBW1sbCwsLAMzMzDhy5AgAcXFxpKWl4eTkxI4dOygrKyM+Pp53330XADc3N15//XUpXUWjUldXl4EDBwJVQx2Ki4uVpgVI25UaGxtXez03dOhQTp48ycmTJ/nll1+Ij49n9OjRAAwfPpzk5GTpXCsrK7S1tR8aQ0VFBfv27cPGxobY2NhaX8cJDUtLS4vFixcTGBioko1C6mLbtm1MmTJF+j8kCA0tOzubwMBAvL296dixo8riqK1OeFi5XlvZW1vZreyzhIQEqY5RtiW6jY0Ne/bsYdeuXdjb2wNVDV1ldcb9FGkZGBjw119/1RprcnIyVlZWAIwcObJuD0sQBJVp8Aaxp6cnmZmZrFmzptrx1NRUvvnmG9LS0jh//jwnTpzg4sWLQNWEBsWuSQMGDMDGxobw8HD8/PwYN24cffr0ISsrC6ga63V/T0Lbtm2lPys2B6msrKSyslJpWoA0y7qysvKh99KvXz8pxjNnzkiF6/1pPCyGwMBABg0aREREBH369HnksxMazowZM3j++efx9fVVdSg1HDlyhN9++43p06erOhShFfPw8KBXr164urqqNI7a6oSHleu1lb0PK7sf/Kx///7SuN3U1NQa50+aNIldu3aRmZnJgAEDAOjbt6/SOuN+95f3D4u1f//+0vHMzMxano4gCM1Fk40h1tXVxcHBgd69e1NSUoKFhQXh4eGcPn2aGzduEBYWBlQVUi4uLqSmppKVlUVQUBCDBw9m1qxZ7N27F7lczpgxY+rU26osrfpM2HBycsLNzY29e/dSWlpao0B/lKFDhxISEkJaWhqlpaVERUXh4eGBiYkJR44cITU1tdnP+m6p2rZty2effcYnn3zCkiVL6Natm6pDknz33XeYm5vTv39/VYcitFKHDx9m3759xMfH88wzzXPutLOzc7Vy3cXFRWo4Kit7k5KS6pW+vb097u7ubNy4EblczpAhQ6p9/txzz6GlpVWto2Ps2LEsXry4Wp0BSGV2hw4dauwoWVs9MXnyZCZPnkxkZCQymYxevXrV+xkJgtB01Cof1U36ELa2tgDs3r27TudXVFSQn59Ply5dWLVqFV27dmXMmDHo6enVWBvz+vXr6OvrV/s2XlxcTPv27esdp7K06uOvv/567BUnZDIZampq6OjoVIv/3r17tGnThjZt2jxWus2V4vXjE/y3ajByuZyXXnqJcePGsWHDBlWHA1TNNjcyMsLf35+ZM2eqOhyhFaqoqOCNN97AwMCAuLi4Js37cX7/H1auP0nZm5mZiY6ODj169GDDhg20a9euzr3lyuqMR5XZtcWal5eHoaHhY91DU1FTU2Pnzp1iky3hqdakXQfq6urSTNu2bduioaGBvr6+0nO7du1a49jjNIZrS6s+nmT5tXbt2kl/vj9+TU3NJ4pJeDQNDQ0WL17MJ598wsKFC2v07KhCWFgYlZWV0phFQWhowcHBZGRkcPbsWVWHUicPK9efpOzt1KkT06ZNQ11dnfLyciIjI+t8rbI641Fldm2xNvfGsCAIVVT2Lu2TTz5RVdbCU8TV1ZWVK1fi5+fXLHqJg4ODsbe3R1dXV9WhCK2QYrkyd3d3evfurepwVMrY2JhDhw5RVlbWbIeNCILQfLTIneoEoa4UvcRbtmzhypUrKo3l119/5cyZM2IyndBofH19+eeff/D09FR1KM2GaAwLglAXokEstHqurq4YGRmxatUqlcYREhJCjx49GDp0qErjEFqn3NxcAgICWLZsWa1D0QRBEATlRINYaPUUvcRbt25VWS9xWVkZ4eHhuLi4SEvzCUJDWrRoEYaGhsyZM0fVoQiCILQ4okEsPBVU3Ut88OBB8vPzmTJlikryF1q39PR0duzYwerVqx97NR1BEISnmWgQC08FVfcSf//99wwdOlSsRSo0uMrKShYsWMDgwYN57733VB2OIAhCiyQaxMJTQ1W9xHfu3CEmJoYPPvigSfMVng47d+4kLS2NdevWieE4giAIj6lFNogTEhKIiYlp0DRnzZqFtbV1tZ/Nmzc3aB6Caqmql3jnzp1UVlZiY2PTZHkKT4fS0lI+/fRTPvjgA8zNzVUdzhO7cuVKtTJ41qxZpKenA3Dq1CkcHR35559/pPPnzJlDWVmZ9PeIiAjmzZv30DwOHDhQo/54knzrkqcgCM1fi2wQm5qaYmZm1qBpenl5ERgYSMeOHRk/fjyBgYE4ODg0aB6C6qmilzg0NJT33ntPrD0sNLiAgADy8/NZsWKFqkNpEEVFRRQVFbF161a2bt3KpEmTGDNmDHK5nJs3b7J//368vb2l85OTk6moqJD+HhAQQHx8/EO/8Obm5nL16tUGy7cueQqC0Pw12QKNubm5zJ8/n7t372Jubo6BgQFHjx6loKAAbW1tfHx8MDExQS6X4+vrS2pqKuXl5YSGhqKrq8uSJUs4e/YsBgYGTJo0CblcjqamJnFxcfz555/cvXuXIUOGkJ6ejoWFBT4+PkrTSk1NJSkpiRs3btCmTRsCAgL417/+RefOnQHQ0dFBT08PIyMjHBwcWLFiBS+99BLr1q0jOjqa7t271ynmbt26NdWjFepBQ0ODJUuW8PHHH7No0aJG373u8uXLHDt2jGXLljVqPsLT5+bNm/j6+rJkyRKMjY1VHU69KTYR+fXXX+nWrRsvv/wyY8eORUNDg+effx6AESNGoK2tzb179wBwdHTk4MGDTJ48ucbGI+fPn0dfX5+JEyfy448/snTp0hr1juL3MC4ujsjISDp06MDq1asBHivfuuZZW722bNkyTpw4Qc+ePTExMWHFihWEhYVRUVGBi4sLiYmJZGZm8vHHH9epLjM0NKxWV+7cuZOKigpRPwlCHTR4D3F5eTlyuZzy8vJqx/fs2YO5uTlRUVEYGxtz/fp1tLS0iI6OZsaMGdLwhEOHDiGXy0lISGD27Nl4eXkRHR2Nvr4+qampWFlZkZKSQmFhITKZjKKiIpKSkujduzcaGhqkpKSQlpbGtWvXlKYlk8mQy+Xs378fOzs7QkNDa70XS0tLIiIiAAgPD8fc3LzOMQvN1/Tp0+natWuT9BL/+OOPGBgYMGrUqEbPS3i6LFu2jPbt2zN//nxVh/JQtdUJe/fu5dVXXyUhIQFDQ0Py8/OBqkbm1KlTcXFx4fXXX2fatGno6OgAVY3WTZs2MWvWLCorK6ult23bNj744APs7Oz48ccfgZr1TklJiXR+UlIStra2Uh3wOPnWNU9ldcSePXswMjLi559/pkuXLvz1118AFBcXI5PJACgpKeHOnTt1rsserCtPnz4t6idBqKMGbxB7e3tjZmbGokWLqh13dnbm5MmTmJubk5OTg7a2NhYWFgCYmZlx5MgRoOqbe1paGk5OTuzYsYOysjLi4+N59913AXBzc+P111+X0rW0tARAV1eXgQMHAlV7yhcXFytNC5DG2hkbG1NQUFDrvdjZ2REdHU12djYGBgbo6+vXOWah+WrKscTbt2/H3t5e7JYlNKgLFy4QEhLC119/LTXamqva6oSEhASpPH377bel4z179sTT0xNPT0/mz5/Prl27ql03cOBATE1N2bp1q3SsrKyMH374gbVr1zJt2jSys7M5efKk0nrn/vwMDAykhmh9861PnsrqiEOHDjFq1CjU1NQYO3as0menqEvqWpcpqytF/SQIddPgtbSiQHlQamoq33zzDZ06dcLJyQk1NTVefPFFAE6ePCm98hswYAB9+vTB3d2dK1eucOLECbKzs8nKymLAgAGEhIRw+vRpXnnlFYBqa24qZlhXVlZSWVmpNK2CggLU1dWl8x5GT0+PLl264Ovry5QpU/j999+5ePFinWIWmrfp06ezcuVKVq1axcaNGxslj5MnT/I///M/D30LIQiPY968efTt25fJkyerOpRHqq1O6N+/PxcuXKB3796kpqZKx5999ll69OgBgImJCZ9++mmN3mUfHx+GDBlCYWEhAPHx8YwfP54tW7YA8N133xEWFsaIESOq1TuKslnZWs31zTchIaHOeSqrI37//XeysrLo378/WVlZUh5aWlrcvn0bgOPHj/Pss8/WuS7r06dPtbrS1NRU1E+CUEdNNqlOV1cXBwcHPDw8KCkpwdTUlKioKKysrJg7dy6fffYZAJMmTeLAgQNMnjwZGxsbTExMcHZ2Jjw8HHt7e2JiYnjttdfqlKeytOrL2dmZyMhIJkyYAFDnmIXmrSl6ibdv306vXr144403GiV94ekUExNDQkIC69atkxpELZG9vT3ff/89lpaWJCQk1PoWpVOnTpw/f77asfbt2/Pll1/y559/AlVDF5ydnaXPJ06cyJ49e2jfvn2NeqeuHpXv999/X+c8ldURjo6OrFmzBgcHB3744QcpnbfeeouDBw/y9ttvc+rUKaDudYyyulLUT4JQN2qVj+omfQhbW1sAdu/eXafzKyoqyM/Pp0uXLqxatYquXbsyZswY9PT0ahTs169fR19fv9o3+eLiYtq3b1/vOJWlVVeHDx8mJiYGf3//x4r5abNr1y7s7e0f2fveHMjlcl5++WWsrKzYtGlTg6ZdUVFB9+7dcXV1FWP2hAZTVlbGa6+9xquvvlrncrcp1ef3PzMzEx0dHXr06MGGDRto164drq6uDR7T/fVOU6ktT2V1xK1bt/jtt9/YtWsXGzZskI6XlJRIQzwedr0yyurKh12rpqbGzp07sbOzq/M9CkJr06QDG9XV1aUCom3btmhoaKCvr6/03K5du9Y49jiN4drSqoudO3cSFhZGUFAQ8HgxC82Xopf4o48+YtGiRdLr0oaQkpLC9evXsbe3b7A0BWHTpk1cunSJqKgoVYfyxDp16sS0adNQV1envLycyMjIRsnn/nqnqdSWp7I64vnnnycrKwstLa1qxx9sDNd2vTLK6kpRPwnCwzVpD7HQ+rWkHmJovF7iDz/8kNOnT0uvPAXhSRUUFPDiiy/i6urKypUrVR2OUo/z+19WViYmnaqY6CEWhBa6MYcgNJT7xxL/8ccfDZLmvXv3iIyMxNHRsUHSEwSAFStWoK6uztKlS1U6w1G1AAAgAElEQVQdSoMSjWFBEJoD0SAWnnrTp0+nW7duDbYu8YEDBygsLBQ7HQoNJjs7m8DAQFasWEHHjh1VHY4gCEKrIxrEwlOvoXuJd+zYwbBhw8RuUEKDmT9/Pj179sTNzU3VoQiCILRKokEsCMC0adMwMjJ64rGZpaWlxMXFid5hocGkpKQQHR2Nv7+/GF4gCILQSESDWBAATU1Nli5dSkhICNeuXXvsdPbv38/ff/+NtbV1A0YnPK0qKipYsGAB77zzDlZWVqoORxAEodUSDWJB+D/Tpk3D0NDwicYS7969m+HDhzf5Mk9C67Rt2zYyMjIabHy7IAiCoFyTNYiLioq4dOlSo6U/a9YsrK2tq/1s3ry50fITWh8NDQ0WLlzI1q1buX79er2vLy0tZf/+/dJyhILwJGQyGcuWLWPmzJn06dNH1eE0uAMHDhATE9Po+WRlZTX4xjuCILQ+TdYgPnfuHGvWrGm09L28vAgMDKRjx46MHz+ewMBAMY5TqDc3Nzeee+65x/q/euDAAWQyGe+9914jRCY8bVauXMnff//N8uXLVR1Ko8jNzeXq1auNns+dO3e4cOFCo+cjCELL1mQzNPz9/cnIyMDV1ZU333wTFxcXEhMTyczMxMjIiLi4OP7880/u3r3LkCFDSE9Px8LCAh8fH2QyGcuXLycjIwMDAwMCAgL4+eefOXToEEePHuXcuXN07twZAB0dHfT09DAyMsLBwYEVK1bw0ksvsW7dOqKjo+nevTsFBQVoa2vj4+ODiYkJcrkcX19fUlNTKS8vJzQ0VKwQ8JRq27YtCxcuZMmSJSxcuLBeQx92797Nm2++KYZLCE8sNzcXf39/vLy8MDAwUHU4jSYuLo7IyEg6dOjA6tWrMTExwcHBgZKSEgDCwsLYtWsXERERQNXyc3v37qVv3741zktKSpLqhLS0NL788kt++eUX9PT0pN9JZXVJYmIiFRUV1eoke3t75s+fz927dzE3N2fZsmWqeUCCIDSZBu8hLi8vRy6XU15eXu24h4cHo0aNwszMDJlMBlTt1X7nzh1kMhlFRUUkJSXRu3dvNDQ0SElJIS0tjWvXrhEVFYWRkRHJyclMnDiR4OBgZDIZ2dnZpKen1xqLpaWlVJCGh4djbm6OlpYW0dHRzJgxQxpScejQIeRyOQkJCcyePRsvL6+GfixCCzJz5kz09PQICAio8zWK1SXEcAmhISxevBhDQ0M++ugjVYfyxGqrExSSkpKwtbUlNDSUnJwcpkyZQmxsLMOHD2f79u3MnDmTxMREbGxssLCwwNTUVOl599cJ4eHh6OrqcvjwYfr27SvlpawuKS4urlEn7dmzB3Nzc6KiojA2NpYa3oIgtF4N3iD29vbGzMyMRYsWPfLcsrIy6c+WlpYA6OrqMnDgQAD09PQoLi4mPj6e0aNHAzB8+HCSk5MBsLKyUrrfu4KdnR3R0dFkZ2djYGCAvr4+FhYWAJiZmXHkyBGgqpciLS0NJycnduzYUS0u4emjpaWFh4cHmzZt4ubNm3W6Jj4+XgyXEBrEL7/8wvbt21m1ahVt27ZVdThP7GF1wttvvw2AgYEBf/31Fzo6Ouzbtw8bGxtiY2MpLS0FqpaeCwsLY+vWrQC1nqeoE5KTk6VVOUaOHCnlV1tdoqAo+52dnTl58iTm5ubk5OQ8tJ4RBKF1aPAGsaenJ5mZmbWOwdTS0uLvv/8G4Pjx49Lx+wt+NTU1ACorK6msrKRfv35cvHgRgDNnzkiNWnX1h4eveFXm6+vLlClTAKR0Tp48ibGxMQADBgzAxsaG8PBw/Pz8GDduXL3vW2hd3N3d0dHRYe3atXU6PyIigqFDh2JkZNTIkQmt3fz58xk8eDCTJk1SdSgN4mF1woMN/qCgIAYNGkRERIQ0kTAnJ4e5c+eye/dutLS0aj0P/r9O6N+/v1TWZ2ZmSp8rq0uU1Umpqal88803pKWlcf78eU6cONEgz0IQhOarySbVmZiYcOTIETQ1NTl48CBvv/02p06dqtO1Tk5OBAcH4+joyObNm5k6dWqd83V2diYyMpIJEyYAVa/MrKysmDt3Lp999hkAkyZN4sCBA0yePBkbGxtMTEzqfX9C66Kjo8O8efNYv349t2/ffui5crmcuLg43n///SaKTmitdu7cSVpaGmvXrpU6Bp4mQ4cOJSQkBFdXVwoLC4mKimLOnDn8/ffffPDBB4waNYqff/5Z6Xn3mzx5MoGBgdja2hIXFycdV1aXvPXWWzXqJF1dXRwcHPDw8KCkpARTU9MmfQ6CIDQ9tcrKysrHvVgxXnL37t11Ov/evXu0adOGNm3aUFJSUu/XUH/99Rd6enr1uubw4cPExMTg7+/PqlWr6Nq1K2PGjEFPT69GD/P169fR19dvFa8pVWXXrl3Y29vzBP+tmo2///4bExMT3N3dWbFiRa3nJSQkMGbMGHJycsSXKeGx3bt3j3//+98MHTqUbdu2qTqcx9IQv/8ymQw1NTV0dHQoLi6mffv2j31eXl4ehoaGNY4rq0serJMqKirIz89/KibJqqmpsXPnTuzs7FQdiiCoTJNuzKGpqUmbNm0AHmtMVn0bwzt37mTNmjV4eHgAVa/nNDQ00NfXVzrcomvXrqIxLEh0dHT4+OOPWbduHQUFBbWeFx0dTf/+/UVjWHgi/v7+3Lhx46Ffvp4G7dq1Q0dHB6DWxnBdz1PWGAbldcmDdZK6uvpT0RgWBKFKq96pzt7entjYWGkJtU8++UR8Axbq5eOPP6ZNmzasX79e6eeVlZXExMSIrZqFJ3Lz5k18fX1ZvHgx3bt3V3U4giAIT51W3SAWhCfVoUMHPv74YwICAigsLKzx+alTp7h27ZpoEAtP5PPPP6ddu3YsWLBA1aEIgiA8lUSDWBAeYd68eQBKt39VbPYiJt0Ij+vChQsEBwfj4+MjDQEQBEEQmpZoEAvCI3Ts2JE5c+bg7+9PcXFxtc+ioqKwtrZ+KlcEEBrGvHnz6Nu3L87OzqoORRAE4aklGsSCUAfz5s3j3r17BAYGSsf++OMPfv31VzFcQnhssbGxJCQksHbt2keuqy4IgiA0HlECC0Id6OnpMXv2bPz8/KRtXiMjI9HV1WXYsGEqjk5oicrKyliyZAnvv/8+b775pqrDEQRBeKqJBrEg1NGCBQsoLS3l22+/Baq2/H7nnXfQ1NRUcWRCSxQYGMilS5f4+uuvVR2KIAjCU6/JGsQRERGkpqZWO5aQkEBMTEydz6+P/fv3V9unvqioiI8++qjGeVlZWUonSwnCg5577jnc3d3x8/Pj9u3bHD16lLFjx6o6LKEFKiwsZMWKFXzyySe8+OKLqg6nVTh16hSOjo78888/0rE5c+ZQVlZW77SetP4RBKHlabIGcU5ODnl5edWOmZqaYmZmVufz6+OPP/7g2rVr0t/v3r3L4cOHa5x3584dLly48Nj5CE+XBQsWUFRUxNKlS5HL5YwePVrVIQkt0IoVK1BTU2Pp0qWqDqXVuHnzJvv378fb21s6lpycTEVFRb3TetL6RxCElqdJh0xs27aNwYMHY21tTXZ2NikpKSQmJiKTyfDw8GDkyJE4OjpKBdGD51dUVGBnZ8f48eMZP368tHvY9u3bcXNzY+zYsUyYMIHLly9Led66dYsJEyZw5coV6VhxcTGLFy9mxIgR+Pr6NuUjEFo4AwMDPvzwQ3788Udee+01OnfurOqQhBYmJyeHTZs24eXlha6urqrDURmZTMacOXMYNmwYNjY2lJeXK60LtmzZwtSpU7G2tsbR0ZHff/8dBwcHsrKyAFi3bh3bt28HwNHRkYMHD3L+/Hkpnx9//JHQ0FAAEhMTWbNmDVBVbzg7O/PWW28xdOhQFi9ejKWlpfQl5cH6B0Aul+Pt7c3o0aN56623yM3NJSIiAnd3d/r27dtkz04QhIbX4A3i8vJy5HI55eXlNT4zMDDg2LFjuLq68u2331JUVERhYSFRUVEYGRmRnJzMxIkTCQ4OVnp+Tk4OU6ZMITY2luHDh0uFoEwmQy6Xs3//fuzs7KTCLz8/HxsbG7y9vXnhhRekOMLDw9HV1eXw4cOiEBPqbfHixfzzzz+1bgsrCA8zf/58evbsyYcffqjqUJpEbXVCdHQ0+vr6pKamYmVlxenTp5XWBQUFBWhpaREdHc2MGTPYvHkzlpaWREREAFXl+ahRowDQ0NBg06ZNzJo1i8rKSqCqA0QxEbakpIQ7d+4AVfVGUVERSUlJ9O7dGw0NDVJSUkhLS6OwsLBG/QNw6NAh5HI5CQkJzJ49Gy8vL2QyGdnZ2aSnpzfJ8xQEoXE0eIPY29sbMzMzFi1aVOMzRaH15ptvcuzYMel4fHy89Op5+PDh0tjfB8/X0dFh37592NjYEBsbS2lpqZSGubk5AMbGxlLP8fr167l9+zZGRkbV4khOTsbKygqAkSNHNsh9C0+PwsJCKisrOXnyJLm5uRw6dIjY2FjOnz8vVcKCoExKSgpRUVH4+/vzzDPPqDqcJlFbnRAfH8+7774LgJubG6+//nqtdYGFhQUAZmZmHDlyBDs7O6Kjo8nOzsbAwAB9fX0p3YEDB2JqasrWrVtrxPLgeGJLS0sAdHV1GThwIFC1oszdu3eV1ldxcXGkpaXh5OTEjh07pPSsrKzQ1tZ+/IckCILKNXiJ7Onpiaenp9LPFK+dzp49KxVwAP369ePixYv069ePM2fOSJ89eH5QUBCDBg3C1dWV2bNnV0tbsYbn/Q0SLy8vtLW1+eijj9iwYYN0vH///ly8eJH+/fuTmZn55DctPFUOHDhAu3btKCwspHv37tX+z5mYmPDFF1/g4uKiwgiF5qiiooIFCxbw1ltvSV/Inwa11Ql9+vQhKyuLAQMGEBISgqmpaa11wcWLFwE4efIkxsbG6Onp0aVLF3x9fZkyZUqNtH18fBgyZAiFhYVoaWlJ264fP36cZ599Vjqvbdu20p8Vm+sofp+V1VcDBgygT58+uLu7c+XKFU6cOIFMJhNrSAtCK9CkXRSKsV1FRUWsXbuWlJQUAJycnHBzc2Pv3r2UlpayZs0aIiIiapz/xx9/4OXlRVpaGqWlpURFReHh4VFrfm3atMHBwYGQkBDi4+Ol45MnT2by5MlERkYik8no1atXY9+60IqEh4fzzz//8Prrr7N06VIsLCzQ1tbmt99+Y+vWrUyfPp3Tp0+zbt06VYcqNCOhoaFkZGRw5swZVYfSLDg7OzNr1iz27t2LXC7HxcWFzp07K60LoqKiOH36NDdu3CAsLEy6fubMmaxfv75G2u3/l707j6uq2v8//kLEFMyQSBTxGuZQoZKKP3NIMCW9mnlVBAQMvVoOdVPxVjZck+j69VZIg6VNTiQGIoKCAyKiJ6eccMxLQjmEoiUIRwQZzu8Pvmd/OZx9EBQ5DJ/n49HjEZu911pnu885i73Xeq8HH+SDDz5gzJgxPPvss0yfPp3ExERKS0sZNGhQldpX8fsHYNy4cQQGBqLRaEhLS2P58uWcPHmy5k6KEMJsLHT38Ix3woQJAKxfv77Kx+Tk5JicSHL9+nXs7Owq3V+r1WJhYYGNjQ15eXk8+OCDd9HyMleuXJFxoDUsKioKHx+fBjt0IDMzEycnJ/r168ePP/6IpaWl0T4bNmzA29ubqKgoxo8fb4ZWirpGq9XSrVs3xowZ06BjHu/m/a/2OV7+u+DDDz+kffv2DB8+HDs7O+Vu7K5du9i8eTNLliypUj35+fnVHtZg6vvq999/x97e3uAOc31mYWFBZGQk3t7e5m6KEGZT6895KptVXbEzrLZ/y5YtsbGxAbinzjAgnWFRbe+99x46nY5Vq1apdoYBxo8fj6+vLx9++GEtt07UVR9++CF5eXm899575m5KnaP2OV7+u+CBBx7AysoKe3t7pTMcGRlJaGhopU8IK7qbMb6mvq/at2/fYDrDQogyjWNWhxA1JCkpidatW9OtW7dK9/P29mbs2LH3/BRD1H+///47S5Ys4b333sPBwcHczal3Zs+ebbTNx8cHHx8fM7RGCNFQyUwAIaohKyuLrl273nG/jh07otPpJNxf8Oabb9KmTRtee+01czdFCCGECXKHWIgqunr1Krdu3eLhhx++4776rNNWrVrd72aJOuzo0aOsW7eOyMhIecQuhBB1mNwhFqKKUlJSaNKkCenp6XecNJSSkkL79u1lJbtGbs6cOfTr108mVwohRB0nHWIhqiglJQUXFxd++eUXVq1aZXK/S5cu8dlnnzF58mQl21Q0PlFRUfz44498+umnch0IIUQdJx1iIaooJSWFkSNH8vrrrzNjxgzCwsK4ffu2wT579uzBw8OD9u3bM3/+fDO1VJjb7du3efvtt5k0aRJ9+/Y1d3OEEELcgYwhFqIKrl69ytmzZ1myZAnDhw+nZcuWvPXWW3zwwQf07duX5s2b8/PPP5OWlsZf//pXVq5cScuWLc3dbGEmYWFhZGZmEhISYu6mCCGEqIJau0McHR2NRqMx2JaYmMjmzZurvH91bNmyheTkZOXns2fP8u9//9tgn5deeomCggLOnz/PmDFjlP9mzpzJwYMHAThy5IjqSkiicdm1axeWlpb07NmT1157jXfffZeMjAwWLFhAy5YtyczMZMKECezfv58tW7bcMV4rKioKCwsL+a8O/BcVFVWj18rVq1f5n//5H9544w3+8pe/1GjZDUlln/93Izc3l19++UX5OSEhgQkTJvDcc88pq0bWdJ1CiIaj1u4QZ2RkGE1EcnV1paSkpMr7V8dvv/2mLOABkJ2dzU8//WSwT1JSEsXFxeTm5pKbm6t8MaampjJ8+HCuXbvG1atXZalVQUpKCm5ublhZWbFr1y4AHB0dmT17NgMGDGD16tV88MEH1S43MjKyppsqquF+ZNkuWLAAGxsbXn/99RovuyGp7PP/bpw8eZLw8HCWL19OdnY2H330EVFRURQXFxMUFESvXr1qvE4hRMNRq0MmVq1axZIlS2jTpg1Llizh8OHDFBQUMH78eBYsWEBqaioODg6EhYWp7u/s7Iyvry/5+fkAhIeH07p1a9atW8fOnTvJzMzE0tJSOR7g2rVr/P3vf2fy5MmVts3KyopHHnkEgCFDhmBtbW00PlTcH6GhoYwZM4bOnTsbbI+OjiYpKYm9e/dy9OhRFi9ejEajoaSkhNWrV+Pk5MSlS5eYN28ehYWFuLm5MWfOHKNraceOHZSWlhIYGMiOHTs4ceIE8+bNMyh///79zJ8/n+PHj+Pg4MD333/PRx99pNR34cIFvLy8lLbl5eXxwQcf8NNPP2FnZ0e7du3u6rXLUqnmVdMd4jNnzvDdd9/x7bffGvxBLoylpKRQUFBAs2bNjD6/mzdvbvC+fvfddykqKjL6DDhw4IDyHu7atSupqamkpKTQtm1bbt26hYWFBY6Ojnz++efcuHFDqbOgoIDo6GgA0tPT2bhxI08++aTqZ4wQonGo8SETJSUlFBUVqf4V7uDgwP79+5k6dSpff/01ubm55OTkEBsbi6OjI8nJyYwdO5YVK1ao7p+RkcGkSZOIj4/H3d2ddevWAaDVaikqKmLLli14e3uzevVqoGwRBS8vL0JCQnB0dKy03adPn2by5MkEBgbSt29fpkyZIl9oteTcuXPcvHnTaLtWqyU9PZ2DBw+SlJREUVERiYmJvPLKKwQHBwOwYcMG3NzciI2NpUOHDkRERBhdS3l5eWi1WgDy8/OVjODy5cfFxWFvb49Go2HEiBF8+OGHSn3+/v6cO3cODw8PpW0RERHY2tqya9cuevTocf9PkqgXgoKC6NGjB5MmTTJ3U+oMU98J+s9/tc/viu/r/Px81c+A8u/hoKAgPD098fDw4PHHH8fX15dnnnkGNzc3vvzySxwcHJQ6p0+fzo4dO/Dy8mLAgAG4urqa/IwRQjQONd4hDgkJoU+fPrzxxhtGv/P09ARg8ODB7N+/X9m+bds2nnvuOQDc3d2Vsb8V97exsWHTpk14eXkRHx9PQUGBUoabmxsAHTp0IDs7G4DPP/+cP/74A0dHRx5++GFu3bpl0J4mTZoo69t36tSJhQsXsnDhQubNm1fj4wqFsbCwMJ555hliY2OZMmUKzzzzDL/++qvBPiNGjMDa2pqEhAT27duHn58fP/zwA8XFxQAEBARw+PBh3NzcyMjIYM+eParXkp7+uIrlb9u2jRdeeAGAadOmcfXqVaW+b7/9FgsLCwYMGKAcl5yczIgRIwB49tlna/bEiHopISGB7du388knn9CkiQT46FX2naBX8fO74vu6ss8A/Xu4vGvXrjFt2jTOnj3Lhg0b+P333w2eHELZHerw8HC+/fZbAJPlCyEahxr/1F64cCEnTpwgNDTU6Hfp6ekAHD9+3KBz0bNnT86ePQvAsWPHlN9V3H/58uU8/fTTREdH0717d8MX8r9fQOXHHQcHB/Ovf/2Lf/zjH3Tu3JkzZ85w+fJlAPbv34+dnZ1yXIsWLXj00UdxdnYmICCAgoICGWt2n82dOxeNRsOYMWNYsWIFGo0GZ2dng330/z69e/fGy8uLiIgIPvroI0aNGgWARqPhs88+Y9++fZw+fZrCwkKja6l58+bKHegDBw6olt+9e3fS0tIAWLlyJYBSX/fu3enYsSMPPvigclyvXr2Uek6cOFGj5+V+q2wSqbg7xcXFvPnmm4wbN47Bgwebuzl1SmXfCXoVP78rvq8PHTpk8jNA7Y+PI0eOEBwcjE6no2PHjrz88sscOnRI+X1GRgZz5sxh/fr1NG/eHDD9GSOEaBxqdQzx9u3bOX36NLm5uXzyySekpKQA4Ofnx7Rp09i4cSMFBQWEhoYSHR1ttP9vv/1GcHAw+/bto6CggNjYWIKCgkzWZ2lpia+vLytXriQ+Pp6QkBB69OiBi4sLp0+fZuPGjSaPbd26NadPnwZg06ZNyh0MgEOHDknQfg3Sz/avzLhx4wgMDESj0ZCWlsby5csBsLW1xdfXFxcXF/Lz81m6dCmzZs0yuJYsLS35+9//TmJiIqWlpQwaNMio/ICAAGbOnMnGjRspKiri22+/ZcqUKWg0GjZt2qTcddbz9/fH39+fmJgYtFotjz32WM2dkPusskmkVlZWZm5d/bR8+XJ++eWXSj9TRNVVfF+7urrSpUsXo8+AkydPKsc4Ozuze/duNBoNzz33HGvWrMHNzY0ePXpw/vx5/v3vfyuf6a+++io3b97kxRdfBOC9994z+RkjhGgkdPfAy8tL5+XlVa1jsrOzTf7uzz//vOP+eXl5Oq1Wq9PpdLrc3Nxq1a3T6XRFRUW63377TVdaWlrtY8WdRUZG6u7xsqrUpUuXdAUFBQbbSkpKdJmZmQbb1K6lmzdv3rH8itfUb7/9pmvRooVu5cqVqvtfvnz5jmWqud/nqTInTpzQeXp6Kj8XFRXp2rVrp8vOzta9//77Ok9PT92zzz6ru3jxok6n0+kuXryo8/b21o0ZM0YXEhKiy8vL082dO1c3ZMgQna+vr+7y5cu6NWvW6FatWqXT6XS6xMRE3ccff6zT6XS69evX66ZPn67r3r27Li8vT/fKK6/oBg0apBs/frzu1q1bqvXVJkAXGRl5T2VkZ2fr7O3tdf/85z9rqFX1V01e12rva51O/TNAr7CwUFdcXKz8fPPmTd2VK1eqVW9l5TdUNfE+EKK+q/WBbra2tiZ/Z2dnd8f9W7ZsqUx2K/8Iu6qaNm1Kx44d5Q5vPdW+fXseeOABg21NmjQxSnlQu5YqjjNUU/Gaunr1Krdu3aJ///6q+7dt2/aOZdZFapNI9+/fb7aJi/V5ElNISAilpaW89dZb5m5Kg6L2vgb1zwC9Zs2aYWlpqfxsbW19x0zw6pQvhGi4ZKU6ISqxf/9+bG1t6dq1q7mbUqP0k0h1Oh179+4lODiYGzducPbsWfz8/CguLlb+8AwICGDWrFm4ubkxatQo0tPTlQlS7u7ufP3114wbN04pu7KJi3PnzgXKJi6++uqrqvXVJxkZGXzxxReEhoaq/hEmhBCifpAOsRCVOHDgAP37929wTxT0k0ihbOzlW2+9haurK927d2fGjBmcP39emYSkn+DUunVr/Pz8sLCw4OzZs/Ts2dNg4uIff/wBlJ2zFi1aKHVVnLjYu3dvg4mLFeurT/75z3/i7OzMyy+/bO6mCCGEuAfSIRaiEgcOHLjjoi4NQevWrenWrRuhoaFmmbhYHycx7d69m40bN7JlyxaZjCiEEPWcdIiFMOHq1av8+uuvJscP11c9evQgMTHRYJs+Om7w4MH8/vvv2NvbK+MoPTw8GDx4MFlZWcqYzm3btnH9+nWDYQI7d+4kPz/fYKx2+T8m2rdvz6ZNm8jLy1PGasfFxRnVVx+Ulpbyz3/+k2effZa//vWv5m6OEEKIeyQdYiFMOHDgAE2aNKFv377mbkqtat++vdG2+zlxUa2+um7NmjUcO3aMY8eOmbspddKECRPM3QQhhKgWWU5JCBOOHDlC586dK01GEY1Pfn4+CxYs4KWXXpJluyvo0KEDXl5e5m6GqCYvLy86dOhg7mYIYVZyh1gIE1JTU+nVq5e5myHqmP/85z/k5OTw3nvvmbspdU7//v1Zv369uZshhBDVVi87xImJiRQWFjJ69OgaK3PmzJlkZmYabGvatCmTJ0+u0XpM1TVy5EimT59eo/WIe3Ps2DFmzZpl7maIOuT3338nNDSUBQsW1NsMaiGEEMbqZYfY1dWVkpKSGi0zODiY4uJi5s+fzzPPPMOoUaPQarW0bNmyRusxVVd9zGBtyP78808uXrzIU089dV/r2b9/P0uWLLmvdYiaM3/+fNq0acNrr71m7qYIIYSoQbXWIb506RLz5s2jsLAQNzc3HBwc2Lt3L9nZ2VhbW7No0SKcnZ0pKipi8eLFaDQaSkpKWL16Nba2tsyfP5/jx4/j4ODAuHHjKCoqojE5NHIAACAASURBVFmzZiQkJHD58mUKCwsZOHAgBw8eZMCAASxatEi1LI1Gw86dO8nMzMTS0pKwsDA6d+5MmzZtALCxscHOzg5HR0ciIyMpKChg6NChBm1/9913jV5Px44dKS0tJTAwkB07dnDixAnmzZun2gYnJyejunx9fXn//ffp2rUrn376KW3atEGr1RqdIycnJ5PliZqTmpoKcN87xBcvXiQ6OlrGXZrBgQMHqrX/sWPHiIiI4IcffqB58+b3qVVCCCHMocY7xCUlJZSWltKkSRODJTT1y7++/vrrrF69ml9//ZXmzZsTFxfHrl27+Oqrr1i8eDFJSUnKcq4xMTEEBwfj4eGhLPn67bffkpKSgouLC9bW1uTm5rJz506mT5+OlZUVKSkpeHh4cPHiRU6dOmVU1v/7f/+PoqIitmzZQnh4OKtXryYkJET1teTm5pKfn2/UdrVtWVlZymIE5ZeuVXs933zzjVFdHh4eREdH8/bbbxMREUFCQgIrVqwwOkfu7u5VKk/cm9TUVNq1a1drj8Vl3GXtmzBhAtHR0VXef/bs2fTr10/+eBFCiAaoxjvEISEhxMTE4OnpSWhoqLK94vKvNjY2DBgwAIA+ffrw9ttvA5CQkGC0nGvFJV91Oh35+flAWUcSyhYP6NevH1AWB5WXl6daFoCbmxtQNiP64MGDd3xNFdtubW1ttM3BwQGdTgcYLl1rqg0VeXt789e//hUfHx8cHBywt7cHMDpHWq223i93Wx+kpqbe97vD5TW0lfAamuLiYv76178ybNgw+bcSQogGqMY7xAsXLmThwoVG29WWf+3SpQsAhw8fViJfevfubbR8bHp6usGSr0ePHuXxxx8HMAjz139R6XQ6dDqdalnZ2dnKUrL6DuydVGz7oUOH+P333w22Xb16FWdnZ8Bw6Vq1Nqixs7OjXbt2LF68mEmTJinbz549a3COqlqeuDfHjh3jhRdeuO/1DBgwgMjIyPtej1Dn4+NTpf2aNm3KW2+9dZ9bYyw3N5esrCy6dOlS6WTi8+fPG4xrdnR0ZPLkycpNgtpsZ25uLu+88w6ff/658vu0tDSSkpJkkqoQos6qtTHEFZd/HTBgABERERw9epTMzEzCw8MBGDduHIGBgQbLufbv399gydfhw4dTUFBwxzrVysrOzr7ntru6unLz5k2DbUFBQcyYMcNo6Vq1NpgSEBDA9OnTDb5IYmNjDc5Rx44dq1yeuDsFBQX897//rZU7xE5OTnh7e9/3eoS6qnaIzeXkyZOEh4ezfPnySicT5+bmkpubS1RUFFD2hGP48OFcu3atVpaVLt/OwsJCdu3aZfD7GzducObMmfveDiGEuFsWuqreJlWhX42oquMfS0tLleVfP/zwQ9q3b8/w4cOxs7NT7trqqS3nWn7J1+qoiaVhy7e9sm0Vl66tTht27drF5s2bldSBys5RXV3uNioqCh8fnyrffa+Ljh07Ru/evfn555+VJxE1rSGcp4bAwsKCyMjIav1REhoaypgxY+jcubPR77RaLQsWLODUqVM4OTnRrVs3goKCqjS5t2PHjkb7zZ49m9TUVL777juysrIoKChg/PjxBpOMIyMjOXPmDPPmzVOW5C4uLuYvf/kLZ86c4fPPPzeahFtaWoqvr68y9Cw8PBwrK6u7bvubb76ptNPFxYUhQ4awf/9+PvjgA3766SflCdjSpUtr5h9OCCFqWK2uVFd++dcHHngAKysr7O3tjTrDULaca8XO3t10hk2VVV1qS9eqbTO1dO2d2hAZGUloaChBQUHKtsrOUU28JqHuzJkzNGvWTLXDUxekpaXx5Zdf1lh5iYmJbN68WfV3ubm5/PLLL5Xu09icO3eOmzdvqv5u48aNPPHEEyQmJtK2bVuysrIMJta+8sorBAcHo9Vqlcm93t7erF69WnW/oKAgPD098fDwIDc3l5ycHOLi4pRJxiNGjODo0aMAnD59msmTJxMYGEjfvn2ZMmUK+/fvNyoTICMjg0mTJhEfH4+7uzvr1q27p7aXb6deREQEtra27Nq1S1b0E0LUeWbLIZ49e7a5qq6TfHx8jB7fyjkyj59//pkuXbrQtGndjOmu6cfPlT2K1z8KDw4OrvHs7/omLCyMmJgYzp07x8GDB7GxsWHNmjXK3AEo++Ni/vz5AAwbNoz4+PgqT+6t6gTcipOMoezfqVOnTixcuBCdTsfevXsJDg7mxo0bqmXa2NiwadMmVq9ezbVr1xgzZgz79++/67arSU5OVsp79tlnleEcQghRF9XNb3whzOjnn3/miSeeMHczDOTl5Rk9flbLuAaMMrO1Wq3BI3Zvb2+Sk5PZu3cvJ0+eJCUlhYKCAm7fvm2Ue71kyRJSU1NxcHCgU6dOjB8/ngULFijbwsLCaNu2LevWrVPN925I5s6dy9y5c5kxYwYzZsxQHWPeq1cvzpw5g4uLCxqNBlCfWKs2ubeqE2a7d+9uMMnY1dUVKysrWrRowaOPPgqAs7Mzb731Fq6urqplLl++nKeffpqpU6fyyiuv3HPb1fTq1YuzZ8/Sq1cvTpw4Ud3TLYQQtapWh0wIUR+cOXPGbB3ikpISioqKjO7Gqj1+Vnucrc/Hjo2NpUOHDuTn5xs9Yj99+jTp6enKnT39o/js7Gwl9/rll1/mq6++Uh6FOzk5kZOTQ2xsLI6OjiQnJzN27FhWrFgBoPoYvaGysLAwGb3m4+PDmjVr8PDwIDExkaZNmzJu3Di2bt2Kv78/Xl5eBneUy1Pbz9nZmd27dysdVCibfBsREYGPjw+bN282OfmzdevWdOvWTbXuQYMGsXLlSqZOnar8u95L29Xa6e/vz7Jly5gwYQIJCQlVOrdCCGEucodYiHKKiopIT083W4fYVI632uNntcfZapnZFR+xr1q1ilatWqmOd6+Ye10x4mvbtm288cYbALi7u/P1118rGeLVzfeur5YtW2byd3/++SeffPIJjz76KEuXLqVly5bY2toSFxdnMBG2T58+yjFDhgxhyJAhAEb7ARw/fhxLS0ueeeYZ5ZhNmzYZTDLu0aOHMqFOT39XdvDgwUZlenp60r9/fywsLLCxsSEvL49ff/31ntqub6elpSWnTp0CYM+ePVy5cqXWFrgRQoi7JR1iIcr55ZdfKCoqMluH2FSOt9rjZ7XH2WqZ2RUfsV+4cIFWrVqp1l8x97qinj17cvbsWXr27MmxY8eUDjRQ7Xzvhqh169ZMmTKFJk2aUFJSQkxMjPK79u3bV6mMivs1a9ZMdb/qTDJWq7tly5YGZd1r2021UzrDQoj6QDrEQpTz888/06RJE7p27Wruphjw9/fH39+fmJgYtFotjz32mGrGdV5enlFmtqOjo0GO9+jRo8nJyVGtp2Lu9SOPPMLu3btp1aoV7du3x8/Pj2nTprFx40YKCgoM7mKLsrvjSUlJFBcX19lJmabU57YLIcS9qtUcYtHw1fd83Q8++ICVK1eSnp5+X+u52/Ok9vi54uNwtXxsuHOOt6nc69u3byuPwvWuX7+OnZ1dtdpeF91NDrEQQoiGp15Oqrsfmajp6emMGTOGMWPG8Le//Y3Q0FCTd9Hul3vJfD148CBjxozh+vXryrbDhw8bbVOrb+vWrXd1Pms6D7cu+O9//3vfFuOoCWqPnytmUqvlY8OdH7Gbyr1u1qyZQWcYaBCdYSGEEEKvXnaIXV1dDSZ21IScnBxu3brFt99+y5dffsmFCxf4+OOPa7SOOzl58iShoaF39fquXLmCRqMxGPe3cuVKNBqNyWWu9fVdunSJCxcuVLu9DXE51oyMDB577DFzN8MsZs+eLXdKhRBCNEq1NlDs0qVLBvmoDg4ORpmnzs7Oqtmqtra2Bjmq48eP5/bt2zRr1oyEhAQuX75MYWEhAwcO5ODBgwwYMIBFixaplqW27Kg+L7VZs2Y88sgjAPztb39j6dKlREdHk5SUxN69ezl69KhReVu3bjV6HR07djRaFrV169YGZR0/ftxon4qZr4GBgcpSsOVzX3ft2mX0GgCef/55oqOjmTZtGqWlpRw9epSePXsCqJ4LfX0tW7bkzJkzxMTE0KpVKz7++GMee+wx1bptbGyM8nAbkoyMDLy8vMzdDCGEEELUohq/Q2wqR7ViPurVq1eNMk9BPVu1Yo7qqVOnyMnJQavVkpuby86dO3FxccHKyoqUlBT27dvHxYsXq7zsqN7JkyeZMWMGkydP5u2332bWrFlotVols1WtPLXsVrVlUQGDstT2qZj5Cqjmvpp6DY888gg6nY6rV6+SkpLC4MGDlTGqlS0L261bNwB27tzJhAkTlPLU6m7Iy7HeunWLrKwsOnXqZO6mCCGEEKIW1XiHOCQkhD59+ihZpXoBAQEcPnwYNzc3MjIysLKyMsg83b17NwAJCQns27cPPz8/fvjhB4qLi9m2bRsvvPACUJajql+NCcDDwwMAW1tb+vXrB5SNb8zLy1MtCwzzUrOzs5WyHn30Uf7xj3/w5ptv8uOPPzJ06FAARowYgbW1tcnyKr4O/bKoXl5exMfHGwxZ0JdV2T7lbdu2jeeeew4oy31NTk6u9DV4eXmxYcMGZdKWnqm26w0bNgwABwcHZcyxWt3JycmMGDECKMvDbUgyMjLQ6XTSIRZCCCEamRofMmEqR7ViPqqjo6NyF7R85qlatmp6erpRjqq9vT2AwWQi/epROp0OnU5X7WVHH3zwQVxcXIzart9frbyMjAyj7Fa1ZVErllXZPuWZyn019RrGjRuHl5cXhYWF9O7dW9l+p2Vhy5/Hyuq2trZusMuxZmRkAJhcjUsIIYQQDVOtjSG2tbU1yEdt164d4eHhBpmngGq2av/+/Q1yVEeMGMGtW7fuWKdaWeXvplaXWnkZGRlG2a1Xr14lODiYffv2UVBQQGxsLEFBQQZlDRo0yGgfX19fg8xXQDX3defOnSbb+PDDD9O8eXODBRNMtb1du3ZKfR07djQqS61uKysrozzchiIjIwMHBweDBQuEEEII0fDVag5x+XxUU5mnehWzVeHOOaqmqJV1L8qXZ+p1aLVag2VR1dqtto9a5ivUXO5rxXNhqr471W1qOdb6nEM8Z84cfvrpJ/bt23ff66rP56khkRxiIYQQUMsr1ZXPRy2feapGbanQu+kMmyrrXpQvz9TrqLgsqhq1fUwtf1pTua9VXRb2TnU3xOVYf/3113o5fnjmzJlkZmYabBs5ciTTp08nOjqavXv3KkkkAOfPn+e1115TfnZ0dGTy5MnKGPy7lZiYSGFhIaNHj67yMWlpaSQlJTFr1qx7qlsIIYS4F2Zbn3P27NnmqrpGNZTXIco6iqNGjTJ3M6otODiY4uJi5s+fzzPPPMOoUaOwsbEBICwsjOvXrzNnzhxlWExubi65ublERUUBkJqayvDhw7l27RpWVlZ33Q5XV1ejdJk7aYhZ1kIIIeofWbBeiP918eJFnJyczN0MVevWras0cxvAxsYGOzs7HB0dATh9+jT29vaMHTuWtWvX8vbbbyvlWVlZKZnbQ4YMwdramps3b/L5558bZFU7OTmh1Wp59913OXToEJ06dcLZ2ZkuXbpQWlpKYGAgO3bs4MSJEzg5OVFQUICNjU2l2d0PPfRQg86yFkIIUf/Uy5XqhKhpBQUFZGdn1/jwmuoyleN9p8xtNatWreLFF1/E29ubtWvXGvzu9OnTTJ48mcDAQPr27cuUKVPYv3+/UVY1lGWIOzo68uOPP9KuXTuuX79OXl4eWq0WgPz8fG7cuEFubq6SD15ZdndDzrIWQghRP8kdYiEom2yo0+nM3iEOCQkhJiYGT09PQkNDDX5XWeZ2RcXFxXz//fccOHCAZs2akZ6eruSAA3Tq1ImFCxei0+nYu3cvwcHB3Lhxg7Nnz+Ln50dxcbEy7CIpKYmgoCAsLCwYOXIk0dHRRnVVVD67u2KZycnJzJ8/HyjLstYP3RBCCCHMRTrEQlDWIQbMPmTCVI43VJ65XdG2bdt4/vnn+eabbwD47rvvCA8PVzrELVq0UBa4cXZ25q233sLV1VU1q7pnz56kpaXRq1cv0tLSAGjevDl//PEHAAcOHKBFixYG9VeW3X3u3LkGm2UthBCifpIhE0IAly5dMhhXW9+tWrWKgIAA5eexY8eyYcMG1bu5AK1bt6Zbt25s3boVf39/vLy8lAVKJk6cSGhoKL6+vnz//fcADB06lO3btzNs2DCOHDlish3jxo0zKtPf359ly5YxYcIEEhISavBVCyGEEHenVnOIRcNXX/N1P/roI5YuXcr58+drpb66fJ5M5XZfu3aNn3/+maioKJYuXQqUjR+2tra+qzJNZVnXJskhFkIIAWYaMqHPHu3cuXO1c0vvVmVZrUL8/vvvZh8/XFeYOg+PPPIIaWlpNG/eXNlWlc6wqTLN3RkWdcuECROMxqeL6vHy8pIbVELcJbN0iPXZo+PHj692bundqiyrVYjMzEwlrkyYNnDgQAYOHGjuZogG6umnn2bu3Lnmbka9VH7xHSFE9dVahzgvL88oezQlJYWCggKGDh3KvHnzKCwsxM3NjXfffZeioiKj/FJHR0d8fX3Jz88HIDw8nJs3b1bpWP1kqfJZrb6+vrz//vt07dqVTz/9lDZt2qDVatm7dy/Z2dlYW1uzaNEinJycTJYnGoasrCyJABPCzJycnGT4yl2SO8NC3Jsan1RnKkdVLXtUn1u6YcMG3NzciI2NpUOHDuTn56vml2ZkZDBp0iTi4+Nxd3dn3bp1VT5WjYeHh/KILiIiAk9PT7Kzs2nevDlxcXG8/PLLfPXVV1UuT1RfaWmpuZsAlI2PbSgT6oQQQghRPTXeIQ4JCaFPnz688cYbBtuTk5MZMWIEUJY9Wl5AQICSkZqRkaHkl+7btw8/Pz9++OEHJcN006ZNeHl5ER8fT0FBQZWPVePt7U1cXBzp6ek4ODhgb28PwIABAwDo06cPu3fvrnJ5ovrefPNNvL29uXbtmlnbce3aNeXfXwghhBCNS413iBcuXMiJEyeMFhXo1asXZ8+eBTDKHtVoNHz22Wfs27eP06dPc+jQIXr37o2XlxcRERF89NFHjBo1iuXLl/P0008THR1N9+7dq3WsGv3QjcWLFzNp0iRlu76dhw8fpkOHDlUuT1Tf4MGD2b9/Py4uLkarqdWWkpISsrOzq3yHODc3l3/84x8G29LS0vjyyy/vR/OEEDUgOjq6SuOTc3Nz+eWXX0hMTGTz5s1ER0ej0WiqXZ98JghRv9TaGGJ/f3/8/f2JiYlBq9Xy2GOPKb+ztbXF19cXFxcX8vPzcXV1pUuXLgQGBqLRaEhLS2P58uU89NBDBAcHs2/fPgoKCoiNjeX999+v0rGmBAQEMH36dD7//HNlW2xsLEePHiUzM5Pw8HA6duxY5fJE9YwePRp3d3f+9a9/8eKLL7J27VqWLVtGx44da60N169fp6SkpMod4sLCQnbt2mWwTT9RVAhRN4WFhXH9+nXmzJlT6efLyZMnCQ8PJzg4mJKSEr7//vu7ikeUzwQh6pda6xB36NCBPXv2mMweHTx4MFlZWbRr1w6AZs2aERcXZ5Rf2r9/fywsLLCxsSEvL48HH3ywyscCLFu2zKDehx9+mMDAQIMoqXfeeYfhw4djZ2enrLhlqjxx71q1asVf/vIXIiIiCA4O5sknn2TBggX885//xNLSkujoaJKSkti7dy9Hjx41muAIGEysnDNnDgsWLCA1NRUHBwfCwsJo27Yt4eHhlJaWEhgYyI4dOzhx4gQdO3ZUJqPY2Njw6quvcvz4cRwcHIiMjKS0tNSoPv2/v9pEUSFE3XP69Gns7e0ZO3Ysa9eu5e233wZg3bp17Ny5k8zMTCwtLQkLC2PJkiXKZ0enTp2AsoVulixZQps2bViyZAmPPfYYWq3W6HPGxsbG6DNBbfL2xIkTzXk6hBAqan2lOlPZo02aNFHtULRv396gA9qyZUslLu3BBx+s1rEVRUZGEhoaSlBQkLLtgQcewMrKCnt7e6UzXNXyxN07d+4cjz/+OMePH2fBggUsWLCAZ555htOnT6PVaklPT+fgwYOqExwrTqyMiIjA0dGR5ORkxo4dy4oVK4CyDqxWqwXKFpS4ceOGUjaUDZGxt7dHo9EwYsQIjh49WumESrWJorWhskex+se9phw8eJAxY8Zw/fp1Zdvhw4eNtt2pbv3j5KKiIubMmUN0dDRvvvkmBQUF99R+Ie6HVatW8eKLL+Lt7W0wNEur1VJUVMSWLVvw9vZm9erVBAUF4enpiZOTEzk5OQA4ODiwf/9+pk6dytdffw2UPUms+Dmj9pmgNnlbCFH3NOqlm318fIiPjzeIUJs9e7bE/tSisLAwnnnmGWJjY5kyZQrPPvss3t7eHD58mNLSUnr16sX69esZNmyYyQmTFSdW7tmzh+eeew4Ad3d3kpOTjeotPzHSxcUFCwsL9u3bxwsvvADAtGnT6Nu3b6UTKiubKHo/VfYo9uTJk0bj98u7cuUKGo2GmJgYZdvKlSvRaDRV6szq63Z1daVPnz6cPXuW9PR0vLy88Pf3p1mzZvfUfiFqWnFxMd9//z2ffPIJU6ZMIT09ncOHDyu/d3NzA8qeYmZnZ6uWoe/E6uc8AGzbts3oc0btM8HU5G0hRN1iloU5hNCbO3cuc+fOZcaMGcyYMYOnnnpK+d2+ffv49ttvee211zh69Cju7u707t2b7t27M2PGDM6fP8+hQ4eUiZWtW7fGz88PCwsLzp49S8+ePTl27JiSGtK8eXP++OMPAA4cOECLFi0AKCgo4KGHHqJHjx6kpaXRu3dvVq5ciaurq2p9evqJor169TKaKFrT1IZnlJaWGuVy6x/3pqSkMHDgQNXhJc8//zzR0dFMmzaN0tJSjh49Ss+ePQGq/BhYnyGenJzMmTNn2LZtGytXrmTlypVYWVkZ1fvQQw/J8BJhFtu2beP555/nm2++AeC7774jPDxc6QjrnwRWNk5Y/xTp+PHjyudJz549jT5nrK2tjT4TTE3eFkLULY36DrGoOywsLLCwsDDY1qRJE15++WVCQkJ46KGHGDBgABqNhs2bN+Pv74+XlxfOzs7KpMygoCDy8/P5z3/+w4oVK5g4cSJfffUVkydPBmDo0KFs376dYcOGceTIEaWeW7duYWtrS0BAABEREfj4+LB582aeeuopxo0bx9atWw3q0/P392fZsmVMmDCBhISEGjkP1cnxVsvl1j/u9fDwMDnc45FHHkGn03H16lVSUlIYPHiw0hmo6mNgfYb4nDlzcHd3Z8SIEVy6dAmdTqdar7mGlwixatUqAgIClJ/Hjh3Lhg0bTMZnOjs7s3v3boOhR9u3b2fixIl8+OGHTJ06FQA/Pz+jzxlTnwkBAQHExMQwevTo+/QqhRD3Su4Qizqh4mTH8l5//XVef/111q9fz6xZs2jWrBnvv/8+K1asUMZ0V5xYuW3bNq5fv46dnZ1STseOHdm5cyf5+flYW1sr28+dO8eFCxdo3749mzZtUiZrQlkCitqEylOnTgFUOlH0boSEhBATE4Onp6fB0Ifk5GTmz58PlD2KjYqKUnK5V69ezbVr1xgzZoxBWQkJCZw9exY/Pz8lx1vPy8uLDRs2cPz4cV5++WUOHDignDd9hri7uztff/01Dz/8sFHdlVGrV639QtQG/fhdPTs7Oy5dugTASy+9pGwfMmQIQ4YMAcruBFtaWmJpaQnAG2+8QU5ODra2tsr+Tk5Oqp8zap8JapO3hRB1i3SIRb0xYcIEBg8ezOuvv860adPYvn07X3zxBY888ojqxMryX1Llle8MA0ZfdPrOcHnt27c32a6a6gxDWY73woULjbarDc/Q53JPnTqVV155xeiYyoZ7jBs3Di8vLwoLC+ndu7eyvaqPgSujVu+5c+dqbXiJEPdKbSx8+c+I8tQ+Z8p/JkRGRhIeHi5xnULUcdIhFvWKg4MDa9aswcfHh1mzZtGtWzcWL17Myy+/fNdl3rhxg4ceeqgGW1nz1HK8Bw0aZJTL7evry+7du9FoNIwbN84oP1t/Z+zhhx+mefPmynhIPT8/P6ZNm8bGjRspKCggNDQUKysrkxniatTq7devX7XKEKKh8PHxwcfHx9zNEELcgXSIRb00atQoTp48yb/+9S9mzpxJbGzsXS/okZOTY/Jucl1hKsdbLZe7/OPeisM9+vTpowyt2Lp1q1LO7t27lf+v6mNgPX2s3d69e5VtasNManp4iRBCCFFTam1Sndryl/os06ruXx1btmwxiNs6cuQIEydO5NatW8q2V1991eTEClH3tWrVik8//ZQ9e/bw22+/8eSTT/Kf//zHaELandy4ccPk49C6pmJnUi2Xu1mzZsrYR7i7/Ow7PQauCrV6pTMshBCiLqq1O8QZGRlGsTaurq4mOy9q+1fHb7/9ZjCJ6OrVq2zZsoWQkBAWLVoElE1UKi0tves6RN0wcOBAjh8/zpIlS1iwYAFxcXF88803uLi4VOn4nJycOj9kQojG4M8//2TChAnmbka99Oeff/Lwww+buxlC1Fu1Gru2atUq+vfvz5gxY0hPTyclJYUdO3ag1WoJCgri2WefZeLEiVy5ckV1/9LSUry9vXn++ed5/vnnlRD1devWMW3aNEaOHMno0aM5d+6cUue1a9cYPXo0V65cYeLEiWzfvp3Tp08btEut3HXr1hEQEMDQoUMZNGgQb775Jh4eHsqSn0VFRYSEhPDcc88xdOhQZWymMA8rKyvefPNNgwU95s+fT2Fh4R2PLZ8qIYQwn1u3bhmlQog7i46ONnj6KYSovhq/Q1xSUkJpaSlNmjQxeGwLZROiEhIS2LRpE19//TWdO3cmPz9fyT5dsmQJUVFRrFixgqZNmxrt/9JLLzFp0iRGjx7NRx99xLp165g1a5bB8pvh4eGsXr2adu3akZWVhZeXF59++imXL1/GysqKqJhyDQAAIABJREFUL7/8kpkzZxqMmdTnuZYv18rKitzcXHbu3Mn06dOxsrIiJSUFDw8PLl68yKlTp5Ss1ZiYGIKDg5Xgd2E+PXr0UBb0mDdvHjExMXzzzTe4u7ubPObmzZsGTxOEEOa1fv16czehXqmY4S6EqL4av0McEhJCnz59lCzT8tSWvwT1JTDV9tfnrnp5eREfH2+w1Kza8puff/45f/zxB46Ojsp+/fr1w9XVlW+//VbZZqpcDw8PoCxup1+/fkDZ2Mq8vLxKl/QV5qVf0OPEiRM4OzszZMgQpk+fTl5enur+0iEWom7RL9Qj/1XtPyHEvavxO8SmclRBfflLUM8+Vdu/stxVteU3g4ODsba25h//+IeyWhnAokWLGDhwIDk5OYDpPNfyE4L0Hzo6nQ6dTldpxquoG5ydndm+fbuyoEd8fDxffPEFf/vb35R9dDodt27dMsomFkLUvocffpjIyEhzN6NeWrNmjbmbIES9Vquxa/rxu7m5uXzyySekpKQA6tmn0dHRRvv/9ttvRrmrQUFBJuuztLTE19eXlStXKitxQdls/A8++ECJn1LLc73TmvNqWauibiq/oMfYsWOZMGGCsqBHfn4+Op1OOsRC1AEtWrTA29vb3M2ol2SYiRD3xkJ3D1EO+tnA1XkjVlwVrLyK2adq+2u1WqPc1Zpwt+VWzFpt7KKiovDx8bmnhJD7acuWLcycOZO8vDwWL17M2LFjadOmDbt27VKGyNSGun6eGgsLCwsiIyOlE1YH3M33ifg/cv6EuDe1mjIBppe/BPXs04r7q+Wu1oS7LfduMl6F+YwcOZKTJ08yadIkZs6cqXSE5A5x9UiutzCn3Nxcfvnll/teZnR0NHPnzq3ycZVl6wsh6rZa7xALYW7lF/S4cOECAD/88EO1F/RozMrneutJrreoLSdPniQ0NPS+lxkWFsa2bds4f/58lY5zdXWlT58+NdouIUTtkKWbRaM1cOBAIiIiePrpp1m6dCkHDhyo1oIetSk6OpqkpCT27t3L0aNHWbx4MRqNhpKSElavXg3AvHnzKCwsxM3NjXfffRetVsuCBQtITU3FwcGBsLAwduzYQWlpKYGBgezYsYMTJ07QsWNHpez9+/czf/58jh8/joODA5GRkZSWlqrWp8/19vf3NzhnpaWl+Pr6kp+fD0B4eDjbtm0jISGBy5cvU1hYyMCBAzl48CADBgxg0aJFFBUVGdXh5ORU+yda1AtLliwhNTWVXbt2sWzZMoNrbefOncr1fPLkSeV9cOrUKZycnOjWrRtBQUFG15u+TH285unTp7G3t2fs2LGsXbuWt99+m3Xr1rFz504yMzOxtLQkLCzM4LisrCwKCgoYP358lerUaDRG5XXu3NnMZ1eIxknuEItGTT+GNyEhodoLetwPJSUlFBUVGd2t1mq1pKenc/DgQZKSkpQM7FdeeYXg4GA2bNiAm5sbsbGxdOjQwSDfOzk5mbFjx7JixQry8vLQarUA5Ofnc+PGDYOy4+LisLe3R6PRMGLECI4ePapaH2CQ611+LLQ+1zs+Ph53d3fWrVuHVqtVcr1dXFyUXO99+/Zx8eJFk3WIxs3U+yEoKAhPT086dOigeq3pr2eAjRs38sQTT5CYmEjbtm3JyspSvd70ZernEqxatYoXX3wRb29v1q5dC2CQee/t7c3q1asNjsvNzSUnJ6fKdaqVJ4QwD+kQi0atqKgI+L8FPZYuXcoXX3xBjx49DBZvUVNYWFjjQwQqy/EeMWIE1tbWqhnYAQEBHD58GDc3NzIyMrC2tjaZ761Xfryvvuxt27bxwgsvADBt2jT69u1baea25HqL+6my9wOYvtb01zOUjevVR3kOGzYM4I7XW3FxMd9//z2ffPIJU6ZMIT09ncOHDwPqmfcVVafOqpQnhLj/ZMiEaNT0HWIrKytlQQ9PT09mzJjBkCFDeOmll/j444+ViZbnzp3jo48+Ij4+nszMTJo0aUL37t3x9/fn1VdfvefJeZXleOuzttUysDUaDZ999hmtW7fGz8+PQ4cOqeZ7N2/enD/++AOAAwcO0KJFC4Oyu3fvTlpaGr1792blypW4urreMXNbcr3F/VLZ+wFMX2v66xmgV69enDlzBhcXFzQaDaD+Hipv27ZtPP/888rqo9999x3h4eF0795dNfO+oqrWmZ2dXaXyhBD3n9whFo1a+Q6xnn5Bj8jISGJiYnj88ceJjY1l48aNuLq6smfPHl577TXi4uJYu3YtHh4e/Pvf/8bNzY2LFy/e9zaPGzeOrVu34u/vj5eXF87Oztja2uLr60tQUBD5+fm4urri5+fHihUrmDhxIl999RWTJ09m6NChbN++nWHDhnHkyBGjsgMCAoiIiMDHx4fNmzfz1FNPqdZXnj7X+/Lly0BZrvfKlSuZOnUqOTk5xMbG3tVrEsIUZ2dndu/eja2t7R2vNR8fH9asWYOHhweJiYk0bdpU9XrTl6nRaFi1ahUBAQFKGWPHjmXDhg2qT4TKH1fdOoUQdUet5xCLhq2+5evGx8czevRo8vPzlbul5WVlZTF79mwiIyNp2rQpL730Ep999hlNmxo+XLl06RIjR47E0tKSQ4cOGf2+opo4TxUzsEtLS8nKyqJdu3YG+6nle+fn51d6N1sti7s6mdv1Jddbcojrjup+n9y+fRtLS0tu3bpV6bV24sQJbGxsePTRR1m6dCktW7Zk6tSpgPH1pi/T0tKyWm2veFx16qwp8n0sxL1ptEMmcnNzeeedd/j8888NtqelpZGUlMSsWbPM1DJRm9TuEJfn4ODADz/8wIULFygsLOSLL75QHveX5+TkRExMDC4uLkRGRuLv739f2w1lGdjlNWnSxKgzDOr53nca2qHWga1YX2VatmxZaVmmVKcO0bg1a9YMuPO11rp1a6ZMmUKTJk0oKSkhJiZG+V3F601f5t225W7qFELUDY22Q1xYWMiuXbuMtt+4cYMzZ86YoUXCHIqKirCwsKj0ju7t27dJTU012RnW69y5M56ensTFxdVKh1gIcWcdOnQgKSmJ4uLiOz65qc91CiHuTa29U+tajmr5x1V5eXl88MEH/PTTT9jZ2aneZRMNU1FR0R2/sK5cucKtW7d48skn71iei4sLO3furKnmCSFqiDk6ptIZFqL+qPFJdfUpR1UvIiICW1tbdu3aRY8ePWr6lIg6rKioyORwCT39uMCqrGRXUlIiX4JCCCFEPVPjHeL6lqMKZUvOjhgxAoBnn322Rs+HqNuq0iF2cHCgVatWpKam3rG81NRUunbtWlPNE0IIIUQtqPFbWfUxR7VXr16cPXuWXr16ceLEiZo+JaIOq0qHuGnTpvztb3/jiy++YNq0aSYn3hw5coRdu3YZTKARQgghRN1nlme748aNIzAwEI1GQ1paGsuXLycvLw9fX19cXFyUHNV27doxbdo0Nm7cSEFBAaGhoVhaWvL3v/+dxMRESktLGTRokEHZAQEBzJw5k40bN1JUVERgYCCdOnUyqq88f39//P39iYmJQavV8thjj9Xm6RBmVJUOMZT9offUU0/xxBNPcOzYMVq1aqX8Li0tjVWrVrF27VqGDBmiPKEQQgghRP1Qax3iyZMnK/9va2tLXFycUR7j4MGDDXJUnZyc2LZtm1GO6s6dO03mqLZv355NmzYZ5FGaqu/UqVNA2YzgPXv2cOXKFdq2bXtfXr+om6raIXZ2dmbt2rWMHTuWTp064ePjwxNPPEFBQQHx8fHs2bMHd3d31q9fX2kShRBCCCHqHrPO/qlrOarSGTaP0NBQxowZQ+fOnQ2210YySWxsLNbW1rz66qt3TCbp168fnTt3JiAggLi4OFavXk1xcTGtW7fG09OTrVu3GiwZ25DNnDmTzMxMg20jR45k+vTpZmqREMYSExMpLCxk9OjRd3V8bm4uWVlZODg4SG69EA1c4/j2FnXauXPnuHnzptH22kgmeemllygsLKxyMomlpSXvvPMOU6dO5Z133qGgoIDp06fTpUuXRtMZBggODmbZsmU89NBDPP/88yxbtgxfX19zN0sIA66urvTp0+eujz958iShoaGSWy9EIyD5UMJswsLCiImJ4dy5cxw8eBAbGxvWrFmDs7Ozsk/5ZJKzZ8/i5+dHcXExNjY2BAQEMGvWLNzc3Bg1apSSMqJPOHF3d+frr79m3LhxSnkVk0ny8vK4efOmQTIJwKuvvmpUX3nJycnMnz8fKEsmiYqKuj8n6X/VtRxvJycnAGxsbLCzs8PR0RFfX1/ef/99unbtyqeffkqbNm3QarXs3buX7OxsrK2tWbRoEU5OTibLE6IqwsPDja5jR0dHdu7cSWZmJpaWloSFhXHkyBEKCgq4ffu20XV45MgRg+u+4nulbdu2LFmyhNTUVCWFCCS3XoiGqvHc0hJ1zty5c9FoNIwZM4YVK1ag0WgMOsNgmEzi5eVFREQEH330EaNGjVKSSfbt28fp06cNkkkAg2QS/R3oAwcOGJSt0+lo3rw5aWlpAKxcuZKjR4+q1leePpkEqNFkkvqY463n4eFBdHQ0UJbt7enpSXZ2Ns2bNycuLo6XX36Zr776qsrlCWHq/WDqOi4qKmLLli14e3uzevVqcnNzycnJUb0Oy1/3au8VgKCgIDw9PRk4cKBSt+TWC9EwSYdYmJ2FhcUdJ6KNGzeOrVu34u/vj5eXF87Oztja2uLr60tQUJCSTOLn58eKFSuYOHEiX331FZMnT2bo0KFs376dYcOGceTIEYNydTodtra2RERE4OPjw+bNm3nqqadU6yvP39+fZcuWMWHCBBISEmrsXNTHHG89b29v4uLiSE9Px8HBAXt7ewAGDBgAQJ8+fdi9e3eVyxOisveDXvnrx83NDSibKJ2dnW2wX8XrEAyv+8reK+VJbr0QDdM9D5k4cOAAEyZMqIm2iAbg0qVL1T5m2bJlqttrI5nkX//6F82aNaszyST1McdbT//4ePHixUyaNEnZrr+TfvjwYTp06FDl8oQw9X6403Ws0+mMjql4HZbfX+29York1gvRMN1Th7h///411Q7RQDg5OeHl5XXfyq/pZBKdTqfcna4vySR1Lce74vHTp083mI0fGxvL0aNHyczMJDw8nI4dO1a5PCHUDB06tNLrWE3F6/DYsWPK7/z8/IzeK1AWt7h7926DoVaSWy9Ew2ShU/tTWohG4p133iEhIaFKyzLXpKioKHx8fFTvZFVVxbvXpaWlBnfL9SreLQdM5njrlb9bbqo+Nbt27WLz5s0sWbIEgA8//JD27dszfPhw7OzsDJI4qlLe/WZhYUFkZCTe3t5ma4Moo3/SuH79+iofc6frWK+y67A8tffK7du3sbS0xNLS0mB7Xcutv5vzJ4T4P5IyIRq18neI65u6luMdGRlJeHi4wR3fBx54ACsrK2U8cXXKE+JOqtIZhsqvw/LU3iumlmqvS51hIcS9kw6xaNR0Ol2jyg++n3x8fPDx8THYNnv2bDO1Roj/I9ehEOJOpCcgGrXS0tJ6e4dYCCGEEDVDOsSiUavPQyaEEEIIUTOkQywaNekQCyGEEEI6xKJRkw6xEEIIIaRDLBo16RALIYQQQjrEolGTDrEQQgghJHZNNGrSIf4/58+f57XXXlN+dnR0ZPLkyfTr1++eyk1MTKSwsJDRo0ffaxOrLDc3l6ysLLp06VJrdQrzSU5OJi8vjzFjxtRIOS1atKCwsBB3d3e5joRoJKRDLBo16RD/n9zcXHJzc4mKigIgNTWV4cOHc+3aNaysrO66XFdXV0pKSmqqmVVy8uRJo0VCRMN14cIFsrOza6wcPz8/SkpK5DoSohGRDrFo1OpLhzg8PJzS0lICAwPZsWMHJ06cwMfHh3nz5lFYWIibmxvvvvsupaWl+Pr6kp+frxxnZWXFggULOHXqFE5OTnTr1o2goCAWL16MRqOhpKSE1atXA2BlZcUjjzwCwJAhQ7C2tub27dsARvvb2try7rvvcujQITp16oSzszNdunQxaqeTkxMFBQUEBgYSHR1NUlISe/fu5ejRo0ZlajQaEhISuHz5MoWFhQwcOJCDBw8yYMAAFi1aRFFRkeoxO3fuJDMzE0tLS8LCwliyZAmpqamkpKTQuXNno/Mk6jetVsv8+fM5fvw4Dg4OjBw5Utm+YMECUlNTcXBwICwsjLZt27Ju3Tqja6RTp05G7xW9lJQUCgoK2LRpk3IdLV++nPfff5+uXbvy6aef0qZNGyZOnGiW1y+EqHkyhlg0anWtQ1xSUkJRUZHRHdW8vDy0Wi0A+fn53Lhxgw0bNuDm5kZsbCwdOnQgPz+fjIwMJk2aRHx8PO7u7qxbt46NGzfyxBNPkJiYSNu2bcnKyiIpKYmioiISExN55ZVXCA4OBuD06dNMnjyZwMBA+vbty5QpU7CxsVHdf8OGDTg6OvLjjz/Srl07rl+/rtrO3NxccnJygLIOS3p6OgcPHlQtU6vVkpuby86dO3FxccHKyoqUlBT27dvHxYsXTR5TVFTEli1b8Pb2ZvXq1QQFBeHp6YmHh4fqeRL1g6n3Q1xcHPb29mg0GkaMGMH58+cBiI2NxdHRkeTkZMaOHcuKFSsAVK8RtfeKnv6aLX8deXh4EB0dDUBERASenp61dBaEELVBOsSiUatrHeKQkBD69OnDG2+8YXKf4uJiAAICAjh8+DBubm5kZGRgbW2NjY0NmzZtwsvLi/j4eAoKCkhMTGTAgAEADBs2DICEhAT27duHn58fP/zwg1Jmp06dWLhwIQsXLmTevHnK8Am1/ZOSkvD09MTCwkK5Q6fWzopGjBiBtbW1yTZ4eHgAYGtrq4xftrOzIy8vz+Qxbm5uAHTo0MHo0bnaeRL1g6n3w7Zt23jhhRcAmDZtGs7Ozsr25557DgB3d3eSk5OVYypeI2rvlcp4e3sTFxdHeno6Dg4O2Nvb19jrFEKYnwyZEI2aTqejSZO683ehvjNaUfPmzfnjjz8AOHDgAC1atECj0fDZZ5/RunVr/Pz8OHToEPHx8Tz99NNMnTqVV155BYBevXpx5swZXFxc0Gg0APTu3Zvu3bszY8YMzp8/z6FDhwBo0aIFjz76KADOzs689dZblJSUqO7/66+/kpaWRq9evUhLSzPZzor051utzOzsbB544AFlX/0fKzqdDp1OZ/IYfZk6nc6oPrXz1Ldv3+r9wwizMPV+6N69O2lpafTu3ZuVK1dy4cIFWrVqRc+ePTl79iw9e/bk2LFjyh+CgNE1snz5cqP3SmXs7Oxo164dixcvZtKkSTXzAoUQdUbd6QkIYQalpaV16g6xKUOHDmX79u0MGzaMI0eOAGV3UH19fQkKCiI/Px9XV1cGDRrEypUrmTp1Kjk5OcTGxuLj48OaNWvw8PAgMTGRpk2bMm7cOLZu3Yq/vz9eXl7KHbaKWrduzenTp1X3nzhxIqGhofj6+vL999+bbKcpVW3D3Rzj7OzM7t270Wg0qudJ1G8BAQFERETg4+PD5s2b+ctf/gKAn58fK1asYOLEiXz11VdMnjzZZBlq75WKyl9H+npjYmJqNTFFCFE7LHRqt1SEaCRmzpzJf//7X4NHq7UhKioKHx8f1TualcnPzzd45F9aWkpWVhbt2rVTtmm1WiwsLLCxsSEvL49ff/0VGxsbHn30UZYuXUrLli2ZOnUqAL///jv29vYGd2Uro7b/tWvX+Pnnn4mKimLp0qWq7axumTVxzO3bt7G0tMTS0lL1PEHZHej/z96dx1VV7Y//fyFhKJZIKMbwcahPwxUnoJvhhDlPkYpAgKHJN4fymvrJ+mjX5Nr149UATXPIUgknFBkEFIlBPYmaaIriNVKMHFGT6YTM5/eHv7Mvh7MPgwznAOv5ePiI9tl7rXU2a52z2Hvt9zs0NBR3d/da1y00jqlTpwKwf//+Wh9TUFDAM888o7X94cOHWFhY1Hh81bEiV1blfpScnEx0dDSBgYG1bmNTeZLzJwjCf4glE0KrZmhriGtSdZLZpk0brUlehw4dpJ+feeYZOnXqxIwZM2jTpg3l5eWEh4dLr9vY2NSpfrn9O3fuTEZGBqampjrbWdcyG+KYtm3bSj/LnSeh+ZObwAK1mgyD9liRo+5HoaGhIgSbILRgYkIstGrNbUL8JOzs7EhISKCsrIynnmqcIT9w4EAGDhzYKGULT6ZychJ1cpTi4mKsrKwYPHhwrcvJyMggISGBuXPnytaxdOlS1q9fX+tjmisPDw88PDz03QxBEBqJWEMstGqtYUKs1liTYcEwXbx4kYCAAOBxchRHR0cyMzO5e/duncrJy8vj8uXLsq8VFxeTnJxcp2MEQRAMkfiGFFq11jQhFpqXgIAAXF1defHFFzW2yyVfiYuLqzY5SXZ2thRWbMeOHQQGBtKlSxcCAwOxsrLSSmZhZmbGF198wU8//SRFVwDw9PTUSE5ReZlMQUGB7DGCIAjNgbhCLLRqYkIsGKqrV6/y559/am2XSyhRU3KSyslRrKysOHnyJDNnzuSbb76RTWaxe/duzM3NSU5Opnfv3lLdVZNTqGNGq/9f7hhBEITmQEyIhVZNTIgFQxMUFMTgwYOJjIxkxowZDB48mOvXr0uv60ooUV1yksrUGdaGDBnCyZMnZZNZJCUlMWbMGADefPNN6diqySk6dOhAfn4+H330EStXriQtLY3Q0NA6rVEWBEEwBGJCLLRqYkIsGJoFCxagUChwdXVl27ZtKBQKjXjL6oQSYWFh2NvbS9urS05S2bVr1wC4cOECzs7OUjILQEpm0b9/f2lbWlqadGzl5BROTk4MGDCAmzdvcurUKZ555hlSU1OZNm0abm5u3Lx5s2FOiCAIQhMQa4iFVq28vBxjY2N9N0MQtBgZGcn+sTZo0CD8/f1JSUmhqKiIyMhI2cxpVZNKqB05coT09HTy8/NZu3Yt7dq1w8/Pj4iICIqKiggICMDExARvb2/Cw8NRKpW88MIL0vE+Pj7MnDmT0tJSXFxcaN++PadOneLGjRt4e3vzyiuvcPbsWWJiYjh27BhDhw5t+JMjCILQwMSEWGjVSkpK6pQQQhCayqZNm2S3jxw5kjfeeENnQolhw4YxbNgw4PFVYGNjY40lDIsXLyY3Nxdzc3NpW1xcnFYyi+PHj3P37l26du2qUb+FhQVt27bF2dmZ6Oho6Q9KOzs76RgrKysmT57M+++/z+XLlw3qj874+HjKysoYN27cE5dROaSdIAgtg1gyIbRqxcXFGgkcBKE56NChA2ZmZoDuhBLwOKmE3GS08mRYTS6ZRdXJcGhoKJ9//jkPHjxg5cqVsmV37doVIyMj/vWvf5GRkcGPP/5Y4/tpSr179653+u7KIe0EQWgZxBVioVUrKSmpdkJhKG7evMmiRYsoLi7GycmJS5cuaYS/6tKlC4BW6K2uXbtqhdRKTk7W2u/FF1/UCqmVmJjIs88+y507dyguLmbgwIGcPn0aZ2dnVq5cqdWmzz77TM9nqXFdvHhRWlfbWrVp04Y+ffpw6dIl+vfvX+2+L730EjY2Npw7d67Bl00olUo+/fRTLly4gJWVFd999x3+/v4a/bxr167s2bNHq6+fPXuW0tJSVCoVFRUV+Pr68sMPP5CWlsasWbNYtmwZly5dwtbWlpdffpmPP/5YK8xd5ZB2AwcOZNWqVSgUCsrLywkODsbW1rZB368gCI1PTIiFVs3QlkyUl5dTUVFBmzZtNK6+HThwACcnJz7++GOCg4Np3749YWFhLFmyhN27dxMbG0tERIQUeiskJITg4GBefvllrK2tCQwMZN++fWzbto3OnTtr7bdixQoppJa6zLfffpuTJ0+SmJjIrFmzMDEx4ejRo7i4uHDjxg3Cw8M12lRYWFinlM3Nza5du/jXv/6l72bonampKZ07d67Vvh07diQ/P/+J69I1HqKiorC0tEShUPDtt9+ybNky7OzsNPr5kiVLNMLRqfv6f/3Xf1FSUoKRkZH0AGJhYSF5eXlERETw6quvEhgYyJIlS8jOzpbC3E2cOJE1a9awZ88eFi5cSEhICC4uLhw+fJjS0lLi4+MJDw/H39+frVu3PvF7FgRBP8SSCaFVM7QlEytWrMDR0ZHFixdrbPfx8SE1NRUnJycyMzOZPn26RvgrS0tLQDv0llxILbn9QDuklqWlpRRn1tzcnNdffx14fGu9oKBAq00teTIMsGrVKlQqVYP8y8vLIyMjgyNHjnDw4EFUKhX79+/n+PHjdSrnl19+4euvv9ZZx4cffljr/Wv777vvvuPevXsUFxdXe77Ky8u5detWvRJ06BoPcXFxvPXWWwD4+fnxxx9/yPZzqF04urKyMuDx+mJnZ2cARowYAegOc6cWGxtLSkoKXl5e7N27VypLEITmRUyIhVbN0K4QL1++nLS0NK31iQqFgq+++oqUlBTS09O5du2aFP6qcoSBqqG35EJqye0HmiG11GVWPjfqiAfqiVHVNp05c6ZBz0VLpl6Dqk6pDDRJWuWGSKns4uJCaWkpUVFR1e53+PBh8vLyNOIY15Wu8WBvb09GRgYA27dvp6ysTLafg+5wdKamplLik1OnTgHQv39/6fyoo3PoCnOn5uDggJubG7t372bNmjWMHz/+id+vIAj6IybEQqtWUlJiUFeIdTE3N8fT05OFCxdSWFhI37598fHxITw8nIkTJ+o8zsvLi23btvHOO++wZcsWpk+fXm09tSmzuja1BgEBAVy9elX2tYqKCtzd3ZkwYQITJkwgJyeHPXv24Ofnx7hx45g4cSJXr14lMDCQH374gY0bN/LDDz9Ix+/YsYM33ngDV1dXrl27hlKpZOHChbz55pu888473L17l4KCAj755BOGDRvGqlWrgMcpldUTxHXr1rFnzx6pTLn968Pa2hovLy8WLVrE77//LrvPnTt3+Nvf/sbkyZO1Uk83BB8fH3bv3o2HhwfR0dGsXr26Tv00YuvdAAAgAElEQVQcYPjw4Rw5coQRI0Zw9uxZADw8PPj+++9xcXEhPj6ep556ikGDBrF9+3ZmzpxJbm4ukZGRGiHtJk+ezOHDh/H29sbNzU0jZrQgCM2HkaqmKO6C0ILZ29szZcoU/P39m7Teffv24eHhUWMShcoqKirIzs6WbkEnJycTHR1NYGBgjcdWDamlS13KlGtTc2NkZERoaCju7u61PmbOnDnMnj1b9g+Aq1ev8u9//1tab2pmZoaJiQk//vgjwcHBhISEkJGRwZgxYwgJCcHR0ZHCwkLmz5/P6tWruXLlCtu2bePgwYOcOHGC3r17c/fuXf7nf/6Hffv2cfXqVZ577jkePnzI//7v/7J8+XIePHiAvb09Dx8+ZMmSJbz++uvExsaiUqkYNmwY8+bN09p/w4YN9Tpvubm5uLi4cOvWLZYuXcrbb7+NtbU1d+7cITo6mi+++AILCwuOHz8uLeepydSpUwHYv39/rdtRNeRcbfq5OpzdnDlzADTWvqelpWFmZkb37t3ZsGEDHTp0YObMmSiVSq0wdyUlJRgbG0trm2/duoWlpaXe7jg9yfkTBOE/9HaFWB10Xvwz3H/79u3TV/doMs3lCjE8vvWrnniGhoYSEBDAwoULa3VsbSbDdS2zaptauppSKoP+0irLrf9W05WGuT7Mzc05ceIE7777Ln//+9/p0aMHTz/9NN27d+eTTz7B3d2dU6dO1Xoy/KSqRoipqZ//9ttvHDhwQCMuc+W17506dWLWrFmMHTtW+j2CfJi7qiHtbGxsDGr5lSAIdaPXKBMfffQRb7zxhj6bIOjg4eGh7yY0CUN7qK62PDw8Gvx31BhltiQLFixgwYIFzJ49m9mzZ9OvXz+tfdTrTWfOnMkHH3wgbX/StMoWFhZcuXKFPn36SGtj27dvz5UrV+jfv7+UVllu/beaOg1z5f0bgpmZGQEBAfzzn//k3Llz3Lt3j86dO+Pg4EC7du0arJ6G1L17dxISEnS+bmdnR0JCAmVlZTz1lAjCJAitiV5H/BtvvFGnW5VC02ktEyNDe6hOMHy6UipD3dMqP/vss9jY2Ejb65NW2cfHh1mzZrF+/XqNury9vXWmYW4IpqamGg+xtQRiMiwIrY8Y9UKr1pyWTAiGQVdKZXiytMrq2+6LFy+uV1rl5557Dl9fX0xNTQHo3Lkzly5d0rm/IAiC8B9iQiy0as11yYRguDp06CD9XFNaZTlPklY5NDSUkJAQNm/erLM+MRkWBEHQzaAnxFlZWfztb3+T/t/a2prp06dLCQIMRVhYGCdOnCAoKKjOxyYlJVFQUEC7du0oLi6uVbgrgPz8fLKzs7l+/XqdjhM0iSUTQksg1n8LgiDUj0FPiPPz88nPz5eiHZw/f57Ro0dz//59TExM9Ny6/wgKCuLhw4d89NFHdOvWrU7H/v777+Tk5ODl5UV5eXmtj7t48SIhISH4+/vX6TjhP0pKSigtLdW4oicIgiAIQutj0BNiABMTEzp37gw8Xn/Xvn17SkpKgMepVBUKBeXl5QQHBwOwaNEiiouLcXJy4rPPPkOpVLJs2TLOnz+PlZUVQUFB/PDDD1RUVODr68sPP/xAWloa3bp1IyEhgRMnTnDy5Ek+/fRTLly4gJWVFaGhoVRUVGjVZ2trS3p6OpaWlkyaNIldu3axZMkStm7dyokTJ8jJyaF9+/asXLmSHj16yG5XO3r0KEVFRUyZMkWrbiMjIzw9PSksLAQgJCSEwMBA6T317NkTX19f2feanJxMYmIit2/fxtjYmKCgoEYJlN8cFRQUANXf1hYEQRAEoeUz+Ex16enpTJ8+HV9fX1577TVmzJiBmZkZCQkJlJaWEh8fzwcffIC/vz8HDhzAycmJyMhI7OzsKCwsJDIyEmtra5KSkpg0aRLbtm2joKAApVIJPA7KnpeXh1Kp5Nq1a5w+fZqoqCgsLS1RKBSMGTOGc+fOydYHjzNLvfvuu7i7u7Nr1y4AcnJyMDU1JSoqivfff58tW7ZUux0eXw3Pzc2VrTszM5Np06YRExPD0KFD2bNnDwsXLmTkyJHY2tqSm5sLIPtelUolpaWlHDp0CHd3d+kPB+HJJsR//PEH27dvZ8GCBXz44YcEBARIKWObSkZGBhs3bpR9LT8/n19//bXGMsLCwliwYEGty6+uzrq0TxCaUuXxEB8fT3R0NGFhYVJa5tqqaczNmzevTscIgmB4DH5C3LNnT5YvX87y5ctZtGiRtHwiNjaWlJQUvLy82Lt3L2VlZfj4+JCamoqTkxOZmZm0b99eNrB9ZWVlZdLPY8aMkY556623APDz8+O1116Tra+srIydO3eydu1aZsyYwbVr10hNTQWQwhA5Ojpy7NgxqQ5d29Xk6tYV7F/uWLn3WtukAK1NXSbEKpWKgIAAunXrxocffsipU6e4dOkSa9as4S9/+Qve3t7k5eU1dpMByMvL4/Lly7KvXbx4kYCAgBrLCAoKIi4ujqysrFqVX12ddWmfIDSlyuOhb9++ODo6kpmZyd27d+tUTnV9uri4mOTk5DodIwiC4TH4JRPt2rWje/fuwOPYnf/7v/9LeXk5Dg4O2NvbM3v2bLKysjhz5gwKhYKvvvqKTp064eXlxZkzZ+jTp49WYHtTU1MePHgAwKlTp6Qg8urg+fb29mRkZODg4MD27dvp27evbH1xcXFMmDCBrVu3AvDdd98REhKCjY2NdNUwNTUVOzs76f3o2q4mV3dUVJRssP+q5N5r5fclsnRrqsuEeNmyZaxatQp/f3/mz58vZa1SqVRERUUxd+5cxo4dS3JycqM8pFdQUMAXX3zBTz/9JCVhqKio0LmU5ujRowwcOLDWy3zkypfbVlpaKlum3L6C0Fjk+n5cXJzW8rDK4yE7O1u6mLBjxw4CAwPp0qULgYGBWFlZaS03MzMz0+rTnp6e/OMf/+Cll15i3bp1dOnShREjRkjtEuNAEJovg79CXFWnTp1IT09n8uTJHD58GG9vb9zc3OjRowfm5uZ4enqycOFCCgsL6du3L15eXmzbto133nmHLVu2MH36dIYPH86RI0cYMWIEZ8+e1arDx8eH3bt34+HhQXR0NP369ZOtb8eOHfj4+EjHTZo0iQMHDlBRUUFkZCRjxozho48+YunSpdI+urZXV/egQYPYvn07M2fOJDc3l8jISCmwf+Xb43LvVdCtthPiCxcu8H//939s3LiRJUuWSJNheJyk4e233yY5OZmLFy+ybt26erWpvLyc0tJSrQcld+/ejbm5OcnJyfTu3Rug2qU0Li4udVrmI1e+3DZdZcrtKwj1pWs8yPV9ueVhlceDelkagJWVFSdPnmTmzJl88803ssvN5Pq0i4sLYWFhwOM+r061rSbGgSA0XwZ9hbh3797Ex8drbKucejQqKopbt25haWkpXZUbMmQI2dnZ0l/mtra2soHtExMTKSws1Mhjr2ZjY8PBgwc1guqbm5tr1af+YFSzsLDg5s2brF69mqVLlzJ69GgsLCykK7SA1va+fftq1V+1bl3B/qsG9pd7rz179pTKrZwUQAClUimd0+ps376dl19+GT8/P537vPzyy8yZM4dvv/2WxYsXP3GbVqxYQXh4OCNHjtRY+pCUlMSnn34KwJtvvsm+ffukpTTBwcHcv38fV1dXjbJiY2O5cuUKXl5elJWVYWZmJi3zOXXqFG3btpWW+ciVL7dNrkxd7ROE+tI1HuT6vomJicbysNOnT+ssVz2RHTJkCF9++SW3bt2Sxu3QoUP55ptveO6557T6tLu7O2PHjsXDwwMrKyssLS25f/++VK4YB4LQfDW7K8RV2djYaNyibtOmjextKrnA9nKT4crkrhxWrU/O008/jYmJCZaWlhqTYV3ba1N3hw4dpMmH+rW2bdtKk+HK5N6roO3hw4c8++yzsuewsrNnzzJ8+HAKCgqqfXhm+PDh/Prrr9JVqCexfPly0tLStNYB9+/fX1puo/6jcPPmzQwYMICwsDDs7e21ynJwcMDNzY3du3ezZs0axo8fLy3zUSgUJCYm8vXXXxMSEiJbvtw2uTJ17SsI9aVrPOjq+7VdHnbt2jXg8d0fZ2dnabkZIC03k+vT6mUQq1atkk3JLcaBIDRfBn2FuLmaP39+nbYL+vHHH3/w3HPP1bifOpVuTQ/PqK9OVU292xC8vb3x9vYmPDwcpVLJCy+8wKBBg/D39yclJYWioiIiIyPx9PTk2LFjKBQKJk+ejK+vLwqFgoyMDDZv3sz//d//aUzqJ02axOeff45CocDX11ejfLk65crU1T5BaCxyfV9ugqpeWlY1qsSRI0dIT08nPz+ftWvX0q5dO/z8/IiIiKCoqIiAgABMTExk+7SPjw+zZs1i/fr1WvWJcSAIzZeYEAt6FxAQgKurq1Z85LCwMCk29Llz5xo87vTevXu5c+cOSqVSNu70P/7xD6Kjo/ntt9/IyMjQaJvcwzO3bt2iTZs2dOnSpcHPkZ2dHcePH+fu3bsaKXhrWkpT22U+gGz5ctvklirpap8gNAZdy8jUKi8PU4+HwYMHS68vXrxY6w9XuaV1cn36ueeew9fXF1NTUwA6d+7MpUuXADEOBKE5a/ZLJoTm7+rVq/z5559a2yvHhm6MuNP3799n4MCBGrGf//rXv7J06VKcnZ1ZtWoVFy9e5Pnnnyc6Oloj3J3cwzNhYWG89tprNS7FqY+qX7K1WUpTm2U+usrXtU1XmWISIDQVub4vR9fSMrm7OHLLzSr36dDQUAICAli4cGG1bRPjQBCaH71eIY6JiWH//v36bIKgR0FBQYSHh3P16lVOnz6NmZkZ33//PT169JD2UceGlnuYy8fHh7lz5+Lk5MT48eOlGNJVH46ZPHmyVF7luNOdOnWiS5cu7N27lx49ejBo0CBSUlJo164dXbp04cUXX+SVV16hvLyc3377jc8//1w6turDM6tXr+bw4cPs3bu3sU+bIAh64uHhgYeHh76bIQhCI9DrhPjXX3/l5s2bDBgwQJ/NECq5efMmp06dapK6FixYwIIFC5g9ezazZ8+mX79+WvuoH5JpyLjTJiYmXL58mRs3bpCVlYVSqcTS0pLJkyfj6OjIO++8w+XLlykpKZHq27BhA2vXrsXU1BSFQkHfvn25cuUKZmZm+Pv7c/ToUd5//32mTp3aJOdOEARBEISGo/c1xAMGDBBXiQ3Ivn37mvwKiJGREUZGRtXuI/cwV0FBAZ6envTq1UuKO/38889rPRxjbGyMj48PwcHBPHjwgNzcXEpLSzE2NmbgwIF88sknbNq0Sdr+17/+lVdeeUWrvmHDhuHm5saQIUOk9qpUKp5++mmGDBki0rQKgiAIQjOl9wlxWFhYjZMhoWXbtGmT7PbKiUXk4kBD9XGn79y5w/79+4mOjpaWQrz55ptMnDiRCRMm0K9fP9zc3Bg7dixjx46tMe40PF6DnJGRwcWLFykqKqJTp06MGjWKp57S+1ASBEEQBOEJ6fVbfPz48SxYsECfTRB0MNR1cjY2Nhr/Xznu9KNHjzhx4gTR0dEcOHCAW7du0a1bN0aPHs0nn3zCqFGjpIltSUkJDx48wNraWipLV9zpql566SVeeumlhnxbgiAIgiDokV4nxC+99BLu7u76bIKgg6FOiKu6d+8ecXFxxMTEcPjwYQoLC+nfvz9+fn5MnDgRBwcH2TsQd+7cQaVSaUyIBUEQBEFoncR9XqHZSU9PJyYmRmspREBAABMmTKjVJPf27dsAYkIsCIIgCIKIQywYvkePHpGQkMD8+fOxtbXF3t6eTZs20atXL6Kionj48CHR0dG8//77tZ7g3r59GyMjo2YfLzQ+Pp7o6GiNbepU0oLQUh0+fFir39dWfn4+v/76KwC//fYbPj4+9OvXj/Hjx3Pw4MGGbCYgP0YFQTA84gqxYJCedClEbd2+fRtLS0vatm3bgK1uen379qW8vFxjmzqVtCC0VDdv3qSkpOSJjr148SIhISEEBQUxbNgwPv74YzZu3MiPP/7I4sWLad++PSNGjGiwtsqNUUEQDI/BT4hv3rxZr/S86tS/Fy9e1ErRu3PnTtasWaORDtjW1lbfb7nVaoilELV1586dZrVconIa688//1z6+bPPPqOoqIjJkydrpZIWhJYsNjaW8PBwnn32Wb788kusrKy0vhfKysq0vj8CAwM5f/48n3/+OX369GHu3LkAjBs3juzsbMLDwxkxYoTGmDt58iTLli3j0qVL2Nra8vLLL/Pxxx/j6elJYWEhACEhIcTFxZGYmMjt27cxNjYmKCiIs2fPUlRUxPDhw7XasmfPHmJjY7lz5w7FxcUMHDiQ06dP4+zszMqVK/V5egWh1TGoJRPl5eWUlpZq/DVd3/S86tS/gEaK3jFjxrB69WqtdMBC02mMpRC1dfv2bYOcNMqNAdBMY1355/z8fHJzc2VTSQtCc6drPKglJiYydepUgoODZb8X5L4/Fi5cyMiRIykvL2f8+PEa5Y0YMYKUlBRAc8xFRETw6quvEh8fT9euXcnOziYzM5Np06YRExPD0KFD2bNnD0qlktLSUg4dOoS7uzvBwcHSGJVri1KpJD8/n8TERHr16oWJiQlHjx4lJSWFGzduNPr5FQThPwxqQrxixQocHR2l1LsAPj4+pKam4uTkRGZmppSed9SoUcDj9LxJSUka5VROz6tO/QsQFxfHW2+9BYCfnx/37t0jJSUFLy8v9u7dq3Gc0Dju3bvH999/j7u7O126dGH06NGcOHECPz8/UlNTuX79Olu2bGHixIlSiLTGcP36dY0U0YZCbgyoVe7LlX+Gx6mkx4wZAzxOJS0ILUF140G9rMHKyoqHDx/Kfi/IfX+o9e7dm+vXr2uUeeHCBY3MqepxFh8fj7Ozs0a9ZmZmHDx4EDc3N2JiYigqKgLAyckJADs7O3JycqSydLXFxcUFeBz7/PXXXwfAwsKCgoKCJzxrgiA8CYOaEC9fvpy0tDQCAgKkber0vCkpKaSnp2uk5wU00vP++eefABqph9WpfwHs7e3JyMgAYPv27QC4ubmxe/du1qxZo3W1QGgY6enp/Otf/2LQoEF07dqVOXPm8OjRIwICArhx4wapqaksX74cR0fHJkvSkpmZaZATYrkxoFa5L1f+GaB///7SmEhLS2vcRgpCE6luPFT9g1nue0Hu+0Nt4sSJREZGkpWVJW3btWuXdNEE/jPO+vfvL63LVygUAGzevJkBAwYQFhaGvb291jEqlUqjfbraUvl9VM6AWfV4QRAal8GvITY3N691et733nuP+Ph4KioqGDRokFZZPj4+zJkzh4iICEpLS/n222+ZMWOGRnpeof7qkiBDH4qLi7l9+7ZBToiflLe3N97e3oSHh6NUKnnhhRf03SRBaFJeXl5a3wu///671vfHgwcPOHbsGJcvX2bevHnY29vj7OxMbm4uLi4u0p2Wyjw8PJg9ezZff/01paWlDBw4kEGDBuHv709KSgpFRUVERkYybdo0ne2T+y47f/58Y54SQRDqwEilpz9DjYyMCA0NrVVijoqKCo30vGoPHz7EwsJCY1thYaHGbTE5lVP0AlrpeYW6/X5Ad1SICRMmNEhUiIaUkZHByy+/zNmzZ3FwcNBLG/bt24eHh0eDXwW6e/dusw8l15Tq2s+FxjN16lQA9u/fX69yqn4vyH1/lJSUYGxsjLGxMaWlpfz222/Y2dlhamoqW2ZaWhpmZmZ0796dDRs20KFDB2bOnIlSqcTIyAgzMzOt7xU5ur7LGkJDnT9BaK0M/goxaKbnrazqZBiocTIM2il65dLzCrX33Xff4efnxzPPPMOoUaNYv34948aNo0uXLvpumqzMzEyAFnWFWE1MhoXWrur3gtz3R+VwiyYmJvz3f/93tWV26tSJGTNm0KZNG8rLywkPDwegQ4cO0j41TYZ1tUUQBMPQLCbEgmEbPXo0R44cYejQoc3iKvv169fp2LEjy5YtY/369RqvZWRkkJCQIIViEgRBsLOzIyEhgbKyMp56SnxtCkJLJEa2UG+2trbNKn7z9evX6datG8nJyVqviaQWgiDoIibDgtByidEtNKiAgABcXV158cUXNbZXDnJ/7tw5Vq1apZEQBWiQBCwnT57USL4SGhpKRUWFRn3Gxsb07NlTSt9aUFAgkloIgiAIQitmUGHXhObv6tWrUvi7yioHuU9ISNBKiNJQCViqJl85d+6cVn2nT5/mpZdektomkloIgiAIQusmJsRCgwgKCmLw4MFERkYyY8YMBg8erBX0Xh3kPjY2VishSkMlYKmafOW1117TqG/Xrl0UFBTwyiuvSMeKpBaCIAiC0LqJCbHQIBYsWIBCocDV1ZVt27ahUCi0ojioA9Y7ODhoJURpqAQsVZOvnDt3TqO+mTNnolKpNK4Qi6QWgiAIgtC6iTXEQoMyMjKqMd7w5MmT8fX11UiIUlBQ0CAJWKomX/H19aVnz55SfSdPnuSpp57SmKyLpBaCIAiC0LqJCXE9hIWFceLECYKCgup0XFJSEgUFBbRr147i4mImTpxYq+Py8/PJzs7mv//7v4mPj6/zsUuXLm30MGObNm2S3T59+nTpZ3Nzc6KiorQSogwZMkQjaL2trS1xcXFagfYTExN1JmCxsbHh4MGDGkHyK9e3fv16YmJisLa25tKlS8DjkErHjx8XSS3qoKn6kyA0JvVn6vXr1+v0eQoQGxvLjh07yMvLY/z48cyfP7/e7anr57ogCA1HLJmoh6CgIOLi4sjKyqrTcb///juZmZn07dsXR0fHWh938eJFAgICAOp8bHFxscGFGbOxsdGIW9yQCVjkguTb2Njwyy+/0KtXL9ljxGS49gyxPwlCXak/U+v6eZqTk8OaNWv4+uuv2bFjBydPnuT48eP1bk9d2yEIQsMx+CvENYXrsrW15ebNmxohuz766COtcF1du3YlJCSkTiG7du7cyZo1a7TqA0hPT8fS0pJJkyaxa9culixZwtatWzlx4gQ5OTm0b9+elStXSmVX3qZ29OhRioqKmDJlilaoMCMjIzw9PSksLAQgJCSEwMBAzp8/z9GjR8nOzpaOrfpek5OTSUxM5Pbt2xgbGxMUFETHjh2leltzmLFLly7h4+Oj72bUmSGFrQsODtb4Q6Y19ydBP2oaD9bW1lqfnyYmJlp9W/2ZamRkxIABA/D19cXV1ZW1a9fSo0cPNmzYwDPPPMPvv/+uUb5SqeTRo0cYGRlhbW3N+vXrycvLA5D9HrC1tdVqo7m5uVZ71N8JXl5etRrjgiA0HIO6QlxeXk5paSnl5eXStprCdQFaIbt2796tFa4LqHPIrtWrV8vWB7Bjxw7effdd3N3d2bVrF/D4qoGpqSlRUVG8//77bNmyRXabWn5+Prm5ubKhwjIzM5k2bRoxMTEMHTqUPXv2sHDhQkaOHImLi4t0rFxoMqVSSWlpKYcOHcLd3V36MFVrrWHG8vLyuHbtGg4ODvpuik5yYwAMK2xd5XEArbc/CY3vSceD3OenXN9Wf6Y6ODiQm5sLwLBhwzhw4AAAu3bt4qmnntIq/5VXXsHT05PBgwfj5OTExo0bsbKyAuS/B+TaKNce9ed6bce4IAgNx6AmxCtWrMDR0ZHFixdrbK8uXBegFbLr+PHj1YbrgtqF7Lp3755sfWVlZezcuZO1a9cyY8YMrl27RmpqKgDOzs4AODo6cuzYMZ3bKpMLFWZmZsbBgwdxc3MjJiaGoqIi2XOmKzSZk5MT8Hh9bE5OjsYxrTXM2NmzZ1GpVAZ9S1LXGADDCFtXeRyotdb+JDS+Jx0Pcp+fcn1bjpeXF5GRkWRkZGBnZ8fJkye1yr9//z5+fn5cuXKFAwcOcOvWLY1nSap+5su1sbr21HaMC4LQcAxqycTy5ctZvny51vbK4brs7e2ZPXs2WVlZnDlzBkAK2dWpUye8vLwwMjLiypUr9OnTRwrXBWBqasqDBw+AxyG72rVrp1G+OmSXg4MD27dvB8DNzU2rvri4OCZMmMDWrVsB+O677wgJCcHGxkYK35WamoqdnR2A7LbKqtbbt29foqKiGDBgADNnzuSDDz7Qec7Uocmqvlf1e1KpVFrHqMOM9e/fv1WFGTt79ixdu3bF2tpa303RSdcYgOrHQdUxUDlsXeW+Udcx0LdvX53jTq219ieh8T3peNi8ebPW56dc35bTpUsXLCwsWLNmDdOnT+fu3bta5Z89e5aEhATWrFlDt27deP/99zXunFT9zJdr47Vr13S2p7ZjXNekXhCEujOoCXFN5MJ1weMoApVDdm3YsIG5c+dqhOsCGD58eJ1Cdn377bfMmDFDq74dO3Ywb9486bhJkybx+eefM3fuXCIjIzl37hy3b98mJCSEI0eOaG37+eefq63X19eXP/74A39/f1JSUigqKiIyMhJPT0+OHTuGQqGQjvXy8tIKTZaYmFjteWytYcbOnj0rXTlvzvQZtq7yOFBrrf1JMAxy46Fjx45an5979uzR6tt3797l2LFjFBYWatw5mjZtGh999JE0tqqW379/f77//nucnJzo3bs3WVlZ/POf/5SOr/qZ361bN60y3njjDa32nD17Vud7khvjgiA0HCOV3CXEpqjYyIjQ0FDc3d3rfGzVcF0AFRUVGiG7AK1wXWq6QnapVQ7Zpas+OatXr8bGxobRo0djYWFBmzZtZLfVtl6lUomRkRFmZmbSayUlJRgbG2NsbKxxrK73Wp3qwozV5/djqF588UV8fHx0XnFqSvv27cPDw0P2Cn5tVe2XcmMA5PtGXceAXH1VNcewdS2xnzdXU6dOBWD//v1PdHzV/in3+QnafVvXZ2pN5cPjcVRQUCCtHwb574HqypAba7r21zXGof7nTxBau2Z1hVjNxsZGa5tcyC5dE8S6huySq0/O008/jYmJCZaWltVuq229HTp00Hqtbdu2ssfWdTIMrSvMWFQwz5MAACAASURBVF5eHpmZmQa9friuqvbLpghbV53W1J8Ew1O1f8p9flb9GXR/ptZUPjweR1XHUnWf+XJl6JoMy+2va4wLglB/zXJCbKjkArM3RLB2of5SU1NRqVQtYsmEIAiGS3zmC0LzZFBRJgShsfz0009YW1uLqyuCIAiCIGgRE2KhVTh+/DhDhgzRdzMEQRAEQTBAYkIstHjl5eWcPHmSwYMH67spgiAIgiAYIDEhFlq8CxcukJeXJybEgiAIgiDIEhNiocU7fvw4FhYW9OrVS99NEQRBEATBAIkJsdDiKRQKBg0aVG0MaEEQBEEQWq8WP0NISkoiKiqK+Ph4oqOja31cfn4+v/76K0CdjxUMh0ql4scffxTLJaqobf/OysrC1dVV+jdnzhxOnz6tl3bm5+drZIhUy8jIYOPGjU3WJsHwqD/n60v0MUFovVp8HOLff/+dnJwcvLy8KC8vr/VxFy9eJCQkhM2bN9O3b986HSsYjl9++YV79+6JCBNV1LZ/5+fnk5+fz759+wA4f/48o0eP5v79+5iYmDRpO4uLi0lOTtbaJy8vj8uXLzd6WwTDpf6cry/RxwSh9TL4CXFFRQWenp4UFhYCEBISQqdOndi6dSsnTpwgJyeH9u3bs3LlShISErS2qR09epSioiKmTJnCp59+yoULF7CysiI0NBQjIyOtOgIDAzl//jxHjx4lOztbOnbZsmWcP38eKysrgoKCSE5OJjExkdu3b2NsbExQUBCmpqYsWrSI4uJinJyc+Oyzz/Ry7gRITEzk2WefxcHBQd9NqRelUsmyZcu4dOkStra2vPzyyyxcuJBVq1ahUCgoLy8nODgYhUKh1R+7deumtZ+u/l11bACYmJjQuXNnAIYNG0b79u0pKSkB0CrX2tpaayyZmJg8cdsrt7PyGvCCggK++OILfvrpJywsLER86VZGqVRq9NVx48ZJ26t+Rnft2pU9e/bUalxUTaks+pggtB4GtWSivLyc0tJSjatVmZmZTJs2jZiYGIYOHcqePXsAyMnJwdTUlKioKN5//322bNkiu00tPz+f3NxcoqKisLS0RKFQMGbMGM6dOydbx8KFCxk5ciQuLi7SsZGRkVhbW5OUlMSkSZPYtm0bSqWS0tJSDh06hLu7O8HBwRw4cAAnJyciIyOxs7OTJgdC04uLi2PEiBE89ZTB/+0HyI8BgIiICF599VXi4+Pp2rUr2dnZJCQkUFpaSnx8PB988AH+/v6y/VFuP7n+LTc2ANLT05k+fTq+vr689tprzJgxAzMzM9ly5cZSfdpeuZ2V7d69G3Nzc5KTk+ndu3dT/XqEJqZrPFTtq1lZWQCyn9FArcdFZaKPCULrYlAT4hUrVuDo6MjixYulbWZmZhw8eBA3NzdiYmIoKiqSXnN2dgbA0dGRY8eO6dxWWVxcHG+99RYAfn5+vPbaa9XWUfXYUaNGATB06FCSkpIApHTAdnZ25OTk4OPjQ2pqKk5OTmRmZmrluheaRklJCUePHmX06NH6bkqtyY0BeLzOV923R4wYAUBsbCwpKSl4eXmxd+9eysrKAO3+qGu/quTGBkDPnj1Zvnw5y5cvZ9GiRdLyCbly5cZSfdquS1JSEmPGjAHgzTffrPX5rY8vv/ySgwcPNkldwmO6xkPVvtqjRw9pu9xnNNR9XOijjwmCoD8GNSFevnw5aWlpBAQESNs2b97MgAEDCAsLw97eXmP/K1euAJCamoqdnZ3ObZXZ29uTkZEBwPbt2zl37ly1dVTWp08fqfyff/5Z+pJXRy9QqVTA46gGX331FSkpKaSnp3PmzJm6nwyh3o4fP45SqWyUCfGNGzcIDg5m5cqVrF27lh9//JGKiop6lys3BgD69+8vrWFUKBQAODg44Obmxu7du1mzZg3jx48HtPujrv2qkhsbAO3ataN79+706NEDHx8fioqKKC8vly1XbizVp+269O/fXxqLaWlpNZ/YBpCVlYWnpycnTpyod1n1eVBX/QDZ6dOncXV15eHDh9JrqampWtt0qe5BMXUd+n7ITNd4qNpX1VeIdX1GQ93HhT76mCAI+mPw95EHDRqEv78/KSkpFBUVERkZycKFC4HHt8fOnTvH7du3CQkJ4ciRI1rbfv75Z43yfHx8mDNnDhEREZSWluLr68sff/yhVYenpyfHjh2TvsABvLy88PPzIyIigqKiIgICAkhMTNRqs7m5OZ6envTq1YvCwkL69u3buCdJkHXkyBH+8pe/0K1btwYrMzc3l/nz57Nr1y5MTU15/vnn+fPPP7lz5w4vv/wymzdv1rq93xA8PDyYPXs2X3/9NaWlpQwcOJDJkyfj6+uLQqEgIyODzZs3y15Vldvv+eef1+rfcmMjPT1dq7xOnTqRnp4uW27Hjh21xtKePXueuO09evSQ2vnKK69I2729vfH29iY8PBylUskLL7zQQGdat7Vr13Lr1i1cXV358ccfNdpTV/V5ULfyA2QKhYLw8HD8/PyAx5NDhUKh8y5XZdU9KKauw9nZ2SAfMqvaVydOnEhubq7sZ7Qucn2wMn30MUEQ9MdIVdOlmMaq2MiI0NBQ3N3da9xXqVRiZGSEmZkZBQUFPPPMM6xevRobGxtGjx6NhYUFbdq0kd2mi7qc6uooKSnB2NgYY2NjjWMfPnyIhYVFtW2uqKggOzu72T6IUZffj6Hq3bs3o0aNqvZLsS7y8/MZOnQo9+7dIygoiLfffpu2bdsC8O9//5ulS5cSHR1NZGSkzquwavv27cPDw6PGK6FqaWlpmJmZ0b17dzZs2ECHDh2YOXMmALdu3cLS0lLjgSA5VffT1b+rjo2aVC236li6fv16vdquq50Ad+/epWvXrrVua1V17eePHj3iL3/5C2VlZZw5c0arbrmHgOPi4rQe6Dp79ixFRUW0bduW2NhY7ty5Q3FxMQMHDuT06dM4OzuzcuVK2fKioqLIycmhZ8+eHDhwgHv37hEXF0dFRQUDBw7k6aefZvfu3Tz77LNaD5iZmZlpPSgWFBSk9XBZQkKCtPxr2LBhXLp0SfYhsw0bNjzxua9q6tSpAOzfv7/Wx+jqq7X5jFarqQ/Wt481lSc5f4Ig/IdBLZnQpUOHDpiZmQFIH35PP/00JiYmWFpaShNfuW26VP0Qlaujbdu2sl/CtfmgbdOmTbOdDLcEt27dIj09vUGXSyxdupRffvmFlJQU3N3dpclwRkYGycnJhIeH4+Pjw3vvvUd+fn6D1QuPr8rOmjWLsWPHSmt01WxsbGqcDMvtp6t/12UyLFdu1bFU37braifQ5BOVdu3a4eLiwlNPPcWoUaPIy8vTeF3uoUK5B7rUDzIqlUry8/NJTEykV69emJiYcPToUVJSUrhx44bOh4rVOnfujEql4t69exw9epQhQ4ZIf2TJPWAm96BYTQ+XqRniQ2a6+mptJ8NQcx9sDpNhQRDqr1lMiOXMnz9f66qO3DahdTpy5Ajt2rVrsPjDJSUlBAcH07FjR60lGJVvHwcFBaFUKgkLC2uQetXs7OxISEjg0KFDJCYm0rFjxwYtvzE157ZXFhQUxODBg4mLi8PMzIxffvmFsWPHUlxcLO2j6wHd6h4WVC+xMTc35/XXXwceT+gKCgpq9cCvm5sbBw4ckO46qMk9YCb3oFhtH7oUD5kJgtCSNdsJsdByBAQEcPXqVa3tYWFhzJ49m969e1NaWsqKFSsYNWoUw4cP5+bNm9y8eRMPDw/efvttvvjiC+Dx7fqFCxfyySefYG5uTm5uLiEhIQQHBwPwww8/EBAQoFG2Uqnkww8/ZPDgwbi5uUmhnirXl5SUREFBAR06dAAe36r95JNPGDZsGKtWrZLabG5ujrOzMykpKY1yrppL+Dg5zbntAAsWLEChUODq6srOnTtJTU3l8uXLzJgxQ7oqq+sB3eoeFqx8ddLIyEjaT6VS1eqB38mTJ7Nv3z7S0tI04m3LPWAm96BYbR+6FA+ZCYLQkokJsaB3V69e5c8//9TarlQquXbtGqdPn5a9rSsX7zkyMpLnnnuOP//8E1dXV7Zt20ZBQQFKpRKAwsJC8vLyNMqWi79btb6vvvoK+M+krrrbx126dOHBgweNfNYEfTEyMsLIyIjevXsTHh7OgQMHWLp0KfD4IeDt27czc+ZMKXZ5fdSmvOeeew5TU1OGDRumsd3Ly4tt27bxzjvvsGXLFqZPn463tzebNm1i6tSpxMbGAo8n1IcPH8bb2xs3NzcphFlVcscKgiC0FM37ko3QrAUFBREeHs7Vq1c5ffo0ZmZmfP/99xpfyGPGjKF9+/bExsZy5coVvLy8pHi3Pj4+zJ07FycnJ8aPH0/79u2Ji4ujb9++lJaWMm/ePObNm8fkyZOl8irfDlaXHRcXx4IFCwCkp/U//PBDjfrUaYrVxyclJfHpp58Cj28fq2PzAmRnZ9O9e/fGOWmC3m3atEn6+c0332T79u34+PjQtWtX/va3v/HGG29oPaCrNmzYMK2Jq9q//vUv6eeIiAgAevXqVW15rq6uABw+fFjaVjn+elxcnNYDZsePH9d6UCwqKkrj4TJHR0fptUuXLgGPl3vIHSsIgtASiAmxoDcLFixgwYIFzJ49m9mzZ9OvXz+tfdS3mh0cHLC3t2f27NlkZWVx5swZKd5zp06d8PLy4syZM/Tp04fw8HBcXFzIysrC2dkZU1NT6YrtqVOnaNeunUbZ6pimDg4ObN++nb59+2rVd/LkSY4dOyZdaVbfPu7fv7/G7eOHDx+SkpKCt7d3o547wXB4eXnx22+/sWDBAqytrTUeGqzrA4py1Mt0nrQ8uQfM5Ca0NjY2tSqvMSfDp06dkqIlCHVz6tQpBgwYoO9mCEKzJSbEgt6pb0FXRy5maEFBgVa8ZwsLC5YuXUq/fv3YsmULAQEBGBsb89577xEfH09FRQWDBg3SKFsu/m7Pnj216vPx8WHz5s1kZmbKxihVqVTMnz+fjh07MmXKlMY8ZYKBWbJkCdnZ2UybNg0rKysGDx6s7yY1O2+88Ya+m9CsDRgwQJxDQagPlZ4AqtDQUH1VL9TAUH8/N2/eVBUVFUn/X15errp9+7b0/xEREao2bdqoLl++rHXsn3/+WW3Z+fn51dZ3//59Vc+ePVVWVlaqkJAQ1aNHj1R37txRqVQq1fnz51UTJkxQmZiYqOLi4mp8H6GhoSo9Dj/h/9eQ/by8vFw1ZcoUVceOHVUXLlxokDIFQRCEpmHwD9WpU4jWlOr00KFDGnnrhZapaszQqvGew8PDGThwIK+++qrWse3bt6+2bLnb0er6ysvLmTVrFn/88QfDhw9nxowZdOzYkYEDB9K5c2f69evHb7/9RnJycqOkiq6t/Px8fv31V+A/6YHDwsI0MtLVRnWpefWdztdQtWnThp07d9K7d2/GjRvHjRs39N0kQRAEoZYMfsmEOoWol5dXtalOf/vtNykZgNA6lZaWEhMTw7Jlyxq0XJVKxZw5czh8+DBHjhxh8ODBfPnllyQnJ3Pjxg06dOiAo6Mjr7/+eo1LPxrbxYsXCQkJYfPmzVJ64J07d9Y6I55adal5i4uLDTKdryEwNTUlJiaGwYMHM27cOBQKBebm5vpuliAIglADg58Qqx09epSioiJ8fX3Zs2ePVipUtfv37/Pee+/x8ccf8/XXX1NcXIyTkxOfffaZHlsvNIUjR46Qm5vLpEmTGrTcv//972zbto19+/ZJa0Off/55vLy8GrSe6tQ2JXBgYCDnz5/n6NGjZGdnS4kcduzYQWBgIF26dCEwMBArK6tapfX19PTkH//4By+99BLr1q2jS5cujBgxQmqXXDrf1q5jx44cOnQIZ2dnJk2aRFxcXK0yCQqCIAj6Y1BLJtQJEeSuBKtTnQKyqVDhcbgrNzc3VqxYwc8//6wVo1Zo2UJCQhgyZIhWJrn62LhxIytXrmTLli0a4dsai64xUNuUwAsXLmTkyJG4uLhojBkrKytOnjzJzJkz+eabb2qd1tfFxUXKurd7925Gjhyp0S5DTOdrCGxtbTl06BDnz5/H19eXiooKfTdJEARBqIZBTYhXrFiBo6MjixcvrnFfuVSo69ev58GDB1hbW+Pj40NqaipOTk5kZmbWuH5UaN7y8/OJjo5m2rRpDVbm3r17mTdvHqtWrWLmzJkNVm51dI2BJ0kJXJl6IjtkyBBOnjxZ67S+7u7uREVFce3aNaysrLC0tNQoV6Tz1c3e3p6IiAgiIyP55JNP9N0cQRAEoRoGNSFevnw5aWlpBAQE1LivXCpUf39//v73vzNv3jwpRm1KSgrp6emcOXOm0dot6F9oaCgqlarBwp0lJSUxffp05s6dW6s/0BqKrjHwJCmBK7t27RoAFy5cwNnZudZpfdXLIFatWiX7x4ZI51s9FxcXablK5aVdgiAIgmFpNmuIa8PY2BhPT0+2b9/O8ePHWbdunUaMWqHlCgkJwdXVtUEeYDpz5gyurq5MmTKFdevWNUDr6m/QoEH4+/uTkpJCUVERkZGRshPUHj16cOzYMa2oEkeOHCE9PZ38/HzWrl1Lu3bt8PPzIyIigqKiIgICAjAxMdGKrQyP4zTPmjWL9evXa9UnF49Z0OTp6cmNGzdYtGgRnTt3xsfHR99NEgRBEKowUtX18fOGqtjIiNDQUNzd3RutjoqKCrKzs8WDPk+gKX4/DSUrK4sePXoQHR3N+PHj61XW1atXGThwIH369CE2Npa2bds2UCs17du3Dw8PjzpFf1AqlTpT+FZWUlKCsbExxsbGGttzc3O1/mComtYX0ErNm5ycTHR0NIGBgTrb1lzT+TZlP1+wYAEbN24kNjZW48FEQRAEQf9a1BXiqqrGqBVapu+//57OnTtLa2Kf1K1btxg5ciTdu3cnIiKi0SbDT6q2KXx1tVvu6nlNaX1DQ0OlMG7VaY6T4aYWGBjIgwcPmDJlCsePHxd3rQRBEAyIQa0hFoQnsWvXLry8vDAxMXniMvLy8hg/fjzt27fn8OHDGpPP1szDw4OYmBhsbW313ZRmz8jIiO+++46//vWvjBs3jqysLH03SRAEQfj/iQmx0KydPHmSX375pV7rMh89esSECRP4448/OHTokOxVU0FoCG3btuXAgQN07tyZcePGVRsZRBAEQWg6YkIsNGtbtmyhX79+ODo6PtHxpaWluLm58e9//5v4+PgGjWEsCHKeffZZDh06hFKp5O2335ZC6AmCIAj6IybEQrOVk5PD/v37mTNnzhMdX1FRwfTp0zl+/DixsbG8+uqrDdxCQZBnbW3N4cOHuXjxIh4eHtWmpRcEQRAan5gQC83Wtm3bMDY25p133nmi4xctWkRYWBj79+/n9ddfb+DWCUL1/vKXvxAZGUl8fDzz5s3Td3MEQRBaNTEhFpollUrFN998w7vvvlttxAVdPvvsM9avX8/OnTulTGuC0NSGDBnC3r17+eabb1izZo2+myMIgtBqteiwa0LLlZCQQEZGBmFhYXU+dv369axcuZJvvvmGqVOnNkLrBKH2XF1dWb9+PR988AFWVla8++67+m6SIAhCqyOuED+B/Px8rVucGRkZbNy4UU8tan02bdrEoEGD6N27d52OCwkJYf78+axevRo/P79Gap3+JCUlERUVJf337NmzWhnm4uPjiY6OrnWZcv0dRJ9vSHPmzGHRokX4+fkRHx+v7+YIgiC0OuIK8RMoLi4mOTlZY1teXh6XL1/WU4talzt37hATE8OOHTvqdFxUVBTvvfceS5cu5X/+538ap3F69vvvv5OTk0OnTp3Iycmhbdu2/Pzzzxr79O3bt04Pccn1dxB9vqGtXr2ae/fu4ebmxrFjx+jfv7++myQIgtBqGPyEOCwsjISEBE6cOMG5c+dYtWoVCoWC8vJygoODsbW15ebNmyxatIji4mKcnJz46KOPWLZsGefPn8fKyoqgoCC6du1KSEgIFRUV+Pr68sMPP5CWlka3bt2k8k+ePMmnn37KhQsXsLKyYufOnaxZs0arPrWCggK++OILfvrpJywsLERWvCayZcsWOnbsyOTJk2t9TFJSEp6envy///f/WLFiRSO2rnEolco69c3qHD16lKKiItq2bUtiYiK3b9/G2NiYoKAgunXrpjXGnn76aelY0ecbj5GREd9++y137txh/PjxpKSk0L17d303SxAEoVUwqCUT5eXllJaWaly9UiqVXLt2jdOnT5OQkEBpaSnx8fF88MEH+Pv7A3DgwAGcnJyIjIzEzs6O3bt3Y21tTVJSEpMmTWLbtm3A4y9zpVIJQGFhIXl5eRrlR0VFYWlpiUKhYMyYMaxevVq2PrXdu3djbm5OcnJynW/dC0+mpKSErVu3MnPmTExNTWt1zJkzZ3j77beZNGkSGzZsaOQW1o/cGADq3Derk5+fT25uLkqlktLSUg4dOoS7uzvBwcE6x5ia6PONy8TEhLCwMKysrBg5ciT379/Xd5MEQRBaBYOaEK9YsQJHR0cWL16ssX3MmDG0b9+e2NhYUlJS8PLyYu/evZSVlQHg4+NDamoqTk5OZGZmcvz4cUaNGgXA0KFDSUpK0qpLfWzl8uPi4njrrbcA8PPz4969e7L1qSUlJUkRCt58882GOxGCTrt37+b+/fvMnTu3Vvunp6czduxYBgwYwPbt22nTxqC6vBZdY6CufbO2nJycALCzsyMnJ0fnGFMTfb7xPfvss8TGxlJWVsaECRP4888/9d0kQRCEFs+glkwsX76c5cuXa21XT2IcHBywt7dn9uzZZGVlcebMGQAUCgVfffUVnTp1wsvLCyMjI65cuUKfPn34+eefcXZ2BsDU1JQHDx4AcOrUKdq1a6dRvr29PRkZGTg4OLB9+3YA3NzctOpT69+/P1euXKF///6kpaU1/AkRtKxduxZPT0/+67/+q8Z9b9y4wbhx43jppZeIiIjQuPVvqHSNgbr2zdpS932VSgXoHmNqos83DWtraw4dOsSgQYPw9PQkIiKCp54yqI9rQRCEFqVZfcJOnjwZX19fFAoFGRkZbN68GQBzc3M8PT3p1asXhYWFbNiwgblz5xIREUFRUREBAQEADB8+nPfee4/4+HgqKioYNGiQRvk+Pj7MmTOHiIgISktL+fbbb5kxY4ZWfWre3t54e3sTHh6OUqnkhRdeaJoT0UodOXKECxcuSBPC6ty/f5+RI0dibm5ObGwsZmZmTdDCxlPXvlnZwYMHpSvBAO+//77OfXWNMTXR55vOq6++yqFDh3jzzTf54IMP2LJli76bJAiC0GIZqdSXhpq6YiMjQkNDcXd3r/Oxt27dwtLSUuOKX0VFBdnZ2RoP+Tx8+BALCwut4wsLC2nfvr3O8gsKCjSSPcjVV9ndu3fp2rVrnd+HIavP76exjBo1CpVKxQ8//FDtfjk5OQwbNoxHjx6hUCjo0qVLE7Ww9vbt24eHhwd1HX517ZtPqrX0eUPs51VFR0czadIk/vGPf7BkyRJ9N0cQBKFFalZXiNVsbGy0trVp00briXe5yTBQ7WQY0Mp8JldfZS1hYmDoLl68SEJCAocOHap2v4KCAsaOHcvDhw8NdjJcH3Xtm09K9HnDMXHiRL7++mvmzJnD888/z4wZM/TdJEEQhBanWU6IhdZnzZo19OrVi9GjR+vc59GjR7z11ltcv36dY8eO0a1btyZsoSA0nlmzZpGVlcWsWbN4/vnnRbpxQRCEBiYmxILBu3XrFqGhoWzZsgUjIyPZfUpKSpg6dSrnz58nKSmJV155pYlbKQiN65///Cd37txhypQpJCYmMmDAAH03SRAEocUw7BhUggBSBBFPT0/Z18vLy5k2bRoKhYL4+HiR4UtokYyMjPjmm28YPHgwb731Fr/++qu+myQIgtBiiAmxYNByc3PZsmUL8+fPl03EoVKpmDVrFjExMURHR/Paa6/poZWC0DRMTEzYv38/dnZ2jB07lnv37um7SYIgCC2CXpdMBAUFsX//fn02QTBw69atw8jIiDlz5mi9plKpmDt3LiEhIURGRjJkyBA9tFAQmtYzzzxDXFwcAwcOZMKECSQnJzf7sIKCIAj6prcrxG5ubtja2uqreqEGbm5u2NnZ6bUN+fn5rFu3joULF2Jubq71+qeffsrWrVvZuXMnY8eO1UMLBUE/OnfuzOHDh8nKysLDw+OJMxUKgiAIj+ntCrG4MizUZN26dVRUVDBv3jyt15YtW8aXX35JSEgIU6dO1UPrBEG/XnjhBWJiYhg2bBhz5sxh69at+m6SIAhCsyXWEAsGKT8/n7Vr1/LRRx9pXR1eu3YtX3zxBZs2bcLLy0tPLTRM8fHxREdHP9GxSUlJREVFcfr0aVxdXXn48KH0WmpqqtY2XTIyMti4cWON9eTn52v9sVPTsYKm1157jdDQUHbs2IG/v3+j1WNkZCT+iX/SP0FoiUTYNcEgrV+/nrKyMubPn6+xfePGjSz4/9g787ga0///vyopLSQRqTHWsYRJ+Q2KSkkkkVKKEbIzQ4YMw2iYGYpi7MugopR2RbRSUSKyfRP6WLIv6ZwcpU7X748e555zOvdpU52W6/l49Ji672t53/dc5/I+1/W+Xu+VK+Hl5VVlCuLWytChQ8Hn8+tU9+nTpygoKAAApKSkICwsDK6urgCAY8eOISUlBcXFxdW2U1hYiHv37lXbz6hRo5CUlFSruhRxrKyssH//fsyfPx+dO3fGkiVLGqSfFStWYOTIkQ3SNqV5cOXKFezcuVPaZlAoDQJ1iClNjqKiIuzatQs///wzOnbsyFz38/PD8uXL8eeff+KXX36RooWNT3l5ORwdHcHj8QAA/v7+iI2NRUJCAl68eAE5OTn4+Pjg+vXrKC4uRtu2bRETE4OXL1+ipKQEhoaGyMjIwKhRo/DXX3+xtifMpEmTEBISAldXV5SXlyMrKwtDhgwBUPH/Z+PGjbh58yY0NTXh4+MDZWVlbNmyBVevXoW6BFH97QAAIABJREFUujq6deuG0tJSbN26FSkpKeDz+fD19WU9N8DlcsXqUmqHq6srnj17hp9++glaWlqYMmVKvfcxcuTIJp3imtI4UIeY0lKhIROUJsfu3btRUlKCFStWMNeCgoIwd+5cuLu7Y926dVK0rmHh8/koLS0VW+XNy8vDrFmzEB0dDWNjYwQGBqKoqAilpaU4e/Yspk+fDl9fX3A4HHz8+BFFRUXgcDhISEjAoEGDIC8vj+TkZFy+fBnPnj1jbU+Yzp07gxCCN2/eIDk5GWPGjAEhBAAQEREBLS0tJCYmYurUqTh69CgCAgKgpqaGpKQkDB48GAAQHx+P0tJSXLhwAUuXLpW4pc9Wl1J7Nm3aBBcXFzg5OeHKlSvSNodCoVCaFdQhpjQpPn36BB8fHyxfvhzq6uoAgNDQUMycORPLli3DX3/9JWULG5bNmzdDX18fa9asEbmurKyMqKgo2NnZITo6mgldMDAwAADo6Ogw4Q4CTExMAABqamr44YcfAADq6urgcrkS2xPGzs4OoaGhCA4OhoODA3M9NjYWFhYWAABjY2MkJiYiMTGRSSc8duxYAEBMTAwuX74MJycnnDp1SqISAltdSu2RkZHBwYMHYWFhgcmTJ+P+/fvSNolCoVCaDdQhpjQp/vnnHxQXF2PlypUAgHPnzsHZ2RkuLi7w8fGRsnUNz6ZNm3Dr1i3s2LFD5PqBAwcwYsQIhISEQFdXl7kuK1vxERas3gqjoKDA/C44CEMIASFEYnvC2NraIjg4GLdu3cKwYcOY60OGDEFOTg4A4MaNGxg1ahT09PSYa7du3QIADBs2DHZ2dggICICXlxesrKxY+2GrS6kbcnJyCAgIQN++fTFx4kS8fv0a2dnZWLt2LaysrGBubo4FCxYgPDwc5eXl0ja3XgkJCWHmDUk0p0OnFAqlcaEOMaXJ8OHDB3h6emLFihXo1KkTzp8/j6lTp8LZ2RkHDx5s1aebjYyMcOzYMcybNw8fP35EREREg7fXqVMnKCoqwtTUVOS6k5MTjh49ihkzZuDgwYNwcXGBs7Mz9u/fD3t7e8TExACocKgFX2js7OzQs2dPVlvY6lLqjpKSEiIiIiAjI4Nx48ZBT08P4eHh6NKlC3r37o379+/Dzs4Ow4cPR15enrTNrTd8fHwQGxuLJ0+eSCwzdOhQ6Ovr16n9p0+fIi8vD69evWIOnQqo70OnLen/C4XSXJAhbEtLFIoU+OWXX+Dn54eHDx8iIyMDkydPhqOjI/79919mJbSlIAhDqM3Hr6ioCDIyMlBWVgaXy4WqqupX2fC17X348IEJaxHw6tUrdO3aVeTa8+fPoaGhIbJizQZb3YZGRkYGQUFBLfKw2PTp0xEbG4t///0XdnZ2Il8oc3Jy4OTkhI8fP+LatWti/x8r09Tf0927d7Fu3TqMHj0aX758wbp16xAYGFivh04jIyNRUFCAXr16ITQ0FG/evEFsbCzKy8thaGgIBQUFBAQEoH379jU6dOrj48N66PT48eMoKCiodrVbGtRl3qJQmgsty8ugNFueP3+Offv2YcOGDbh69SpsbGxgY2ODI0eONClnWJrauSoqKkyK3q91huujPTYnis2h7d69e7XOsKS6lLqRmpqK06dPIyAgAPb29mK7K/3790dcXByKi4uxZcsWKVlZfxw/fhw//vgjpk+fjpMnTwJAizl0SqFQGoem42lQWjW//fYbNDU1oauri6lTp2LSpEk4ceIE5OTkpG2aCCUlJVQ7l9LkOXnyJIYPH45JkyZJLNOpUyf89NNPCAgIaNbxxGVlZThx4gR27tyJOXPm4NGjR7h27RqAlnHolEKhNA5Uh5giddzd3eHv74/ffvsNkydPxvjx4xEQEICIiAjEx8cjLS0NWVlZrNuL+fn5WLVqFUpKSmBgYIAVK1aIbVfGxcWhvLwcs2fPRlxcHG7duoVVq1YhJCSEaf/KlStYu3YtsrOzoampiRMnTsDLy0uihi7VzqU0Ze7cuVOjJBqGhob49ddf8ebNm2a7Qh8bG4tJkyYxqav//fdf+Pv7Q1dX96sPnc6bNw9Lly5l7dfW1hZ2dnYoKSlhPXQ6ZMgQ5tCpkpIScnJyoKenJ3LoVFdXF4sWLcKTJ0+QmZlZPy+E0ip58+YNXr58iffv36O8vBwFBQWQl5eHqqoq1NTUoKqqClVVVXTt2rVVn8epCuoQU6ROUFAQtLS04O3tjXHjxiEwMBBt2rRBUVERHj16hIyMDJHtxbCwMHh4eODw4cMIDQ2FgYEBVq9eDV9fXwQEBDBtBQcH4+jRo1BTU2P+QeTxeCgsLAQAkfbDw8OhoaGBlJQUHDlyBJ6enigrKxPrT4DwFuimTZvw7t07qbw7CoUNHo8HJSWlassJyghiZZsjx48fFwljmjp1Kn7//XcMHDiwzm0aGRnBw8MDly9fRnFxMSIiIjB37lyRMoJDp6NGjRK57uTkBFdXV4SHh6O4uBg7duyAvLw8nJ2dERYWhqKiIvTu3Ru2traYPXs2UlJSkJubiwMHDtTZXkrr4cuXL7hy5QoyMjKQlZWF7OxsPH78uEYHOoGKULkBAwZAV1cXAwcOxMiRIzFixIgmtxsrDahDTJEaPj4+OH78OJ48eQJZWVl06NABf//9N+Tl5ZkylpaWUFJSQkxMDHMQqKysjIl9nTlzJpYsWQIDAwNYWVnh0aNHjIavsbExDh06BFtbW6a9ytuSgvZjY2OZQyyurq5YtmwZa38CEhMTsXbtWgAVW6DBwcH1/4IolDrSvXv3GikVPHr0CG3atGnWOxwhISEif6urqyM/P1/kmqmpqZhaioBt27Yxv4eHhwMABg0ahJEjR0o8dGpjYwOgQhZSwMWLF5nfY2NjxQ6dXrp0SezgaGRkpNihUxcXlxo9N6X1wOPxEBoairCwMCQkJIDL5aJ79+7Q09ODnZ0d+vbtC21tbXTv3h0aGhqQlZWFmpoaSktLweVyUVhYCA6HAw6Hg/v37+PevXu4e/cuzp8/j9WrV6NTp06YOHEiJk2ahIkTJ0JFRUXajywVqENMkRorV66En58fZGVlMWLECCQkJEBRUVGkjGDLU9L2YkpKCv755x907NgRTk5OkJGREduuVFRUZFZw09PT0a5dO7H2dXV1kZubi2HDhuHYsWMAKmIEJW1nCrRzhbdA64K9vX2d61Iokhg/fjzWrVuHd+/eQUNDQ2I5Pz8/jB49WuQzQalA2Clo6EOnFAob9+/fx/bt2xEcHIzi4mJYWFhg27ZtsLS0lChjKUzbtm3RqVMndOrUibk2ZswYkTK5ubmIiopCTEwMnJ2doaKiggULFmD58uUiYYKtAXqojiI1fHx8cPPmTWhoaMDHx0fMGRZGkqatmpoaHB0d4ebmBh6Ph23btolp5JqZmeH8+fMwNzfH9evXWdufOXMmAgIC4ODggDNnzuCPP/6oUkP3a7VzdXR0YGdnV+t6lPrFzs4OOjo60jaj3nFxcYGqqip+/PFHfP78mbXM7t27cfbsWfz222+NbB2FQqmKBw8ewMnJCQMHDkRqair++OMP5Ofn48yZM1i8eHGNnOGa0q9fP/zyyy9ISkrCq1ev4O7ujhMnTqBXr16YNWsWnj59Wm99NXkIhSIF0tLSiJycHNHU1CQ8Hq/G9fLz80lxcbHINT6fT168eCFy7f3792J1P336VG37HA6n2v6EefnyZbVtUijSIDMzk6irq5N+/fqRgwcPkjt37pDc3FwSFRVFrK2tiYyMDPH09KxRWwBIUFBQA1tMaeoEBQUR6jY0HJ8/fyYbN24kCgoKZNCgQeTUqVOEz+c3uh0lJSXE19eX9OvXj6ioqJDt27eT0tLSRrejsaEjm9LoZGZmknbt2hE5OTnyf//3f9I2p1748uWLtE2gNBLnz58nUVFRdaqbkJBAIiIiSHp6Opk8ebLIF7fMzEyxa5K4f/8+2bt3b5V9FBYWEhcXF/Ljjz8SJSUlAoAAILKysqRXr14kPj6+xnZTh5hCCHWIG5I7d+6QgQMHElVVVeLt7d0kHNDi4mLi4eFBFBUVyffff09u374tbZMaFBpDTGlUUlJSMHHiRHz58gW///47+vfvL22T6szDhw+xfft2xMTEID8/H23atMHgwYPh7OyMJUuW0LjMFsrQoUPB5/PrVPfp06eMHq4g/a+rqyuA+kv/K+hj1KhRyMzMxJ07d3D48GE8ePAAX758QUFBAcLCwmBmZlYr26Ojo3H69Ola1aG0LOic1jCcOHECCxcuhJ6eHs6dO4dvvvlG2iYBqJAm3LhxI2bMmIG5c+fC0NAQAQEBsLKykrZpDQJ1iCmNxsWLFzFp0iSoqqpCU1OTUYNojoSFhWHWrFnQ1NTEgAED0KdPH5SVlaG0tBS///47jh8/jvPnz0NLS0vaplKE2LFjB2xsbNCnTx+R62ypejt27CiS/vfjx4/Ys2cPHjx4UOf0v8JMmjQJISEhcHV1RXl5ObKysjBkyBAAFZKANUn/W1paKqbPzUZJSQn8/Py+Sjf7wYMHyM/Px4gRI2pdl9L8SU9Pb3WHrBqDv//+G+vXr4ebmxu2bt2KNm2anlvWt29fJCQkYMmSJbCxsYGnpyfc3NykbVa90/TePKVFEhsbC1tbWwwfPhyXLl1CbGxsjdL5NkWys7MxY8YM9OzZE7m5ueDz+fj+++9BCMGNGzfA4/GQn58Pa2trXL16leo71jOJiYmMDBaXy4W2tjYuX74sllL7woULKCkpgbW1NXPt4cOH+PTpk1ibeXl5mDZtGlJTU/HNN98gMDAQS5YsQVFREd6/fw9zc3P8+uuv2LhxI2xsbBidX0H634ULFzLpf01MTPDs2TOUlJRg1qxZsLa2hpeXFwIDA0W0gTt37ozXr1/jzZs3uHPnDsaMGYP09HQA/6X/FdbT7tSpk5j2NZs+t6Ghodjz1Zdu9ogRI+gqcSvF3t5eTM6O8nWsXbsW27dvx+7duyUmgGkqtG3bFkeOHMGAAQOwevVqfP78GevXr5e2WfUKVZmgNDgxMTFMOubHjx/D3t4e48ePl7ZZdYLD4WDq1KlQUlLC+/fvERoaisePH8PLywuWlpZ48uQJTp06BUIIbt68SZ2HBuDp06fIy8tj/vvmzRvcuHFDrNzQoUOhr68PoELRZPTo0YiIiMCcOXMwevRo/O9//2PKKisrIzo6Gn5+fmKpevv06YO8vDwYGhqK9dNc0v+y1a0LISEhkJGRoT+t8Key3jPl6/D09ISXlxd8fX2bvDMszKpVq7B3715s2LABhw4dkrY59QpdIaY0KKdPn4azszNcXFzA5/PB4/Gwe/duaZtVZ7hcLh4/fgxZWVlkZGQwDpcgplNWVhbTp0+HtrY2jIyMsGfPHjg6OkrZ6qaFpLCFoqIikfTZQUFBKC8vr1FIABvJyclMaMPdu3ehqqoKBQUFeHh4wNLSUqTdIUOGQF9fHzdu3ICuri5KSkrg7u6OyMhItGvXDoaGhhg3bhySkpLw9u1bJlFLU0z/W1RUJNZPfehmW1lZMclrKK2T3NxcZheDUneCg4Oxdu1a7Nq1C87OztI2p9YsWrQIb9++xZIlS9ClSxdMmTJF2ibVC9QhpjQYp06dwqxZszB//nxMmTIFlpaWCA4OhqamplhZSU5SSEgI4uPjkZaWhqysLFbnaNWqVSgpKYGBgQF+++031vjLuLg4lJeXY/bs2YiLi8OtW7fQo0cPpu0rV67UyBl7/fo1CCEwNzdHv3794O7uzhqXOWrUKPTp0wd3795t2JfcDJEUthAZGSmSPjsrKwvv3r2rUUgAGxwOhwltKC0txdmzZ2FmZoYzZ86gTZs2Iu0eOXIEly9fZmKFL1y4gLlz52LVqlWIiIgAAAwfPhxKSkq4evWqxKxnwkgr/e/t27fFbHF2dharW1v69euH6dOn17oepeVAM3J+PTk5OXB1dcWSJUvEwryaExs2bEB+fj7mzJmDYcOGNZmDgF8DdYgpDcK///6LBQsWYNWqVVi/fj0GDx4MR0dHickoJDlJRUVFePToETIyMljjJXV1dWFgYIDVq1fD19cXPB6PNf5STU0NhBAAFWkwCwsLRdoODw+vkTO2ZMkSABUrbtXFZXbv3h2PHz+u3xfbjPHx8UFYWBgePnyIjIwMKCsrw8/PjxGZr5w+G0C1KbRrioGBAYCKSTwkJEQsFbimpib27duHiRMn4uTJk5g2bRosLS2hp6eH7777DsHBwTA3N8f8+fMRExOD8PBwZkUYaFrpfwW7FgBw584dABWJYNjqUiiUxqOsrAwzZszAwIED4e3tLW1zvpqdO3ciNTUVs2fPRkJCApP5tbnSvK2nNEkOHjyIBQsWYPXq1fD09MSyZctQWlrKGipRXWwnAFhaWkJJSYk1XnLmzJm4du0aDAwMkJeXByUlJdb4S2GE4ywFbcfGxmLy5MkAKpyx4cOHs/YnWN1+9+5dtXGZr169Qnl5+Ve8yZbFypUrkZKSAhsbGxw9ehQpKSkiGZcE6bOBCgmyrKwsDBs2DHZ2dggICICXl1ed5X4EE7XgSxFbu8rKyky54cOHIycnBwBEQgxmzZrFOPQ1QUVFhXHiGzr9b00OqTYlZ/jChQs4c+ZMneomJiYiMjISQEUctb29PSwsLLBr1y4AFbsDDx48kFi/uvsUSkPg4+ODnJwc+Pn5oW3bttI256tp164dTpw4gbS0NEydOhVOTk6ws7PDr7/+irS0NGmbV2uoQ0ypV/bt24fFixfj999/x9atW3H06FEEBAQwp+QrU52TBPznzLA5MSkpKfjnn39w+fJl3L17F5mZmUz8JQAm/lJRUZFZgRaOgRO0XVNnTF5eHrKysoiOjhbpp3Jc5rVr13D//n107ty5Pl5ri0JwSKcyldNnf//99xJTdlcmKioKBgYGzI/A8ZVEde1KSs2tr68PXV1dMQk1Su0RPvRYWwQHKgsKCuDl5YW9e/fi+PHjuHLlCi5duoTbt29jx44dEutXd59CqW/y8/OxadMmrF+/Hv369Wu0fgVf/u7cuQMbGxvY2Nhg+vTp8PLywpcvX76q7dLSUhw7dgx8Ph/Xr19HcXExCCE4dOgQjIyMMHHiRLx79w65ubnYt2+fxHaqu18XOBwOa0hKVX3RkAlKveHp6cnIyLi5ueHu3btYvnw51qxZgwkTJlRZV5KTJAxbvCSXy4WjoyMGDRoEHo+HoUOHolu3bmLxl3Jycpg7dy4uXLiA8vJyGBkZibQ9c+ZMLF68GOHh4SgtLcXs2bPRq1cvsf6AilW/t2/f4sqVKzh79qxYXGZ2djamTZsGZWVlZtWZ8h/79+9nvd69e3dERUWJhBaoqalVGRIggE1GbP78+WLXTE1Nmfjfyu0CNQsxcHJywvbt2+Ht7d1spQMbiproOcvJycHHx4f5B/Rr9Jxfv36Nz58/Q0ZGBlpaWti9ezcKCwvh7u6OmzdvIjk5GWPGjBGr7+3tjZs3byIuLg7p6eki5wSo1i6lIdi8eTM6d+6M1atXN2q/t2/fhr+/P2bMmAEAOHLkCJ49e4adO3di/vz5tTqoXBnBv7O+vr5wcnKCrKws3r59C1NTU4SHh8PFxQXjx4/HP//8IzGREFB1oqG6UlJSgqSkpNr1JbUceZQWxdatW4mMjAzZtWsXIYQQHo9HhgwZQn744Yd6T2ucn59PiouLmb/5fD558eKFWDm2FLifPn2qsm0Oh1Ntf9nZ2URWVpYoKysTDQ0N4urqSvbu3Ut27NhBpk6dStq0aUO++eYbIi8v32JSU1P+Iz8/n8jJyZHw8HBpm9JogCV1c1lZGfny5QspKytjrj148IBJa+3p6cmklz506BD58ccfCSGE+Pn5kd9++40cOnSI7Ny5kxw6dIhYW1sTQghZsGABWb9+PSGEEGNjY/L06VPWNo8dO0a8vb0JIYR4e3uT7777jujr65NNmzYRDodDUlNTycKFCyXaJLh/9uxZsmHDBkIIIaGhocTV1bX+X14LgqZurhsPHz4kcnJyZOvWrWL3Dh06RGbPnk0mT55MHB0dSV5eHuHz+cTe3p5YWVkRKysr8uHDB3L69GmycOFCoqurS758+UL++OMPMm7cODJ27Fjy7NkzQgghAQEBZN68eWTChAlk0qRJ5MGDB8TW1pb06tWL7Ny5k0yfPp3pl8/nEx0dHVJSUkK4XC5ZuXIlMTU1JY6OjuTly5esbRFCmLLff/89AUBOnjwpYtubN2/IoEGDCIfDIQsXLiSysrKkX79+ZOnSpSLPzeFwyJo1a4iJiQmxtbUlS5curZMdwmXZ7JDUFxs0ZILyVRBC4O7ujnXr1uHw4cP46aefAABLlizB8+fPcfr0acjLy9drn5XjJWVlZVkzb7HFXwonRmCDLc6zcn9DhgzB3r178fnzZ3z69AlhYWH4/fff4eXlhRcvXkBXVxf5+fk4ePBgs05NTWGne/fuGDNmTKsPm9i8eTP09fVFMk5Wpb0sONioo6PDpK8WUFc957dv38LV1RU5OTkIDQ3F8+fP4ePjI9J2VfVrquNMoXwNe/bsgZKSEnO2RZiCggIoKioiMjISCxYswMGDB5GXl4dZs2YhOjoaxsbGCAwMlHjAfOnSpfDw8ABQcQhdoKgzffp0+Pr6ws3NDePGjcP3338v0q+srCwGDx6MGzduMAfRExMTMXXqVBw9epS1LeC/pEFDhgxB//798fjxYxHbBAQEBKBHjx4YPHgw3rx5I/bcwofSBw8eLNJ2beyoXLayHZL6YoM6xJQ6w+fzsXDhQnh7e8PX1xfz5s0DULEl7ufnB19fX+jo6EjZyoZh0aJF8PX1xefPn/Hhwwe8e/cOr169QkZGBhQUFJCUlIQ5c+ZI20xKAyH4x+r9+/fSNkVqbNq0Cbdu3RKJxRVoL4eEhEBXV1ekfOWDjcLURM+Zrc3r16/Dw8MDhBD06NEDCxYsQGZmpkiZqurX16FNCkUSW7duxZ49ewAA8+bNYz04LpBd1NfXx8WLFyV+iavqgLmAqr54VqawsBA9e/aUeBCdrS1B2ezsbIwfP54pK7BNwIEDBxAcHIynT5/i48ePCA0NFXlutkPpdbGjctnKdkjqiw3qEFPqxJcvX+Dk5AQ/Pz8EBQVh5syZAIDU1FSsWLECHh4eLf4fF4FcVkpKCmJjY3H+/Hk8e/YM6enpGDNmjJStozQk06ZNQ5s2bWj2rkoYGRnh2LFjmDdvHj5+/MhoODdUmxYWFnjx4gUMDAzg4uKC1atX49dff0XPnj1x8eJFpKSksNYX3O/cuXONDm1SKHVFS0sLsrKysLW1lXhwXHA4+9q1a9DR0ZH4Ja6qA+aVy7B98RQmMTERpaWl6NKlC+tBdEltCcoWFRWBw+GIlRXg4OCANWvWMOd1rKysRJ5bkCwI+O9Qel3skFRWGLa+2KCH6ii15tOnT5g2bRrS0tIQHR0Nc3NzAMCTJ08wbdo0TJo0qcXlOGcjOjoaPXr0EDugR2n5tG/fHjY2Njh58iQWLlwobXOaDOPGjRPTXgZEDzgKH2ysTF30nAMCAsDj8cDlckWS/mRnZ0NOTg5ycnKs9QX3ra2txQ5XUij1RXBwMCwsLNCuXTuJB8cjIiKQlZWFFy9ewN/fH2/evKkyqQ/bAXNJCL78DRo0CAkJCRg1ahRkZWXRoUMHnD59GgB7IqCEhATW9gRlORwOkpOTER8fj0uXLomVEyQDysnJgaysrNhniy1ZUF3sEC7LZoekvlipe5i4dABAf2r5U/kwzNfw4cMHMmrUKKKpqUmysrKY6zwej+jr65OhQ4eSoqKieuuvqZKcnEwAEA8PD2mbQpES4eHhRFZWluTn50vblAanvucRSvOEHqqrHYWFhaRt27bE19dXYplt27aREydOkLdv3xI+n89c53K5zL+lbIe9CRE/8C2JkpISkcOvkmA7iC4Jd3d30q1bt2oPqhsbG5OJEydKvP/y5cuvsqM2Zdn6EqZZrhCvWLECI0eOlLYZzQIHB4d6a+vly5ewtLREYWEhLl26xGgp8vl8ODs748mTJ8jMzKxzNrHmxKZNmyAjI4MVK1ZI2xSKlJgwYQJUVFQQFhbWrFOwUiiUhiElJQWlpaUYP368xDIKCgqQl5eHhoaGyHUVFRXmd0lJfbp3714jO2qaBITtILok3NzcsH//fixbtgyHDx+GnJycWJm9e/fi0qVLIhk4K8OWLKg2dtSmbHWJiZqlQzxy5EhMnz5d2mY0C+rLIc7Ly4OFhQXatm2L1NRUEa3OFStW4Ny5c4iLi8O3335bL/01ZYqKipCamor+/fujffv20jaHIiUUFBQwadIknD59mjrEFApFjKSkJAwaNEgklKcyP//8cyNaVH906dIFp06dgq2tLXJycrBmzRqMGDECcnJyuHv3Lvbv34/Tp0/j77//xujRo6Vtbo2gh+oo1XLnzh2MHj0a6urquHTpkogzvG3bNuzbtw8nTpxoNbG0x48fR1lZGWviB0rrwt7eHmlpaXj+/Lm0TaFQKE2MxYsX49ChQ9I2o8GYMGECMjIy0L59e0ybNg3dunVDly5dYGpqitzcXERHR8Pd3V3aZtaYZrlCTGk8Ll26hMmTJ2PYsGGIjIwU2bo5deoU1q1bB29vb0ybNk2KVjYuO3fuhIyMDBwdHaVtCkXK0LAJCoUiid69e0s+wNVCGDJkCGJjY/H+/Xvcu3cPZWVl6N27N7755htpm1ZrWvQKcUPk7gYq5EoiIyPrwcLaI8hL3hhER0fD0tISJiYmOHv2rIgzHB8fj9mzZ2PlypXNdsunLly9ehWPHj3CwIEDWZOBUFoXCgoKsLa2Zk5rUygUSmukU6dOGD16NExNTZulMwy0cIdYIJp/5MgRrF27Frdv366Xbe6nT58iLy/vq9upC7dv3xYRwm8oTp48CVtbW0yfPh0hISFQVFRk7qWlpWHKlClv/xA0AAAgAElEQVSwt7eHp6dng9vSlDhw4ADatGnD6C5TKDRsgkKhUJo/LdohBgBFRUV07twZw4YNw/Hjx5GUlIQvX76gtLQUmzdvhoWFBczMzJCfnw8bGxsmk8qePXsQEBDAWk5AUVER3NzcMHbsWMyYMQOvXr3C4cOH4eLiAhsbG8yYMYNpLzAwEDNnzoSZmRmMjIzg7u4OExMTrFu3TmIfgYGBcHV1xcSJE2FtbY2HDx/C29sbcXFxSE5ObrB3tmfPHvz4449wc3PDsWPH0KbNf5E12dnZsLa2hrm5OY4fP84qgt1SKSwsRGBgIMrKymBjYyNtcyhNBEtLS6iqqiI0NFTaplAoFAqljrQebwaiubvZcoGbmpoy/6idPHkSlpaWEnOGA+y5tNnykgNgsrokJCRg0KBBkJeXR3JyMi5fvozAwMBa5yU3MTFpkHe0bds2/PTTT/j777+xdetWESHx3NxcjB8/Hvr6+jh16pSIo9waOHHiBPh8Pnr37o0BAwZI2xxKE0FYbaK101ghXXUJW6vONsH9Cxcu4MyZM7Vqu6HC8yrbxxannpubi3379tVrX5TaISMjQ39q8dNUaV0eDf7L3e3v74+cnBw4OTmhrKwMysrKcHJygq2tLSZPngwdHR2oq6sjJiZGrJyA2NhYrFmzBkBFLu1Dhw7BwsJCJC/5unXrmPICJ1ZNTQ0//PADgAoNvdjYWLx584a1D+Ec3hkZGQ32XgghWLp0KQ4fPox///0Xc+bMEbn/8OFDmJqaom/fvoiMjBQJoWgt+Pn5QVlZGdbW1tI2hdLEsLe3h62tLZ4/f15jbdCWyO3bt+Hv719l5qz64OnTpygoKKhVnepsE9z38PAAn8+vVdvC4XnPnj3Dzp07MX/+fPj6+taqnaooKSlBUlKS2PXCwkLcu3ev3vqh1A2aH6F6rly5gp07d0rbDIm0KodYOHf3sGHDoKuri0WLFjEJJbp06QJ1dXV4eXnBxcUFAFjLFRUVAfgvl/aQIUNEcmlXzksuQDh1oeBbEiEEAwcOxJgxY0T6EFDTvORfi4yMDNTV1XH69GlMmTJF5F5ubi7Gjh0LbW1tREdHQ0lJqUFtaYo8ePAAV69ehYyMDCwtLaVtDqWJIRw28dNPP0nbHKnh7e2NmzdvIjk5Ge/evUN8fDzS0tKQnZ0NR0dH8Hg8AIC/vz9iY2ORkJCAFy9eQE5ODj4+PlBUVMSqVatQUlICAwMD/Pbbbzh8+DDS0tJQUFAAJSUl/PXXX0x/5eXlYu127NgRgYGBYm0LbEtMTMSBAwfE6gjuy8jIYMSIEZg2bRo2btyImzdvQlNTEz4+PkhKShJrt0+fPgD+C8/r3Lkzjh8/jm+//RYfPnzAli1bRNro2rUrq31du3YV6y81NZV5h4mJicxzc7lcbNmyBVevXoW6ujo94NsEoPkRakZTdohbfMiEIHe3kZERduzYwWxr2tra4ty5c3B2doadnR169uwJAJg1axbOnj3LZJaRVA6oyKV99OhRzJgxAwcPHmSc6IiICFhaWmLFihVYv359tTaam5tL7KMygrzkKSkpdX0lEtmyZYuYM3z//n2Ympqia9euiI2NRYcOHeq936+BbRuxIbYQfX19oaamBkVFRYwZM6Ze26Y0f1qj2gSfz0dpaanIaqpwSFdRUREePXqEjIwM5OXlYdasWYiOjoaxsTECAwNZQ8JCQ0NhYGCAiIgI6OjogMfjSQxDA8DaLlB1uNk333zDWkdwf9iwYfj48SNrSBxbu2wIwvN+//13sTYk2SepP8E7FCYgIABqampISkrC4MGD6/X/K4XSWmnRK8TGxsZ49+4d6z01NTVERkbi+fPn0NDQYFZv7e3tYW9vX2U5fX195n5sbCw+fPggkj5w/fr1GD9+PNTV1ZkVXmF1i23btjG/h4eHAwCrLcJ1TE1NYWpqCqDiYBtbmsT65v79+xg7diy+/fZbnDt3rklmZWPbRqzvLURCCAICAqCpqYlevXqhXbt29dY2peVgb2+PKVOm4NmzZyI7Qy2VzZs3IywsDOPGjZOofGNpaQklJSUoKysjKioKvr6+ePv2LWxsbCAvLy8WErZixQosWbIEBgYGsLKyYnajKoeh9e/fHwBY2xUgKdysqjrCsIXEOTg41DiMrbCwEPfv32fmcUEbgjC6yu2w9Tdz5kzmHX769IlpOzExEWvXrgUAjB07FsHBwRLtoFAoNaPFrxBXR/fu3UVCGepSTtgZFs5LXlsFhpra0rZt2wZ1iHfs2IGYmBgYGxujV69eiI2NRfv27RESEoJFixYxKxJs6hj5+flwcHDAlClTsGXLFlYlDqBim1KwuhIXF4cdO3aItF9UVIRly5Zh9OjRsLOzY1ajJCl+cLlcuLu7w9TUFFu3bq3X95GSkoL//e9/ePHiBQ2XoEhk/PjxUFVVRUREhLRNaRQ2bdqEW7duVSkDKZgDDxw4gBEjRiAkJAS6urpi9wUhYSkpKfjnn39w+fJl3L17lwkfkxSGJqldtrZrUkcYQUgcAJGQuJqEsQnC88zNzVnbYGunuv6E0dPTY8reunVLoh2UlkNjHNxs7bR6h7i++fnnn5t9HFFaWhqcnJwwcOBAnDt3jknIUXn7jk2Bo/KWZ0BAAOuWIZfLZWKxeTweCgsLRdqPjIyEhoYGUlJSYGlpiaysrCoVPxpyC9Hf3x99+/YFl8vFhAkT6rVtSstBQUEBEyZMQFRUlLRNkRqSQrqMjIxw7NgxzJs3jwlHYENNTQ2Ojo5wc3MDj8fD0KFDAUgOQ6tpu8K2EUJY61S2XVJInCTYwvNq00Ztyjo7O2P//v2wt7dHTExMlXZRWgYNlVeBIgRpZgAgQUFB0jaj2VCb9+Xt7U0GDx5MZGRkSIcOHcioUaNIXl4ec//YsWNk+/btzN9Lly4lZmZmZMaMGcTe3p64uLiQd+/ekenTpxN9fX2yceNG4uzsTLKzswkhhLx69YqYmZkRQgjZu3cv2bNnDyGEkJCQELJhwwaR9mfOnEmuX78uYh9bf2/evCGDBg0i06dPJ1lZWYQQQi5evEiWLl1axzcmyufPn4mamhoxNzcnPXv2rJc2KS0Xf39/Ii8vTz5+/ChtU+qV2swjJSUlpKysTOw6l8slRUVFhBBCOByOxPp8Pp+8ePGC+Xvbtm3kxIkT5O3bt4TP59e5XWHbJNVhs/39+/dVtlkTatNGbcq+fPmyLubUmaCgINIM3YYGpzH8kuTkZDJ9+nTmbz6fT3R0dMj79+/JypUriampKXF0dGTGREBAAJk3bx6ZMGECmTRpEnnw4AHhcrliZU+fPk0WLlxIdHV1G9R+Qpr++KErxBSG3r1748GDB+jduzdzsrnyAT/h7bthw4bBzs4OAQEB8PLygpWVldiWZ0lJCes2oKKiIhMTl56eLta+rq4ucnNzAQDHjh1DVlYWa38CGmoL8cyZM+ByuXj16hUmTpxYb+1+LcHBwVLXkmwqP00pfnLixIkghCAuLk7apkgNSSFdKioqjKSkcBr4ysjKyoqoJlQXhlbTdoVtk1SHzXbhkLi6Ups2alO2a9eudTGH0gJo6IObrZFme6hO+OAb5eshhGD79u1wdXVFaWkp5OXlq61ja2uL2bNnIyUlBbm5uThw4AC4XC4cHR0xaNAg8Hg87NmzB0uWLEF4eDiKi4uZeEMzMzPMnTsXFy5cQHl5OYyMjETanjlzJhYvXozw8HCUlpZi9uzZ6NWrl1h/ApydneHs7IywsDAUFRWhd+/e9fJeTp48CWNjYyQlJYnIPTUVgoKCpG2CVHFwcJC2CSKoq6tj5MiRiI6Ohp2dnbTNaRH8/PPP0jaBQmmS1PfBzdZOs3WIQ0JCMGLECGhra0vblCaL8MprdcjIyCA2NrbKD4WWlhY6derE/C1JqWPMmDF4/fo1s8rDpsTRo0cPJCQkgMfjoaysDK9fv0bfvn2ZLFHW1taIiooCl8tlVnDY+uNwOAgPD4eOjg4uXbqEV69eSVw14XA4WL9+PXbv3i1yPTc3F/Hx8ViyZInIdS6Xi/Pnz2Pu3Lm4dOkSjI2Na/w+G4vmHq/+tTQ1hxgAJk2aBE9PT/D5/EZRg6FQKK2Pygc3K+dDACQf3KxctrYCAC2VZusQA8DKlStbvUNQFfb29ggJCalx+eq+IQ4dOpQ1g1PlzFyVtzwByduASkpKSEtLYzJIVe6DbQtUuL/K2aeq2kKsbaanqKgo8Pl8fP78GQYGBk1Sdo7S9LC2toa7uzsyMjJE/nGiUCiUr0FwcFNWVhYdOnTA6dOnISsrC1dXV7FdWDacnJzEyl66dKkRn6Bp06wdYgcHhya5QtTc2bFjB2xsbJgMTAKSk5NRXFyMtm3bsmZrsrGxwc6dO9GzZ0/s2bMHqqqqePr0KVJSUsDn8+Hr6wttbW3k5+eLZKO6ceMGk93q9evXKC4uZrJE3blzB9ra2vjuu++wevVqsaxUwpmxDAwM6jXTU2hoKMzMzJCWloZp06Y17EuntBgGDBiAPn36IDo6mjrEFAqlXqgqrwLbLqykPAaVy/bq1asBrW5eNFuHuLXHTtaUunxhePjwoYgIvAAOhwMejwclJSUmWF+gJ7x582aYmpoiNDQUv/zyC06ePIlly5YxMmlhYWHw8PDA4cOHGWm21atXw9fXFz/88ANCQ0NhYmKCw4cPg8fjITw8HAMGDIC3tzfWrVuH169fM1mprK2t4eXlhcDAQLi5ucHf3x8mJiY4ceIEtLS04O3tjeDgYBw9ehRaWlrMgQHhZxKWadu0aZPYRMPj8XD+/Hl4eHggNjaWmUxaIo8ePYKbm5vItXnz5mHy5Mm1bktS+Elrw8rKCmfOnGmScecUCqXl0VAHN1sTzdYhpqESNaM2DrGPjw/CwsLw8OFDZGRkQFlZGX5+fqyppNmyNTk5OcHW1haTJ0+Gjo4Orly5gpycHDg5OaGsrIw51T1z5kyRbFSVV6IB4MKFC0wmJnNzc0RHR1ebYao+Mz1FR0ejpKQESkpKaNu2bYte6fv48SOKiorw77//MtfqOmHWd5bA5oq1tTV27dqF//3vf1WmYqdQKBRK06DZOsSU+mflypVYuXIlFi1ahEWLFuH777+XWJYtW1OXLl2grq4OLy8vuLi44NWrV9DV1cWiRYvw5MkTJuuUQJqtY8eOcHJyQseOHcXa19PTw7179zBo0CBGKF+QYWrevHlYunSpWJ3aHBgQyLTp6emxyrQJVqyvXbuGESNGMM58S6Vdu3b49ttvRa75+/ujvLwcs2fPRlxcHG7dugUtLS2xcBlNTU3W8JPS0lJs3bpVJGQmPT2dCWG5ffu2FJ60cRgzZgzU1NQQExODZcuWSdscCoVCoVRDqzlamJubi3379n1VG4mJiYiMjKwni2oHh8PBgwcPwOFwsHz5crH79fF8AgT6rnVh1qxZOHv2LMaPHw9bW1ucO3cOzs7OsLOzY1bKKmejmjJlilh2KwcHB/j5+cHExAQXLlxAmzZtWLNSCWeXqq9MT58/f8bZs2cxbdo0JCUltehwCQGpqakwMDCAgYEB/t//+38AJGcTrKxtKSlLIFtmwdaieSkvL49x48bhzJkz0jalUQkJCRHLUldTzp49KxLn39gIz6ExMTGwt7eHhYUFdu3aBeC/ObgmCNRyKBRK86HVrBDXx1bu06dPUVBQUE8W1Q6BmsLmzZtrpZRQF/bv3896nS1NpHCwPlChbCHQiJYky2ZiYiImzZadnQ05OTmMHj0aQEVyjZ07d+Lbb7/Fnj17oKKignHjxmHkyJGQkZGBsrIyI8kmqCsnJ1flgYHOnTvjzp07AFClTNv58+fB4/Ggp6eHx48fY+zYsXV6j80JIyMjREdHS7xfVlbG/F45XCY3N5c1/CQmJoY1ZKa1aF5aW1vD1dVVRDqwpZOXlyeya1QbHj9+LNWdGMEcWlBQAC8vLwQHB6OsrAxubm7Q09ODnJyciKJNVUhS5KG0XKKjo3H69Glpm9GkadeunbRNqJIW7RCzKQmwbeMuXbpURB1BXV0d9vb2YuUEFBUViakZdO3aFYcPH0ZaWhoKCgqgpKSEv/76C+np6YiJicHLly9RUlICQ0NDRo7Jw8NDrA9tbW0EBgaKbUsL1BQsLS2rfL6mSGVZNkBcmq1t27Yi9zt27Ig5c+ZAVlYWfD4fYWFhACqyUgkQOBmV635tpqfIyEiMHDkSubm5UFBQwA8//FDj9loSioqKzGHD9PR0ZjKrHC4jKfxk2LBhYiEzRUVFrUbzcsKECeDz+YiLi4Otra20zWk0jh8/Dm9vb3Tp0gXe3t7o3bs3ysvLxRRi5OXlsXbtWmRnZ0NTUxMmJiYAgLdv32Lu3LnYtWsXunTpIqY2I5xJ88qVK6xz8deE+7x+/RqfP3+GjIwMtLS0sHv3bhQWFsLd3Z1RtHn37h1jQ3Z2ttizVafIQ2l5PHjwAPn5+RgxYoS0TWmSpKenN/m8ES3CIebz+SgvL4esrKyIED6bkoDwNq5A+aCyOkJMTAxrOUNDQwBg0h8KqxmsW7cOBQUFUFRURGRkJJKSknDw4EH07t0bHA4HCQkJWLhwIeTl5ZGcnAwTExMEBgayqjAIb0sLVBwEagoCGyQ9X0tBR0cH8fHxKCsrQ5s2jTdMy8vLce7cOaxYsQKpqakYPnw4s7Ld2qgum6AASVkC2TIZtuS44cpoaGhg+PDhuHDhQot0iCXNu5qamoiJiUFUVBQOHTqEbdu2sSrEdOjQARoaGkhJScGRI0fw4MEDdOrUCXZ2dti1axd69eoFf39/MbUZTU1NJuwmLCyMdS7mcrnMFzZBuE/79u3F5lVtbW2xObR///5wdHTE6NGjoaKiAmtra7i5uYko2hw/fpyxge3Z5OXlq1TkobRMRowYQVeJJWBvb4/8/Hxpm1ElLWKpZvPmzdDX12cUBgQkJiYyK6qCbe+YmBhcvnwZTk5OOHXqFMrKyuDk5ISIiAjk5uZCR0cH6urqrOUExMbGwsLCAkCFmoFw3JvgIJe+vj4uXrwIAMzKh5qaGrPaqK6ujtjYWIl9CG9LSwrTYHu+lkZjOsMAkJmZidevX2PSpElIS0tr0eoSAvT19VnDJQTZBKOiopCYmIg//vgD8+fPZw40mpqaYs+ePUz4ye7du3Hu3Dns2bMHwH8hM56enkhNTYW+vj5cXFywcuXKRn0+aWJmZoaEhARpm9EgSJp3x40bB6DiYOGVK1cAgFGIsbOzQ3R0NIqLixEbG8tI+7m6uqJHjx7YvXs33r17By0tLQAVsbiCz6C5uTnThyDspqq5WEBV8yrbHPr27Vu4uroiJycHoaGheP78OXx8fMTaFdjA9mzC1GQup7QMQkJCmDM49Ef0pzZJwqRFi1gh3rRpEzZt2iR2nW0rl20bt7I6gqRyggNGktQMACAnJwcAcO3aNejo6ACAyAqj4LAaIQQDBw7EmDFjxFQYAHYVh5o8H+XriImJwTfffANtbW3k5OTg77//lrZJUqem8b6SsgSyhcy0FszMzPDnn3+2SPk1SfPuo0ePAFScCxDMjWwKMbq6usjNzcWwYcNw7NgxPHv2DB4eHlBSUsLy5csRFBTEqjYD/Dc/SpqLvybc5/r164iPj4eXlxd69OiBBQsWwMPDA2ZmZiLPKWirOvWbmszllOaPlZVVq/qyXxdyc3ORnp4ubTMk0iIcYkmwbeWybeMCFeoIK1asYP6uaruXLf2hgIiICGRlZeHFixfw9/fH1atXJdpnbm6Ov//+W8wWNgRqCsKDSdJWNaXuREdHw9raGpcvXwYhBCNHjpS2SZRmjKGhIZSVlZGQkABXV1dpm9MonD9/Hnfv3gWHw8HOnTsBVBza9PDwwOXLl1FcXIyIiAgEBgZi8eLFCA8PR2lpKczMzCAnJwdHR0ccO3YMUVFRcHBwwKJFi7B3716UlpaKhIwBkufirwn3sbCwgJ+fHwwMDDB48GA8efIEf/75J7799lsxNRxJzzZr1qwGeLOUpky/fv1ofoRqqKz33+QgzQwAJCgoqFZ1Xr58KXYtPz+fFBcXV1u3qnLv378X+Xvbtm3kxIkT5O3bt4TP59fYvpraUlJSQsrKysSusz2fgLq8r9bK8+fPiYyMDDl79ixZt24d+e6776RtkkSCgoJIM/z41jvNYXyPHz+eODo6StuMr6K277mgoEDsGpfLJUVFRYQQQjgcDnNd+PfKZGdnk4cPH5KysjKyc+dOcuTIEdZylediAZ8+faqRvWxz6KdPn8irV69ErkmagyU9W0uDzjvsNId5qCnQ1MdPi14hFsC2lVvTbdyqylVWM1BQUIC8vDw0NDRqZV9NbamspiBA0lY1pXZER0ejXbt2MDExwbZt21pF/DCl4TEzM4OnpydzAK01oKamJnaNTSGm8u+VkaQ2UxlJyjJfE+6jpKQkVl/SHCzp2SgUSvOhVTjEjcXPP/8sbRMoX8HZs2dhZmaGNm3aIDMzs1lse165cgXe3t7SNoNSBebm5lizZg1u376NoUOHStucZoW01GYoFErro3UsV1Ao1VBWVoakpCRMmDABt2/fBo/HaxZ6ks+ePWsWp3cbgqZ8OEOYoUOHonPnzoiPj5e2Kc0W6gxTWgL5+flwcHDAlClTsGXLFgAVKe43b94MCwsLmJmZIT8/H3/88Qd2794NPp+PSZMmITc3V8qWtw7oLEOhAMjIyACHw4G5uTkSExOhoqKC/v37S9usGtMatS/t7e2bxZcBWVlZmJqaIiEhAatWrZK2ORQKpRFg0+kODQ2FgYEBVq9eDV9fX/B4PFy8eFEsH4GPjw9GjBiB+/fvQ19fH/369ZPy07QO6AoxhQIgPj4e33zzDfr27Ytr165BX19fJNlAU0faGpNU17JqzMzMcPHiRZSUlEjbFAqF0giw6XTPnDkT165dg4GBAfLy8qCkpMSa80BFRQXLly+Hn58ffv31Vyk+ReuCrhBTKAASEhKYhAKZmZkiSQCaMqNGjUJQUJC0zZAaDg4O0jahRpibm4PH4yE9PR3GxsbSNodCoTQwbDrdKSkp+Oeff9CxY0c4OTkhMzNTYs6D/fv3w9HREZ6enti4caN0HqKVQR1iSqunqKgI6enpWLx4MYqLi3Hv3j2sXbtW2mbVCG1t7VatfdlcHOJevXqhZ8+eSEhIoA4xhdJKUVNTg6OjIwYNGgQej4ehQ4eib9++YjkPVq5ciUWLFmHu3Ln44YcfYGVlBX19fWmb3+KhDjGl1XPx4kWUlZXB1NQUN27cQGlpKYYPH94gfT18+BBnzpzBo0ePICsri4EDB8LGxgbdunVrkP4oTQczMzMkJSVJ2wwKhSIlTExMMGbMGLx+/ZqZ89u2bYvIyEg8f/4cGhoaUFBQwOHDh5k6N27ckJa5rQ4aQ9yIcDgcLF++XOx6bm4u9u3bJwWLKEBF/PCQIUPQtWtXZGZmomPHjujVq1e99sHj8TB//nx89913+Pvvv3Hnzh3cvHkTa9asQc+ePbFx40bw+fx67VOY0tJSrFixos5xtzUdo3SMS8bIyAiZmZkoLi6WtiktCg6HgwcPHgAALly4gDNnzkjZIgpFMrKysqwLIN27d4eCgoIULKIIoA5xI1JSUsK6QlRYWIh79+5JwSIKUOEQC2KGBQceZGRk6q19Pp+PqVOnIjw8HCdPnsSrV6+QnJyMS5cu4e3bt/D09MT27duxbNmyeuuzMjk5OXj06BHs7OzqVL+mY5SOcckYGhqipKQE169fl7YpLYrbt28zKZuHDh1Kt5YpFEqdaNEhEyEhIYiPj0daWhqysrKwdetWpKSkgM/nw9fXFwCwatUqlJSUwMDAAL/99huKioqwceNG3Lx5E5qamvDx8UFcXBzKy8sxe/ZsxMXF4datW+jRowfT9pUrV7B27VpkZ2dDU1MTQUFBKC8vF+tP+Nsfl8vFli1bcPXqVairq9Mtcynx+vVr3L17F56engCAmzdvYuLEifXax7Fjx5CcnIwrV65g2LBhIvcUFBTw008/QVtbG9OmTYOjo2ODxJhu374d9+7dw+rVq6GrqysylrW0tJCQkIAXL15ATk4OPj4+6NOnD+sYLS0tFRvX6enpzGchMTGR6ZOOcVH69OmDbt26ITU1FYaGhtI2p0EQzJ937tyBtrY2vvvuO7i7u7OOm5SUFLFx16NHjyrHV3Z2NhwdHcHj8QAA/v7+8Pb2xs2bN5GcnIzXr1+juLgY06ZNE5vHk5KSWMc5hUKhAC1khZjP56O0tFRsy7moqAiPHj1CRkYG4uPjGa2/pUuXwsPDg9EEjIiIgI6ODng8HiIiIqClpYXExERMnToVR48eBZfLRVFREYCKre/CwkKRtiMjI6GhoYGUlBRYWloiKyuLtT9hAgICoKamhqSkJAwePLjR3hVFlLi4OMjLy2P06NH48uUL7t+/X+/ZxP799184OzuLOcPC2NraYsyYMThy5MhX9SXps7BixQoYGxujZ8+erGO5tLQUZ8+exfTp05kvi2xjlG1cC38WhKFjXBxDQ0OkpaVJ24x6gW2shYeHY8CAAbhw4QK6du2K169fA5A8biqPu+rGV15eHmbNmoXo6GgYGxsjMDAQbm5uGDduHExMTMDhcPDx40fWeVzSOKdQKBSghTjEbHp/AiwtLSVq/bFpAsbGxsLCwgIAYGxsLLLiBVRkNKvcdmxsLCZPngwAcHV1xfDhw1n7EyYxMRGWlpYAgLFjx9br+6DUnISEBIwaNQoqKiq4d+8evnz5giFDhtRb+3w+H1lZWTAzM6u2rJmZGa5du/ZV/VX1WaiM8Jg0MDAAUJEqt6CgAAD7GJU0rgWfBWHoGBfH0NAQqampKC8vl7YpXw3bWLtw4QJGjRoFACLShZLGTeVxV934UlZWRlRUFOzs7BAdHS0xHlvSPM42zikUCgVoISETbHp/AmRlK3x+Nq0/Nk3AIUXx/rgAACAASURBVEOGICcnB0OGDMGNGzcwatQoKCoq4t27dwAq0sW2a9dOpG1dXV3k5uZi2LBhOHbsGIYOHcranzB6enrIycmBnp4ebt261UBvhlIdCQkJWLBgAT5//oxLly6hbdu2KCsrw/Xr1/H582cUFBSguLi4xr9Xvvbx40cQQqCmplatLR07dsTHjx+/6nmq+iwAqHYsE0KYsmxjVJJmpqC+MHSMi2NoaIiCggLk5ORg4MCB0jbnq2Aba3p6erh37x4GDRqElJQU5jrbuCkoKBAbd9WNrwMHDmDEiBGYN28eli5dKtE2tnkcYB/nFAqFArQQh7gm2Nraimn9cblcMU3Abt26wdXVFeHh4SguLsaOHTsgJyeHuXPn4sKFCygvL4eRkZFI2zNnzsTixYsRHh6O0tJSzJ49G7169RLrTxhnZ2c4OzsjLCwMRUVF6N27d2O+jmYHl8tFSUkJOBwOPn36hOLiYhQWFjJOaEFBAUpKSpgwgJKSEhQVFVVZ79OnT+BwONiwYQM2bNjA9PX999+L9N2uXTsoKiqiY8eOUFBQgJKSEjp06AAFBQWoqKigS5cu+Pz5M96/f4/x48dDUVERHTp0YOrNmTMHz58/B1BxIn79+vXYvXu3SB+5ubmIiopC165dG/Q9mpmZVTmWhWEbo2yfo9u3b9e4fmtHT08PKioqSE1NbfYOMRsODg5YtGgR9u7di9LSUiZWmm3csK3QVje+jIyM4OHhgcuXL6O4uBgRERFwdHTExYsXRRxwJycnsXk8ISGh4V8AhUJptsiQZvZVWUZGBkFBQXVORiCs9QcA5eXlIpqAAj58+AB1dXWRazweT2xbWBgulwtVVdUq+6vMq1evGtQJ+tr3VRvYVkirW0Gtye9cLlcs5KQyioqKjAMq7MBW9XtmZibOnj2Lo0eP4t27d9iwYQNGjhwJLy8vpqyGhgbatm1b7bNnZmbC19cXe/bsEbtnbW2NL1++4Pz583j79i1MTU1x584dkTLp6emYMGECXFxc4OPjU21/wcHBcHBwqPNKV3VjWRi2MVrduK6ufn3RmOO7vjAzM4O2tnazimGt6Xu+desWlJWV8e2332LPnj1QUVHBvHnzmPs1HTdVlSsqKoKMjAyUlZWZOffLly+Qk5MTS7fONo9T6s7XzjstleY4D0mDpj5+Ws0KsYDu3buL/C1JE5BtEq3OgajsDLP1V5mGXhGsDXfu3EFaWho+fvzIOK8fP35EcXFxtSuvX758qbJtOTk5tG/fHsrKylBQUICamhrjdKqpqTGO6oABA5iVV1VVVSgoKEisJ7xiW1N27NgBGxsb9OnTB1OnToWFhQUcHR0xe/ZscLlcfP78GdeuXatXFQZ9fX14eHhAW1tbRGRduP7Lly/B5XIbVHpNmNq8M7YxWt24rq5+a8bIyAgnT56UthkNQseOHTFnzhzIysqCz+cjLCxM5H5Nx01V5VRUVJjfBXOupC+t1BluPuTm5iI+Ph5Lliyptzar2pGr774ozZ9W5xBTJJOZmYlff/2VcVArhwZoa2tX6aBKqqeqqoo2bZrGUHv48CE+ffoEPp+Pixcv4o8//gAAuLi4wM/PD7q6umIqDO3bt2dOp/v7+8PX1xebN28WUVHYtGkT3r17J3JKPiwsDB4eHjA0NETPnj3x+PFj/PLLLyguLgYhBCdOnACHw4GamhouXryIsWPH0rCCVoChoSH++OMPvHjxAlpaWtI2p17R0dFBfHw8ysrKmsxnntI8aAitcqqLTqkNdMaiMMyZMwdz5sypskxpaSlWr14NAwODOiV5qOk38/r+Zu/j44OwsDA8fPgQGRkZKC8vR0FBAaP+kJeXBwAiuwWSVBgE8mKJiYlYu3YtgAoVheDgYMTExCAnJwdOTk4oKyuDsrIyAGDp0qXo1q0bfv31Vzx9+hTy8vKMXNXQoUOxY8cOPHr0qFbPRGmejBw5EnJycrh8+XKdE6U0dagzTBFGeGdOGLZdNrZcAF27dkVgYKDYTl3Xrl3FyqampjZZXfTy8nIxHe2OHTuy6ne7ubmJ7TZqa2s3us2tiRYhu0ZpPJprxrOVK1ciJSUFNjY2OHr0KBwcHNCtWzf0798fAPD48WPIy8tDU1MTnz59AlAR1yugKhUGACIqDHZ2dggICICXlxesrKyY+k5OTrh69Sp69+6NkydPYubMmfDy8sLNmzchLy9f62eiNE9UVVUxcOBAMeUZCqWlItiZqwybVjmbhjQAVh1pSXrTTUEXnU2nm01HG2DX764ulwGl/qEOMYWVHTt24OHDh2LXhTOeCQ4FxcXFYceOHQgMDISrqysmTpwIa2trpj6Xy4W7uztMTU2xdetWABUrzZs3b4aFhQXMzMyQn5+PkJAQLFq0SGyyYqtfV2RkZCAjI4OEhASYmZkxKZofP36MDh06wNzcHOfPn4e5uXm1KXadnZ2xf/9+/H/2zj0uxvT945+RDspSSLS1FntURMaZdNDKikh0xC4tWWxkrf0uX1tYy6ayWKelpF1tqRQih1IiQm05LW21i1ToOI10vn9/9Hue70zzTE3H6XC/X69eL57nPlzPM8/cc8091/W55s+fj8jISAC1WfLnz5+Ho6MjbGxsMHjwYLE+3bp1g4qKCmxtbbF9+3acPn1arD+la8Dn86lDTOn0+Pj4YMqUKQgPD8fnn3+OKVOm4J9//mHPc2mV11cLoK6OtLS2jdVFbw1dcC6dbmk62lz63Q3VMqC0PPR3LQon0r7Rr1mzBgoKCpwVz1oi1pb5Zi86N1f/pnLgwAGUlZUhISEB+/fvZ4/n5+djxowZGDRoEKKjo6WqMJiYmMDExARA7aJ89epVCRWFiIgIsSz50aNHs+c0NTVZhQlp/SmdHz6fj9DQUNTU1HBqOFMonYG1a9di7dq1cHFxgYuLi4SkJZdWuTQNaUDyl7qG9KalzZWcnIy7d+9i3LhxSElJQUVFBXR1dWFhYYGvv/4aH3zwQbOvnUunW5qONpd+d0O1DCgtD12JKWI09I2ei45W8SwhIQFv3rxhHVugNhTkww8/ZP/fEioMskiSSetP6dyMGTMGAoEAf//9t7xNoVBaHeaXubpw/crm4OAAX19f2Nvb49ChQ/jss8+kjtuYtsxcs2fPxvfff48bN27AwMAAR48excmTJ/Hll1/i+vXrGDlyJP7444/mXjInkydPhp+fH5YuXcqWGAdq9buPHz8OY2NjXLx4Ed27d2/w10ZKy0N3iCliNPSNnqEjVzyLjo7G+++/j0GDBgEAysrK8PTpUzaemEJpbQwMDKCsrIzbt2+LfRGjUDojBw4c4Dwu7VeyqKgoCQ3pL774gv236C91ddsOGTKEbVf3F7m4uDiMHz8e/fv3R1RUlISqz9dff43169dj0aJFGDp0KMaMGdPMKxfH3NwcEyZMENPRBmp/ody9e7eYfre6urrEr42U1qVT7xBfvHgRZ86cafFxmZ2dpozfmF0hgUCA1atXix1LS0sT+6m/tZD2jZ7BzMysVWNtG+rfHJj4YYbHjx+jurq6UzvElZWVWLNmDUJCQprUX9bnLikpCfb29njz5g17bNWqVTT+rQ5KSkrQ19fHnTt35G2K3GjO+hwTE4OIiAgkJibCysoKBQUF7Lk7d+5IHJNGfc81MwfXOtxQX0rj4PqVrDEa0rK2PXv2LJKSkhASEsIpcdm9e3d4e3tj0qRJ2LRpk8zzN4aePXuy6kOMjraGhgaWL1+OGTNmsDHGDI35tZHSPDr1DrGBgYFYhmdLce/ePQQEBMDDw6PR4zN965Zy5oJLaaGt9BOlfaMfNWoUm/XbEWNti4uLkZSUhK+//po99vfff0NBQUFCEqgzwaiD7N69u0n9ZX3uXr58iXPnzmHr1q3Yvn07gFrHojWSVjo6Y8aM6dIOcXPW56dPn7IhWfHx8QgLC4OzszMAwM/PD/Hx8WzCUn3U91wzc0ycOJFq2TaRq1evNli0qbEoKSmxDiWPx4O6ujp7rlevXmy1QkYfX5TTp09j4sSJMDAwkDo+j8fDl19+CQcHB87qs60B1e9uH3TqOx8bG4uysjIoKSlJ6BeuW7cOu3fvxuDBg7Fv3z706dMH8+fPl9D9A4B169ahvLwcfD4fmzZtgre3N1JSUsDj8TB+/HjMmzdPQkNww4YNnJqDTN+zZ88iJiZGQmsxJCREQkOxPegnSqOjVTyLjY1FTU0NjI2N2WMZGRls0ZHOiqg6iL6+fotW4rt58yb7zP7000+wt7fHhQsX4OjoCD09PdYGrvdDVFQUIiMjkZOTg/LyckyaNAmJiYmYOHEitm/fzjlfZ9Hi5PP5OH78eKf6EJSms8qlIZuUlMSuz/U9A1xjimJpaYmQkBA4OzujpqYGycnJGDFiBABwatqqqanJ9Fxz0Z7X4vaInZ0dcnJy5G0Gunfvjrfeegu9evXCjBkzGmyvp6eHqqoqPHnyBPr6+m1gYS2dZR3oqHSKkAkuvT+gNuSgqKiIU7/QxMQEoaGhAIDff/8dFhYWnLp/oaGh4PP5CA8Ph66uLkpLS+Hm5gZzc3MYGhqiqKiIU0MQ4NYcZPoWFRVJ1Vqsq6HY1vqJnZno6GiMHDkS/fr1Y49lZmaKxZ11ZKS9F9asWYOpU6dyqoNwvT8A7ueO6z1S95lVVFTE/v37sWLFCrFYcq73g1AohEAgQHR0NPT09KCoqIjY2FgkJCTg2bNnnVqLk8/no7S0tMPuMjZGZ5XrGRNdn+t7BqSNyaCpqQlCCF6+fInY2FgYGRmxzx2XTq2szzUXdC1uHH/99RcKCgpa9O/58+fIyMhARkYGHj9+jDt37rB/ly9fxqVLl3Dp0iWcOnUKwcHBCA4Ohp+fH3bs2IH+/fvL9GsV04bZbaZ0DTqFQ8yl91eXuuoHDg4OCA8PR1paGnR1ddGnTx9O5QMnJyfcuXMHfD4fmZmZnDuiXBqCgHTNQaB+rcW6SgstrbLQlakbPwzU7hB3lpLJsrwXGFpTHWTcuHEwMDDAkSNH2GPS3g/Mbr26ujrGjRsHoDYmsKSkpFNrcerr60NNTa3Dhk00RmcV4H7GGOp7Buobk8HGxgahoaEIDg6Gra0te5xrnW3Mc10XuhY3jt69e0NDQ6NF/l69eoXAwEBoa2tjyJAhGDJkCD744AOMHj2a/TMzM8O0adMwbdo0zJkzB/Pnz8f8+fPh5OSEZcuWgc/nIzU1FQB3jg5QGxu+a9cuKCsr45133mnrW0aRI53CIXZ3d8fdu3fh5eUltU1d9YP+/fujT58+8PT0ZKVauKqMxcfHY8+ePUhISMCDBw84tQAZDUEArIYg8D/NwZCQEImfXRj9RABStRZFx69bEY3SeHJycvDXX39JfJB1ph3iht4LKioqrVaJry7bt2/H3r17UVRUBED6+0E0VIVJ5CSEgBAidb7OgIKCAkaMGNFhHWKuZ62+NY/rGWOo7xmob0wGa2trBAcH4+7duzA0NGSPc62zjXmu60LXYvnREjHb1tbWuHXrFq5fvy61GmphYSHOnz+P6dOns7HKlK5Bp3CIm8rChQtx7tw5TJ8+HQC38oG6ujrs7Ozg5uaG0tJSGBgYYPDgwYiLi2OdXy4NQYBbc5Dpq6ur22j9RFrRrHlERUVBWVkZRkZG7LGqqio8e/as0zjEDdGW6iBvvfUWtm3bxsYQStPgrI/OrsU5atQopKSkyNuMFqMpr3FLjNm3b1+oqKiIaYsD3Dq1zXmu6VrcOkirjMpVpVQoFMLNzQ2mpqawt7dHbm4uZ5VUrnZFRUXQ1dWFsbExu1MsOo+RkREWLFiAgoIC/Pjjj212/ZR2AulgACBBQUGtOkdWVhYpKytj/19dXU2ys7PF2pSXl5OqqipCCCGpqakkPT2dVFVVkd27d5MjR46w7UpKSohQKCSEECIQCCT65ufny2xXTk5Oo6+lLe5XR8Ha2prMmDFD7Fh6ejoBQG7fvi0nq5pGUFAQac7b9/Xr1zK35Xru6r5HZIXr/SAL0ubr6M/3oUOHiJqaGqmurpa3KfXSmPvc1Ne4NcfkWmeb81w3ZS3uDDR33ZGGi4sLSUlJkTh+8OBBsn37dkIIId9//z1ZuXIlCQgIIJ6enqw9P/zwAzl8+DBZtGgRIYSQ48ePk02bNnG28/PzI8bGxsTU1JQoKCiQt956i3h5eREHBwcyadIkMnDgQNKjRw8ya9asRtnf0dehtqK1np+WokvvEEujru5ft27dJLKJlZSU2ID7+jQEuTQHRfs2RmuRVjRrOpWVlYiOjpb4KZSpwtfZdh4boi0r8YnC9X6Qhc6qxWlgYIDXr183WA2yI9HU17g1x+RaZ5vzXNO1uGVoqDIqV8y2tPybujHq0tpZWlri0qVLrPSpl5cXQkJCkJ+fjyVLliAwMJDGDndRqEPcAjAagufOnUN0dDR69+4tb5Modbh69SqKi4vZxZXh2bNnUFNTQ9++feVkGaUro6+vj27duon9fEuhdBXWrl2L+Ph4WFlZwdfXF/Hx8WKbE6Ix25cvX8b9+/el5t/UjVGvr123bt1gamoKRUVFPH/+HB4eHti8eTO2bduGpKQkVgOf0rWgonctCNUQbL9ERkZi2LBhEmoSWVlZjdJCplBaEjU1Nbz33ntITU2FtbW1vM2hUOSCtMqojo6OcHR0RFhYGJ4/fw6hUAgHBwc4Ozvj1KlTKCsrg5eXF6KjoyX6crW7evUqe76iooJNMOaapzUQrTOQmprKqdktFArx7bffIjU1FVpaWvjtt9/g6enZKbXY2xt0h5jSJYiMjOTMHH/+/DldXChyxcDAgO4QU7o07733Hqeig7q6OiZMmIDs7GwMHDgQRkZGUFdXx7Bhw5CVlQUVFRWoqqqiZ8+e+PPPP/Hpp5/C29sba9askdru8ePHGD58OPr27ctWJ+Wap7lw6XSLarZL09eOiIhAv379EB8fDwsLC/z000+dVou9vUEdYkqnJy0tDWlpaVIdYrpDTJEn1CGmdHXS09PZ3VpRmEIo169fZwuhMMVW4uPj2WIrXIVfpLWrW/hK2jzNRZomPKPZLk1fOyoqCrNnzwYAODs74+XLl51Wi729QX/jp3R6Tp48CU1NTUyaNEniXFZWVpuW5mxp5s+fL28TKM3EwMAAT548QVFREdTV1eVtDoXSZvj4+CAsLAzp6elITEyEmpoajh8/zsYRx8TE4NtvvwVQm1QXHByMqKgo1smcOnUqDh8+DFtbW7GkusTERM52Tk5OrEP6+vVrVFdX49q1awgMDMTatWvF5mku7u7ucHd3lzjOxDoz+tpLly7FypUr2fP6+vpIS0uDoaEh/Pz8ANQWnnFxccGTJ084ayFQWga6Q0zp9ISEhGDevHmcMd4ddYdYV1dXTM2kq2JjYwNdXV15m9EsDAwMQAjBvXv35G0KhdKmNCapjimE0hJJdenp6Vi8eDEeP36MKVOmIC4uDnPmzMF7772HX3/9tQ2uXLq+tpOTE06cOAFbW1ucOXMGW7Zs6dRa7O0JukNM6dRkZmYiJSUFu3btkjhXXl6OvLy8DhlDPGHCBJw8eVLeZlBaAKZ0fGpqKqZMmSJvcyiUNkeWpDqhUIihQ4c2O6nuyZMnGD16NHR1dfH2228jMTERBQUFWLhwIQQCAX7//Xfo6em1ynWKFuAyNzfHhAkTwOPxoKamhpKSEgC10n+nT59GSUkJKzEYERGB58+fo1+/fp1SfrLdIGcd5EaDVhDAPnnyJLl69arE8ejoaBIeHk4uXLhATp8+LfN4xcXFJC0trdH9mL6rVq0SO/b48WPyyy+/NGochta4Xx2J7du3k379+pHKykqJc5mZmQQAuXXrlhwso1D+x9SpU8myZcvkbYZUWmMdacr6yMCszTdv3iSzZ88WK7xx+/ZtiWPSqG9tZebgoqKigri6upKTJ0822wYG5n6Iji0rzGdOQ+ebc88JkV9hBa5CKLLeW9F2QqGQ6OjoEEtLS1JeXs45z6lTp4iCggL5/fffZbavq3/OygotzNEByMzMRG5ursTxp0+fIjMzEwYGBhg9erTM4927dw9eXl6N7geAs756S9Rw76qEhITA2tqaM1wiKysLADrkDjGlczFs2LAu9x5vyvrIwKzNubm5iI+PR1hYGHvOz88P8fHxbJJSfdS3tjJzcPHo0SNkZGTAxsam2TYwMPdDdGxZYT5zGjrfnHsuT7gKocha1Eq03YkTJ1BYWAhfX18oKSlxzjNnzhwsXryYLRVN6Tp06pCJX3/9FdevX0dhYSFUVVWxfft2XLt2DTU1NVi8eDEuXbrExiUdO3YM3t7e6N+/P7y9vcX0amNjY1FWVoZ58+aJ6QMGBgbC0dFRQkfQ29sbKSkp4PF4GD9+PObNm4fNmzcjJSUFWlpa8PHxwZUrVxAdHY3s7GwoKCjAx8eHlYABamurb9u2Dbdu3UKfPn0kKuVRGuaff/5BcnKy1Jr0z58/R/fu3dG/f/82toxCEUdPTw9//PGHvM1oNjU1NZzaqoGBgRLrXVJSEsrKyqCkpITIyEjk5OSgvLwckyZNQmJiIiZOnIjt27dzjimKpaUlQkJC4OzsjJqaGiQnJ2PEiBEAamWu6q69ampqEmtrZWUlduzYIab1ysA1xq5du/Dw4UNERUU1aAOX/VFRUVLvR0xMDDu2mZkZp13r1q1DeXk5+Hw+Nm3axH7mXLlyBQcOHJD6maSlpYUhQ4Y06TOpMxAdHQ1TU1NoamrW287Ozg6+vr54+fIl/XzoQnQKh7i6uho1NTXo1q0bWxIZAAoLC6GiooKIiAhcuXIFhw4dwjvvvMMG3ZeWlqK4uBg9e/aElpYWIiMjcfr0aRw+fBg7d+5kxxEIBCgtLRXTBzxy5AhCQkKwcOFCzJo1C56enggMDMSXX34JNzc3BAQEwNDQkA2W19bWhre3N4KDg+Hr6wtNTU1WJiYgIAD+/v7YunUrOycjA3PlyhW4u7sjLy+v7W5oJ+G3335D//79YWJiwnk+KysLAwcOFHtmKBR5oKenh8LCQmRnZ0NbW1ve5sgE17rLaKvWXRNFZbGY9e6dd95BaWkpVFVVIRAIEB0djeXLl0NRURGxsbEwNjbGs2fPUF5eLjGmaOlxTU1NvHjxAi9fvsT9+/dhZGSEmzdvAgDn2tu3b1+JtfXy5cus1mtYWBg8PDxYVRquMdasWQMFBQVYWFggIiKiXhu47omioqLU+yE69vnz5yXs0tfXB5/Px/r16+Hv74/S0lL2M0dXV7fezyQdHZ0mfyY1hd9//51TTq05CAQCVtu3rKwMb968AVD7PAoEArZdcXExampqAABv3rxBWVkZnjx5gunTpzc4x7vvvgsAyM7Opg5xF6JTOMRbt25FWFgYzM3NJX42YjJLR48eje+++w4LFy5kz4nq+ZmbmwMAjIyMOBOwgFp9QEaaxdnZGTk5Odi8eTP8/f3x6tUrWFlZSe0ni0yMKFxyMxTZIYTA398fTk5OUFRU5GzTURUmKJ0PRvrvwYMHHcYh5lp3GW1VrjWx7nr3zjvvsOeMjY0B1BZIGDduHIDan7pLSkqgoaEhMaaoQwzUqo2EhoYiNTUVy5YtY51RrrW3b9++EmtrZGQkHj16BAcHB1RVVYkVieAaY8aMGRL3Q5oNXPdEUVGx3vvBwGWXk5MTvvzyS/D5fMycOVPsXtR3/0VpymdSU9i2bRtevHjR7HFEUVNTY8MdlJSUxF4rDQ0N9t89e/Zk1351dXWoqqoiPz+fTV6rD8axZpLaKF2DTuEQS9P7A8DKrty5cwe6urpQUVFhd1tv3ryJHj16AAAyMjIAAKmpqawTXZe6+oBhYWGYM2eOhI5gXRj5lxEjRtQrEyMKIzczatQoNqyDIjuxsbHIyMjA4sWLpbahDjGlvdCvXz/0798fDx48YL+ct3e41l1p2qpA/eudaOY8ozZACAEhpN4xGaytrWFjY4Py8nIYGhqyx7nWXlVVVYm11dDQEPr6+mJar0z5Xmnrt6w2SLO/vvvBwGVXfHw89uzZAw0NDTg4OIjp0spyr+q7Jllsagx//fVXvecFAgFevHiB999/v0Xmk0ZMTAxKSkrQr18/BAUFgRDCqWrBEBcXBw0NDVRWVnKeF7X74sWLjbLl/v372LhxI4Da537MmDFwdXXljGluDgKBABs3bsTevXvZY2lpabh8+TK+/PLLFp2rs9Dpk+rCw8NhYWGBNWvWYOPGjTAzM8OFCxcwbdo0JCUlse0uXLgAe3t7/PTTT1i6dCnnWHX1AVetWsWpIzh48GDExcUhPj4eQK38i6+vL+zt7XHo0CEx6RVpODo64sCBA5g/fz4iIyObfyO6GH5+fhgzZgwbx8dFTk5Oh9mNo3R+9PT08ODBA3mb0Sykaau29ph9+/aFioqKRHgU19rLtbZaW1tL1XqVdf2WZkNz7gmXXerq6rCzs4ObmxtKS0thYGDAfuaoq6vX+5n0999/N+qaWpuGkgFbCiZB0snJCf/++2+9WsN5eXnw8vKCqakpdu/ezdlG1G4DA4NG2ZKfnw8AOHLkCL799lvcu3cPX3zxRaPGkAWaoN94eKSlvgq2ETweD0FBQViwYEGDbX/66Se8/fbbmD59Ovr06cN++wXAxq6JImulKFF9QKFQKKYjyByvqKiAgoKCWHxqQUGBzJmxDLm5uZwZtrLSmPvVWRAIBBg4cCB27dqFFStWSG334YcfYuHChdi0aVMbWkehcLN69WokJSUhISFB3qZI0Jh1RNqa2ByaOybX2su1ttan9dqU9ZuhufbXtaumpgYvXrwQS7ZmPnPevHnTap9JwcHBsLW1bfQOspeXF6ysrCSS9ObNm4eUlBQcPXqUjeW+fv06UlNTZUpEVFFRkUgw5Eqmj4uLQ2FhIVxdXaGvr49Hjx7h448/RkxMDGJiYthxhUIhXr58iaqqKnz88cd4+PAhjhw5IpGowplbKQAAIABJREFU6OzszNr94sUL2NnZwd/fHykpKQ0mKj5//hz79+9HUFAQ+1q+++67SE9PR0VFhUzJjgMGDJBoN2DAAISEhLD3MCYmBiYmJrhx44ZEEum+ffsa9fq1FE19ftqKTr1DrKysDEVFRfTr10/MGQYg4QwDkLlsquhi1rNnTzaGSfS4kpKSRLJWUxbT5jjDXZWgoCA2s7s+8vLy0Ldv3zayikKpH2aHuL1+WMiKtDVRnmNyrb1ca+vbb78ttfBBU51hoPn217WrW7duEspDzGdOa38mNYX09HTO5Do3NzeYm5vD2NgYQqEQGRkZSExMZBMRz549i6lTpyIwMFAsMXPBggXw9/dHaGgo+Hw+wsPDoauri9LSUrFk+mXLluHQoUPsfJmZmdixYwe2bt2Kx48f47333sPOnTtZh/PatWsoLS1lc3jMzc3ZREVRW0TtZuKNb9++DW1tbcTExGDu3Lnw9fXltLku3bp1w/Dhw/Hnn3+yyY4NjcHVDgBevXqFe/fuITExEY8ePcLTp08xefJknD9/Hp9++imGDRvWoq+rQCDA6tWrJY6npaVh//79LTpXW9CpHWJXV9cutTNKqcXX1xdz5swRS7CoS3V1NYqKitCvX782tIxCkY6enh4EAgGeP38ub1MolBbBx8cHU6ZMQXh4OD7//HNMmTIF//zzj9T2FhYWUFVVZZMDbWxscPbsWVbPWTTpr7CwEE5OTrhz5w74fD4yMzPZjS7RZPq4uDh2fDU1NZw5cwZ//vkn+Hw+TExM0KNHD/Tu3RvTpk3Drl27MHv2bLEER2m21CUlJQWffPIJgNpExZiYGE6buSguLsbgwYMRFRUl0xjS2mVlZYEQAlVVVRQUFACoDZf5z3/+g3v37onFm7cEXGEZzPV0xNCMTu0QU7oed+7cwc2bNxtMGigoKEBNTQ11iCntBlGlCQqlM7B27VrEx8fDysoKvr6+iI+PF4vPrgvzSy6THBgSEsK+L0TPM7+iMAmGCQkJePDgAevw1U2mZxAdd/To0TA2NsaSJUvwxRdfYNeuXRg1apSETdJsqcugQYPYeaUlKj58+BA7duzAtWvXYG9vj3/++QcxMTGorKzEqlWrkJSUhM8//xyFhYXYu3cvCgsL4eHhAUIItm7diq+//hoREREYNGgQjh49CmdnZ1haWuLp06dIT0/HhQsXkJaWhtjYWHbu8ePHA6ittXDr1i1UV1dDKBTCzc0NpqamsLe3R25uLgIDA+Hs7IxPP/0Us2bNQnp6Ome7kJAQuLi4YPjw4WLXX1JSgg0bNsDExKTDFjWhDjGlU+Ht7Q1DQ0NMmTKl3naM0gh1iCntBQ0NDQwYMIA6xJROB4/H41R1qJuAziBrIiJXgiEgmUzf2HFFbeNKVOSye9KkSWKJigsXLmS1uhmYQjTl5eW4e/cujIyM4OXlBU9PTyxcuBCXLl2CUCiEubk5zp8/jx49euA///kPHj9+jMrKSnh6emL48OH4559/EB0djejoaOjo6GD58uXw9/fH9OnT8cEHH7AyhsD/EvRtbW3RvXt35OXlNSs0QzS0RRTR2gl1neWOQqeQXaNQgFoR9ZCQEBw9erTBttQhprRHOoPSBIVSlwMHDnAe19bWRmpqKhQUFMQ2MczNzTFhwgSpiYgmJiasmoeRkZFEguHGjRvFkulFlSBkHVfUti+++EKij6jdy5YtQ9++fREVFcUmKrq7u7M63czYc+bMwYABAxAREQGBQIDp06ezVRqZmgYDBgyAubk5dHR0kJ+fj5UrV2LVqlVISEhAeno6evbsCWVlZbi6uqKgoAAbNmxAbGwsQkJCYG9vz6pYqKurY/r06dDV1cXVq1eRm5sLGxsb/PLLL3Bzc5NJh5pLr9rJyYkNbRGNC+8MtRPoDjGl07Bv3z5oaGjIFDfOOMQ0qY7SnqAOMaWrwZXsB8ieiFg3wbC+ZPrGjCtqG1cfaXYziYru7u64e/euhKwcVzhH3bAMJhaasd/Q0BA2NjY4ceIEPD09MXPmTPZaANl0ox8+fIjKykr079+f1aEGpId3AGiwnShM7QQAHbZ2At0hpnQK3rx5g8OHD8PV1VVqlrgo+fn56NWrV4uLoVMozUFPTw++vr4NFg6gUCjcuLq6ytuEegkPD0dycjKys7MREBAAoDaUw8PDAwkJCSgrK0N4eDiWLFnC9rG2tsbixYsRHx+PtLQ0HDx4kDNBr24oR3R0NCZOnIhu3bqhd+/eOHnyJIBaHWpnZ2ecOnUKZWVl8PLyQnR0tMR4XO2uXr3KeV2Ojo5wdHREWFgYhEIhhg4d2ux71dZQh5jCkpubC4FAgA8++EDepjSa48ePQygUYtmyZTK1z8vLo+ESlHaHnp4ehEIhnj17xlnKl0KhdGzqhnMADYeIqKurIyIiQkyPevTo0ex50VAPJpRDQUGB/SW0Ljo6OmLhHQAwZMgQzvHqa6epqYn79+8DgFhoRkeVi+3UIROVlZVYs2YNQkJCmtRfVi29zqLF98MPP2DMmDEICwuTtymNorq6Grt374ajoyO0tLRk6pOfn08dYkq7Q19fHzwer0uETVy8eBFnzpxpUt+YmBhEREQgMTERVlZWrMQUUPtTdN1j0qhvjWbmuH//PqysrGBlZYUFCxbA09MTFRUVzb4GStejvnAOWUI56tPJZpAWysGFrDrUjdGr7qjOMNDJHeJHjx4hIyMDNjY2Teovq5ZeZ9Hi27VrFz777DPMmzcPy5cvl1rHXRZCQkIkMoeZD5jGfogIBAK25ChX36CgIPz9999s8H/dvlxfVjIzMzmF4ikUedK7d29oa2t3CYfYwMBAbJerMTCleHNzcxEfHy/2Jd7Pzw/x8fFS9WJFqW+NZuaor9Ruc66B0vWgtRHaN506ZGLXrl14+PAhoqKi8OrVK9TU1GDx4sW4dOkS7t69C21tbYmSiFpaWhJlDisrK7Fjxw7Ex8ejuroa/v7+uHnzpliJRIaSkhKJ/h0FZWVl/Pzzzxg7diyWL1+Ohw8fIigoCNra2o0eKzMzUyLQ/+nTpygsLISDgwOqq6tlHuvevXsICAjAwYMHYWBgINa3uroaW7duhaOjIz788EOJvtK+rDDlOSmU9kZHTqxjKkSKlrnV0NBAYGCgxFqblJTEylAxmfbl5eWYNGkSEhMTMXHiRGzfvp1zTFEsLS0REhICZ2dn1NTUIDk5GSNGjABQWzK5bolbNTU1mdZ4UVRUVKCpqQlNTU0cO3YM7777LioqKhAbG4uysjKYmZlJlBDmGlNbW1viWl6/fi1TXx0dndZ++SiULk2n2CGurq5GZWWlhJO1Zs0aTJ06FRYWFigpKYFQKAQAlJaWori4mFN3j0tL7/Lly6isrMTFixexcuVKeHh4dGotPkdHR6xcuRK5ubkYOXIkLl++zJ779ddf8dlnn8HKyooVFg8ICGA/QC5dusRm1R47dgwTJkyAlZUVMjIy2DFiY2NZvcVVq1ZhypQpsLGxYTUbFyxYAEtLS1haWqKwsBDe3t64dOkSYmNjxfq6ublh+PDhePz4MZYtW8YpLC6KqHD4w4cPoaKi0gZ3k0JpHB3FIeZad7lK7gLgXGsFAgGKioogFAohEAgQHR0NPT09KCoqIjY2FgkJCXj27JnUMRk0NTVBCMHLly8RGxsLIyMj9ss4l46qrGu8NERL7TLXwFVCmGtMrmuRtS+FQmldOoVDvHXrVowePZrzJ3MuRHcG65ZEjImJgYWFBYBaLT0AiIyMREJCAhwcHPDHH3+w/RktPlG4+ndEBAIB/P39YWJiAgsLC7i7u6OmpoazTjzXlw0A0NLSwo0bN7B06VIcPnxYbOyioiJERESgX79+iI+Ph4WFBZKTkzk/MOrWjWfE0QcMGICamhpMnToVcXFxDdaNF/0g5PF41CGmtEv09fXx8OFDMUH/9gjXultfmdv6StgyhQTU1dUxbtw4ALVxiyUlJTKVzrWxsUFoaCiCg4Nha2vLHucqcduYNV4aTKldBq4Swlxjcl2LrH0pFErr0ikcYml6f6KoqKiwMaM3b95kj9fV3ePS0pOmAdgZtfhEa8+vWrUK2dnZ2LJlC7Zv3w4rKyu8efNGap14QPzLBiNIbmRkhBs3bkjMFRUVhdmzZwMAnJ2dMWbMGJnrxkdFRaGiogLp6en44YcfZKobL/pBSAihkmuUdomenh5ev36Nf//9V96m1AvXultfmdu6a60ooolCjNwcIQSEEJlK51pbWyM4OBh3796FoaEhe5xLR7UxazwXTKnd/v37s8e4Sghzjcl1LbL2pVAorUunjiEWxczMDEuWLMHFixdRU1ODyZMnc7bj0tLj0gC8d++ezP07EmvXrsXatWvh4uICFxcXjBw5EkCtU2tra4vr16/DysoKixYtYoXFVVRUWHmXmzdvokePHgDAhkmkpqayTrQo+vr6SEtLg6GhIfz8/GBgYICIiAiMHz8eS5cuxcqVK6Xaqa+vjz179mDx4sUQCARShcVFYT4IR40ahZKSEpn0iimUtkZPTw88Hg/3798XkzjqCHDpqbq5ubX4mKIarUBtgR0VFRWJdYZLR1VRUbHRa7w0PVcGpoSwnp4eW0L4/ffflxizd+/eEteyZcsWmfpSKJTWhUdkKXHSjuDxeAgKCmpypmZpaalEmAMXXFp6ohqATekvD5p6v1asWAEXFxexkpevXr3CpEmTkJ6ejmHDhqFbt24ICAiAuro6lixZAh6Px37Z6NmzJ86cOQMdHR0IBALs3r0b169fR2FhIXr27InS0lLY2NhgxYoV6NGjByorKxESEoLo6Gh4eHjgww8/RFlZGZ49e4Y//vgDZmZmOHz4MB49eoTS0lJUVFRgw4YNsLS0hIKCAissXlFRgZUrV+LKlSsIDQ3F999/DxMTE9y/fx/Pnj2Do6MjNDU1ERYWhk8//RSRkZEtfcsplGYzePBgfPHFF/juu+/kbQqAxq0jQqFQqp5qU2numKI6qgzNXePrUlNTI1FCmGtMrmuRta+8YUJSOpjb0Oo01y/pKrT754d0MACQoKAgeZvRYWjp+/Xjjz8Sa2tr0q1bN+Lk5ERev37NnhP9N0NhYWGDYwoEArH/l5SUEKFQKHauvLycVFVVsccGDhxIvvrqK5Kfn9/oa7h37x4BQGJjYxvdl0JpCywtLYmDg4O8zWCh6y6FEEKCgoJIB3QbWh15vT8uXLhATp8+3ebzNpX2/vx0ihhiStvRo0cP2NraIiIiApGRkZg8eTIbGsG1866urt7gmHV3exqqG79t2zaUlZVh8+bNjRIMZ2B2W3r37t3ovhRKW6Cvr89WgKJQKBQuqA52y0IdYkqjYITFLS0tkZKSgu7du8PQ0LDNqttlZmbi559/xpYtW9C3b98mjcGoYMjirFMo8kBPTw+PHj1qVnEcCoXSvsjKyoKtrS3mzJmDbdu2AeCWMq2srMTWrVvxySefwMzMDFlZWZwypYwMKVd7rrko9UMdYkqTeeedd3D16lXY2dnBxsYGrq6urS4PtG7dOgwZMgTLly9v8hhFRUUA6A4xpf2ip6fHqqhQKJSOB5dON5fmNJeUKZcONZdMKSNDytWeay5K/VCHmNIsVFRUcOjQIRw7dgxHjhzBtGnTkJub2ypzXblyBeHh4fD29oaiomKTxykuLgaPx0OvXr1a0DoKpeUYNmwYunfvTsMmKJQOCpdON5fmNAAJKVMuHWoumVIGrvbS5qJIp0PKrvn4+EjI3lDky6JFizBixAjY2NiAz+cjKCgIkyZNarHxq6ursWbNGsycOZPVEm4qxcXF6NmzJxuTTKG0N5SVlTF06FDcv38f8+fPl7c5FAqlkbi7u8Pd3V3sGKM5raGhAQcHB9y+fRsAWF1sRsrU0NAQ+vr6cHFxwZMnT3D79m1kZGRIyJQycLXnmkvUiaZI0uEcYhsbG3mb0KGwsbGBrq5um8w1cuRIJCcnY8mSJTA2Nsa2bdvwzTffsEL7zeHIkSP466+/EBQU1OyxioqKaPwwpd0zYsQIpKamytsMCoXSQnDpVTO/fCYnJyM7OxsBAQEYNGiQhA71hAkTsGLFCpw6dQqVlZVYvHgxkpKSAIBTR7ukpERiLkr9dDiHmO4Mt2969eqFkydPYs+ePVi/fj1u3ryJY8eONSteNzc3F//5z3+wevVqfPTRR822sbi4mMYPU9o9I0eOFCt5TqFQOjbGxsYwMjKS0JzeuHEjpk+fjj59+rDFpSIiIiR0qE+fPi2mw/3FF1+wY3C155qLIh0aQ0xpcXg8HlxdXXHp0iXcvHkTY8eOlVrZTxZWrVqFXr16wcPDo0Xsaw8OcXBwMHg8Hv1rB3/BwcFyfRakMXLkSDx58gQFBQXyNqVZCAQC/P333zK1vXjxIs6cOcN5LikpCfb29njz5g17bNWqVa2eyMtFTEwMIiIiOM815nopXY9u3bqJOajKyspQVFREv379WGeY4e2335YoylJfUZq67evORamfDrdDTOk4TJ06FXfu3IGtrS3GjRuHX375BZ9//nmjxjh79ixCQ0MRFRWFnj17tohd7SlkoiVCQChNx9bWVt4mSIUpm56amgoTExM5W9N07t27h4CAAJnKDxsYGIhl5Yvy8uVLnDt3Dlu3bsX27dsB1DqmNTU1LWqvLDx9+hSFhYWc5xpzvRSKq6urvE2g/D/UIaa0Km+//TZiY2OxadMmLF26FDdv3sTevXuhpKTUYF+BQIAVK1Zg8eLFmD59eovZ1B52iBloqU/50p4dYm1tbWhpaSElJaXDOMRZWVlYt24dysvLwefzsWnTJnh7eyMlJQWxsbHIy8vD5cuXcf36daSmpsLOzo6VgwoICEBsbCzKysqgpKSE6OhoZGdnQ0FBAT4+PgAAe3t7XLhwAY6OjtDT02PnFQqF2Lx5M1JSUqClpQUfHx9cuXIFkZGRyMnJQXl5OSZNmoTExERMnDgR27dvR2VlJXbs2IH4+HhUV1fD398f8fHxEvMOGDAA3377LVJTU6GlpSX2JbampkbiGkSv99mzZ6ipqcHixYtx6dIl3L17F4MGDWLvQXJysoQNOjo6bfiKUSgUBhoyQWl1unfvjh07duDUqVMICgrCxIkT8e+//zbY7+uvv0ZZWRk8PT1b1J725BBTKPVhYGDQbhPrZNVZdXNzg7m5OYyNjSEUCpGRkYHExERkZmZi4cKFOHv2LKZOnYrAwEBWV1UoFKKyshLnzp3DggUL4O/vDwBQVFTE/v37sWLFChBC2HnDw8Ohra2NmJgYzJ07F76+vhAKhRAIBIiOjoaenh4UFRURGxuLhIQEPHv2jFO7lWteLv1XBq5rEL3ekpISCIVCAEBpaSmKi4vF7gGXDRQKRT5Qh5jSZlhZWeHWrVuoqKgAn8/HhQsXpLaNi4vDkSNH8Msvv0BTU7NF7WhPIRMUSn2MGjUKKSkp8jaDk8borIpiYWEBVVVVqKmp4fTp07CxscHZs2dRVlYm1o7P5wMAdHV1xcITxo0bBwMDAxw5coQ9FhUVhU8++QRAbahWTEwMgNokJqA2u3/cuHEAgD59+qCkpIRTu5Vr3vr0Xxu6BlFEY52ZeyDNBgqF0vZQh5jSpnzwwQdITEyElZUVZsyYgW+//VYiBrC8vBwuLi749NNPWyWkoKvtEGdkZMDKygpWVlaYM2cOvLy82Gp9XISEhCA+Pl7sGJNEVF/SExeiCUaN7Uup3SF++PBhvY6WvHB3d8fdu3fh5eXFHmO0TxMSEvDgwQNWZ1UUJnHo4MGDGD9+PEJCQqCvry+1nehOMMP27duxd+9e9jkeMWIEq+X6559/soUORBOMGPlHQggIITA0NISNjQ1OnDgBT09PzJw5k3NefX19pKWlAQD8/PzEdogbugYVFRW8fv0aAHDz5k2Ja5NmA4VCaXuoQ0xpc3r06IGjR4/i4MGD8PHxgbm5OV6+fMme37x5M3JycnDo0KFWmb+rOcRFRUV48+YNjhw5gv379+Pp06fYtWuX1PaZmZkS1QafPn2KzMxMGBgYYPTo0TLPfe/ePdZhamxfSm1iXWVlJR4+fChvU2SC0Vl1c3NjtU8HDx6MuLg4iS9ZkydPhp+fH5YuXYqioiKEh4fLPM9bb72Fbdu2IScnBwDg4OAAX19f2Nvb49ChQ/jss88aHMPa2hrnz5+Ho6MjbGxsMHjwYM52Tk5OOHHiBGxtbXHmzBk22VHaNYher5mZGS5cuIBp06axmrFNsYFCobQ+PML19ZtCaSOSkpIwf/58VFVVITg4GOXl5TA1NcWhQ4fg7OzcKnMqKioiICAAdnZ2rTK+LAQHB8PW1pZz96ulSUpKwvfff4+zZ88CqC2BvW/fPoSGhiIgIEAi6ae6uhpxcXEoKChA//794e3tjfj4eBQWFkJbWxtlZWWYN2+eRKIRj8eTSDBydnZGSkoKjh49ihcvXrB9uRKg6iYzvffee61+b3g8HoKCgtptcmN1dTV69eqFffv2NVqhpSVpzH2qqamR0D6tqKiAgoKCRHVIoVAIHo8HNTU1MX3VplJQUIA+ffo0qk9d7VZpSLOP6xrqXm9paWm9pXNltUHetOW61ZFo7+tIe6G9Pz90h5giV0aPHo3bt29DT08PxsbGsLa2xuzZs1vNGRYKhaiqqupSO8RA7U6ti4sLPvvsM3z33Xf48ssvAYAz6QcAtLS0cOPGDSxdulSsOAST9MSVaNRQghHTV1oCFFcSVVdHQUEBI0eO5Aw9aK9waZ8qKSlxlkrv2bMn1NTUANSvryorjXWGAW6tVy6k2cd1DXWvtz5nuDE2UDoPaWlp2L9/f4uOKRAIsHr16jaZqzNCHWKK3Onbty/OnTuHjz76CAUFBejevTsbd9fSMA5fV3OI3333XaxevRobNmzAtWvXYGZmJtFGNKHH3NwcQG2loxs3bki05Uo0kjXBSFoClLQkqq7O2LFjcevWLXmbQaFQWpDi4uIWD4UqLy/HlStX2mSuzgh1iCntAn9/f9y7dw+enp64evUq+Hx+q7yBGYe4q6lMvPXWW9DT08PHH38stnMlLeknIyMDQG1RCCZBSRSuRKOGEowYpCVA1ZdE1ZUZO3Ys7t69K1ahjUKhdDxKSkqwYcMGmJiYYMeOHexxoVAINzc3mJqawt7eHrm5uQgMDISzszM+/fRTzJo1C+np6ZztQkJC4OLiguHDh8s0F0U61CGmyJ3MzEy4urrCzc0NX3/9Ne7cuQN1dXWMHz8eJ0+ebNG5mKz0rrZDLA1pST8XLlyAvb09fvrpJyxdulSiH1eiUUMJRgxNSYDqyowbNw6VlZXtVn6NQqFIwqXTfeLECairq+PKlStiDqysYWTS2jG61qJIm4tSD4RCkSOVlZVkwoQJRF9fn7x584Y9XlZWRr766isCgCxbtoxUVFS0yHznzp0jAEhJSUmLjNdUgoKCSHt6+71+/VriWGFhYYP9BAKB2P9LSkqIUCgUO1deXk6qqqok+ubn5zfF1BYFAAkKCpK3GQ3Sv39/4uPjI7f5O8p9orQu7W3dai9wvT++//57Mnz4cOLm5sYeW7BgAUlOTiaEEBIXF0dWrlxJCCHE0dGRpKamEkIIyc3NJWZmZuTw4cNkz549hBBCrly5QlauXMnZzs/Pj+zatYsQQsjLly+Jnp5evXPJk/b+/NAdYopc8fDwwJ9//okTJ05ARUWFPa6srIyff/4Zv/32G37//XeYmpoiOzu72fMVFxeje/fubBIMpRaupB9ZwkrqJhrJkmDE0JQEqK4Kn8+nccQUSgeCS6d71KhRbLjY3bt32eOyhpE11E4UaXNRpEMdYorciI+Px48//ghvb2+pP+k4Ojrizp07KCgowMiRI3H58uVmzZmfn48+ffqwIv0USkeAJtZRKB0fR0dHHDhwAPPnz0dkZCR7XNYwssaEm0mbiyKd7vI2gNI1efHiBRwcHDBz5ky4uLjU2/ajjz7CzZs34ezsDAsLC2zatAmbN2/m/FbcEIxDTKF0JMaOHQsPDw/k5eWhX79+8jaHQqE0AV1dXVy9ehW5ubkYMGAAe1xHRwdRUVFiOtpDhgxhz5uYmMDExAQA6m2nqamJ+/fv1zsXRTp0h5jS5lRVVcHW1hbdu3eHr6+vTLu1b731FoKCgrB//378+OOPsLKyapI0V0FBAfr27dsUsykUuTFu3DgAaPd6xFxlv2Xl3LlzrASfPBDVao2MjMT8+fPxySef4Oeff663nyzXLFrCvCFoifPOjzQHVdbNmsZs6lBnWHboDjGlzfnmm29w69YtXLt2rdHO6bJlyzBs2DDY2tpi1KhROHnyJMaMGSNz//z8/HblEN+4cQPe3t7yNoPSzunTpw+GDh2KxMREzJgxQ97mSCUzM7PJsnn//vuvXGP7Ga3WwsJCeHp6Ijg4GFVVVXBzc8OoUaNgZGTE2U+Wa7537x4CAgJw8ODBBu0wMDAQUyagUChtA3WIKW3KH3/8AR8fHxw7dgyGhoZNGmPy5MlISUmBo6MjjIyMsGfPHnzxxRcy9c3Pz4eWllaT5m0Nnj17hpCQENjY2MjblC6HqO5yR2D8+PGcRVLaG8eOHYO3tzdb9nvo0KGoqamRKOutqKgoVv576tSpAIBXr15hyZIl+Pnnn9G/f39s3rwZ9+/fh46ODj788EMMHToUly9fxvXr13Hjxg2JMuADBgzgLEmura0tUR5cS0sL27Ztw61bt9CnTx8MHDgQL168wJs3b8Dj8aCtrY29e/eiuLiYc8x169ZxXrOysjLWrVuH8vJy8Pl8/Pnnn0hJSUFsbCzy8vJY+1NTUyXuS2xsLMrKyqCkpCSXcuYUSleFOsSUNiMlJQXOzs5wdXXF4sWLmzWWpqYmzp8/j61bt8LFxQXx8fE4ePBggyVS8/PzMWzYsGbN3Rq0tN4ypWHmz5+PkJAQeZshM1OmTMG6detQWVkJRUVFeZsdUe+LAAAgAElEQVSD6upq1NTUoFu3bmIqIlpaWoiMjMTp06dx+PBh7Ny5ky3rPWvWLHh6eiIwMBC9e/dmy38fOXIE169fx8cffwwbGxv8/PPPGDJkCAICAvDxxx/D29sb3333HV68eAEtLS1WdzUsLAza2trw9vZGcHAwfH198d1336GkpITdtWVKkvfq1YvVdQ0ICIC/vz90dHRYrVZ3d3fk5eXho48+gp2dHaZMmYKePXti1qxZcHNz4xxT2jVra2uDz+dj/fr18Pf3x7hx4xAaGgpjY2McO3aMtZ/rvigqKqK0tBSqqqoS9m7durVtX2QKpQtBY4gpbcLz589haWmJ8ePHw9PTs0XGVFBQgLu7OyIiInD27FlMnjyZrbAmDdFkhPYEj8ejf23815GcYaC2zLVQKERycrK8TQEAbN26FaNHj8Y333wjdpyr7DdXWW+u8t979+5FXl4etLW1AdTG0zLSUtOmTWPnsLCwgKqqqtQy4KKIliSvWx48JiYGFhYWAABTU1MAtTvUzs7OePToEUJDQ/H8+XP4+PhIHZPrmp2cnHDnzh3w+XxkZmZKfFFn7G+o3DktZ06htB10h5jS6pSUlMDS0hK9evXCyZMnW3x3y9LSEikpKbCxsYGhoSH8/PxgbW3N2ba9xRBPnDgRQUFB8jajy2JraytvE2Tmww8/hLa2NuLi4tgkO3ni7u4Od3d3ieNcZb+Zst5Lly7FypUrAfyv/Dfznk1OToaHhwdUVVWxevVqBAUFYdSoUXj48CH09PTEEtcYhRlGl3XEiBFiuqwqKirIy8sDUBsa06NHD7F+zE4vo9U6atQoVqs1KSkJly9fhqenJwYNGoRly5bBw8MDc+fO5RyT65rj4+OxZ88eaGhowMHBARoaGmL3iLGD675wtWtqXDal7fDx8aG/9DVAVlaWvE2oF+oQU1qV6upqODk5ISsrCzdu3JD4YGgp3nnnHVy9ehWurq6wsbHB6tWr4eXlhe7d//eIV1dXo7i4uF05xDo6OliwYIG8zeiydCSHGKiNn7969arErmx74sKFC3jw4AEEAgF2794NoNZuDw8PJCQkoKysDOHh4QgMDMSKFStw6tQpVFZWwtTUFAoKCrCzs4Ofnx9Onz4NW1tbuLi44JdffkFlZSUmTZokNpeDgwOcnZ1x6tQplJWVsUUQzMzMsGTJEly8eBE1NTWYPHkyp62Ojo5wdHREWFgYhEIhhg4dik8++QTHjx8Hn8/H8OHD8eTJE/zwww94++23pY5Z95qfP38OOzs76OnpobS0FHPmzMGMGTMk1Ci47svChQtb8uWgtAE0B0Q2dHR02ve9kmOVPEoXYMWKFURVVZUkJia22Zz+/v5EVVWVTJ06leTk5LDHX716RQCQmJiYNrNFGu29hGVXAR2sJPG+fftI7969OUthtyaNvU9cZb+5ynrX/XddUlNTSXp6OqmqqiK7d+8mR44c4WwnrQw4V0lyLkTXCdG+ubm5Mo9Z95qrq6tJdnY2+39pJcyl3Zf2CF23KJ0ZGkNMaTXc3d1x+PBh/Pbbbxg7dmybzbto0SJcv34dWVlZ4PP5uH79OoDacAmgc5cMFtU7PX/+PNUz7WRMnToVxcXFSE1Nlbcp9cJV9purrHfdf9dFQ0MDy5cvx4wZM9hYWy6kvacbSrJl4NJqVVVV5VSkkTZm3Wvu1q0bBg4cyP5fWglzafeFQqG0LdQhprQKe/fuxZYtW3DgwAHMnTu3zecfOXIkkpOTMX78eBgbG2Pnzp2sQ9yeQiZamnv37rE/G2dlZeHp06dytojSkujp6aF///6Ii4uTtyltgq6uLi5fvoxz584hOjoavXv3lrdJlE5MdXU1Hj16hNu3b+PJkyfyNofSxtAYYkqLc/z4cbi6umLnzp0y6wO3BkwS3549e7B+/XqMHj0aQMd0iLl0XM+ePSuhi5qQkMDqnQK1FbfCwsLQq1cv7Nq1C1paWhK6rdeuXWN1Uc+fPy+mn7pp0yY5XjWlLjweD5MmTUJcXBzWrl0rb3PaDNFcAAqlpSkpKcGWLVtw9OhRMTWPoUOHws3NDStWrJCpoiqlY0N3iCktSnh4OJYuXYr//ve/WL9+vbzNAY/Hg6urKy5duoSHDx9CQUEB6enp8jZLKtXV1aisrJSoVMXolZ49exZTp05FYGAgSkpKIBQKAfxPF9XNzQ3m5uYwNjZm+0ZHR2P+/Pnw9/dHeHg4tLW1ERMTg7lz58LX1xdCoZDVRQ0NDQWfz0d4eDh0dXVZB5zSfjAyMkJ8fDxqamrkbQqF0uF58eIFxo4di+PHj2PDhg1ISUlBZmYmrl27hpkzZ2Lt2rWwsbGRkNqjdD6oQ0xpMSIiImBra4svv/wSHh4e8jZHjKlTp2LJkiVQVlbGuHHj4OfnJ2+TOJGm7dqQXqm0xZrRbtXS0kJBQYFU3VZGF7Uh/VSK/Jk6dSoKCgpw//59eZtCobQ5aWlp2L9/f4uNZ29vj9zcXKSkpGDDhg0wMDDA4MGDoampiQ8//BDR0dGIiorCjh07WmxOSvuEOsSUFuHcuXOwtbXF4sWLJUTs2wslJSWYPHkyvvrqKyxduhTLly9HRUWFvM0Sw93dHXfv3mXjgBkYvdKQkBDo6+sDqNVaff36NQDpZYiVlZXF/s/otgIQ021l9E4Z/dSEhAQ8ePAAt2/fbrmLo7QIBgYG6NevHy5duiRvUyiUNqe4uBgPHz5skbFu376NK1euQENDQywBUnSeyZMnY+PGjdi1axfKy8tbZF5K+4Q6xJRmExkZCWtrayxatAgHDx5knav2RnZ2Nt5++23s2LEDp06dQnBwMCZOnIh//vlH3qY1yOTJk+Hn54elS5eiqKgI4eHhMDMzw4ULFzBt2jQkJSUBAAYPHoy4uDgJvVMGBwcH+Pr6wt7eHocOHcJnn30mdl5dXR12dnZwc3NDaWkpDAwMWvvSKI2kW7duMDc3x4ULF+RtCoXSYnh5eUkNZyspKcGGDRtgYmLC7tQKhUK4ubnB1NSU3eUNDAyEs7MzPv30U8yaNQvp6emc7UJCQuDi4oJZs2ZBR0eH/SWMax4AcHJyQnFxMRITE1v/RlDkBs1UoDSLyMhIzJs3D4sWLcKhQ4fadeJBdnY2Ro0aBQCwsrJCYmIibGxsMGbMGPz++++YPn26nC2Ujrm5OSZMmAAejwc1NTWUlJTgrbfeQnR0NEpLS8VCG1JTU6GgoIApU6awx8zMzGBmZgYAiIqKEithPWTIELadsbExjIyM8OLFC4kdE0r7Yfr06Vi+fDmEQiF69uwpb3MolGaTnp7O/uJVlxMnTkBdXR1XrlyBu7s78vLy2HwIb29vBAcHw9fXF5qamqisrMS5c+cQEBAAf39/tsKjaDttbW1kZGRg9uzZePjwIYqKiqTOA9SqnSgpKbX7SmuU5tE+t/IoHYI//vgDc+fOxdKlS9u9MwzUOsSiTt4HH3yAxMREWFlZYcaMGfj222/bdaKSNL3SunG+0vRORalPi7mufiql/TF9+nRUVFS0O/k1UR3s1iQmJgYRERGN6tOQbcz5ixcvNlq/e8WKFbCyshL7O3ToUKPG6Kr4+PhgypQpCA8Px+eff44pU6ZI/GoXExMDCwsLAICpqSkASM2H4PP5AGqd2MLCwnrzJnr37o03b97UOw8AVFRUoLKykl1/KZ0T6hBTmsSBAwfg6OiIr776Cvv27Wv3znBlZSXy8/Ohra0tdrxHjx44evQoDh48CB8fH5ibm+Ply5dyspJCkY0BAwZg5MiR7S5sQlQHuzV5+vQpMjMzG9WnIduY8wYGBqxEo6x4eHjgwIED6N27NywtLXHgwAHY2dk1aoyuytq1axEfHw8rKyv4+voiPj4egwcPFmszatQoNvfh7t27ABrOhyCENNhu+PDhePDgAbsRwjUPACQkJIAQguHDh7f8DaC0G2jIBKXR7Ny5E99++y02bNjQYTJvs7OzUVNTI+EQMyxbtgyjR4/G/PnzwefzERwcjPHjx7exlRSK7FhYWCAkJETeZojh7e3N6mDn5eWx+tapqakSOtpRUVGIjo5GdnY2FBQU4OPjAxUVFQkd7F9//RXXr19HYWEhVFVVsX37dnY+Ln1uDQ0NBAYGSozN2BYTE4ODBw9K9GHO83g8jB8/HvPmzZPQ7L5y5YrEuO+99x769+8PoFYNpk+fPtDW1oadnR22bNmCDz74AD///DMiIiLwzjvviF3H4MGDUVlZiR07diA+Ph7V1dXw9/eHjo5OG79y8ofH40ndWHF0dISjoyPCwsIgFAoxdOhQODg4wNnZGadOnUJZWRm8vLwQHR0t0Zer3dWrVwEAs2bNgrKyMl69eiV1nurqari7u2PSpEli4WWUToi8a0dTOg41NTVk/fr1hMfjER8fH3mb0yhu3LhBAJAnT57U2y4vL49YWFgQZWVlsnv37lazJygoiNC3n/wBQIKCguRtRpOIjY0lAEh6enqrz8V1n6qqqkhFRQWpqqpij127do0sX76cEEKIn58fmTZtGnn9+jX5+++/yenTpwkhhPz000/kl19+IYcPHyaLFi0ihBBy/PhxsmnTJrJ7927y008/EUIIOXbsGHn9+jXZuXMnO2ZMTAzZsGED8fPzI97e3pzjEkI4x2Zsk9aHOX/48GGye/duEhAQQDw9PQkhte/XH374gXNcUVxcXEhISAghhJADBw6QH374gRBCyNixY8n69eslroMQQs6dO0f++9//EkIICQ0NJc7Ozo1/gdoIea9bOTk5Esfy8/Nl6iut3eHDhwmPxyPu7u6krKxMbJ4XL16QuXPnEjU1NZKcnNxEqykdBRoyQZGJiooKfPbZZ9i9ezd+//13rFmzRt4mNYrs7GzweDwMGDCg3nZ9+/bFuXPn4OHhATc3Nzg5OUlN9KBQ5MmkSZPQu3dvREVFyWV+aZrZojD61tJ0tOvGe0rTwWZ+5h49erRY3HR9+tx1x5aljyiyxqhKY8GCBYiIiEBGRga0tLTQr18/zuuIjIxEQkICHBwc8Mcff9ACEPXAtX7Xlw8hS7slS5bg/fffxw8//ABdXV0sWLAA33//PWbMmIF3330Xt2/fxrlz59iEbErnhTrElAYpLi7GzJkzcerUKZw5cwb29vZysUMgEGD16tUSx2URas/OzoampiaUlJQanIfH42HDhg24fPkyLl++DD6fL6Z7+eDBA2zYsAHm5uaYOHEibG1tcfToUbHkDAqltenevTtMTU3lFkcsTTNbFCaek0tHW/Q8+f94T2k62Exc5507d6Crq8v2lzYu19iy9BFF1hhVafTp0wcDBw7Ejh07sHDhQqnXYWhoCBsbG5w4cQKenp6YOXNmveNSWpadO3fiyZMnOH/+PL7++mtUV1cjMzMT/fr1w759+5CWlgYjIyN5m0lpA6hDTKmX7OxsmJiY4MGDB4iNjZWrNFl5eTmuXLkicVwWofacnJxGKyeYmJjgzp07UFdXx/jx4xEcHIz169dj+PDhOHXqFAYNGoTx48fjzZs3WLVqFYYNG0YLWVDalOnTpyMmJqbdFAyQpoPNpaPNhTQd7PDwcFhYWGDNmjXYuHFjo8cVtY0Qwtmnru0NaXbLgpOTE8LCwjBr1iyp12FtbY3z58/D0dERNjY2EglllNYjOTkZHh4e+PHHH2FmZoZvvvkGoaGhuHTpEgICArBkyRL06NFD3mZS2gr5RmxQ2gO7du0if//9t8RxLy8voqamRpSVlUl6ejrZsmULMTc3J6ampuTZs2fk2bNnZMGCBcTKyops3bqVEEJISUkJWbt2LTExMSF2dnYkJyeHHD9+nBw7dowQQsjFixfJrl27yMmTJ8ny5cuJvr4+KSkpIStXriSTJ08m8+bNY2MT68738uVLoqenRwghRCAQkG+++YYYGxsTa2trsnLlynqv0cHBgcyePbtJ96esrIysWLGCqKqqEhUVFXLs2DFSU1Mj1iYnJ4dMnz6daGhoyBTTKe9YPEot6MAxxIQQ8vTpUwKAXL58uVXnacx9Ki8vF4srZigpKSFCoZAQUvv+lUZ1dTXJzs5m/79z507y22+/kVevXpHq6uomjytqm7Q+XLbLGqPKRUxMDFm7dq1M15GVlcXGsLZXOtO69fr1a/LRRx+RadOmcb4elK5Hh98hDg4OZrNT6R8P8+fPb/Q95BJEj4iIwMaNG6GkpITMzEykpaWhsrISFy9exMqVK+Hh4YHQ0FDw+XyEh4dDV1cXpaWlrFh6TEwM5s6dC19fX5SUlOD/2Lv/uJrv///jtyQisyJChfnx3syPJtkwiQ1jMZPEwvIj5se8Td4bb/b25m0zsymz9wh7izVaRD/EJ6mUo4jkt1nS5lfkV7+OVk6dvn/0PWedzuv0S3X68bxeLi4XXj8f53ider5e5/m8P+VyOQA5OTlkZmYil8u5ceMG8fHxBAcHY25ujkwmY9SoUSQmJhIREaF1vuKKB6iXJwonJSWl0iOEmzZtyqJFi8jLy+OHH37Azc1NazR0u3bt1O9DaX0qq1tAQIDW0zlVZmtF81WL57ZWdN/Lly+r81hdXFz45ptvSp0mu6yM2GvXrvHll19qLJs9e7bO/p+VyZKti6ytrenZsyehoaH6LkVNVw62rhztkkrmYDdt2hQjIyPMzc0lZ8Es73GL16ZrH6nay9tHtSR/f382bNiAh4dHuV6HpaWl1lTrQvVZsmQJ9+/fZ8eOHbV2dlWhZtWb2DV/f399l6B3Xl5eFd7+wIEDJCcnEx8fj4mJCbt27WLfvn0sX74ce3t73n33XTp06MDatWu5du0arq6u5OfnY2JiwtSpU5k/fz52dnY4OjrSvHlzwsLC1A1CBwcHtm3bhpOTk/qcxQeMqAbchIWFsXjxYgDc3d0B+Pjjj7XOV1xUVBTLli0DigLU9+7dW+prTUlJea6+z/7+/nTo0IEZM2bo3MbY2JilS5cyY8YMsrKyaNmyZaXPV1kpKSlafRtv3bpFeno6rq6uFBQUlPtYly5dwtfXF29vb2xsbCq07+PHjwH48ccfuX37Nhs3bmT27Nns2rWrzHNJSU9P5/Tp0xrLIiIidA5Aqmi9ddn48ePZuXMnnp6etT4PvDIWLVqk7xIqZdKkSUyaNEn977r6OuqjsLAwtm7dip+fn0afdKFhqzcNYhcXF32XoHf79u2r0PaLFy9m8eLFzJ07l7lz59K9e3emT59OUFAQa9euxcLCQj2K2tbWll69ejF37lxu3rzJmTNn1ANgzMzMcHV15cyZM+qBKH369FEPRDE2NlZPgXnq1Cl1nyzVXXmvXr1ISkrC1tYWHx8fbGxsJM9XnCpAvW/fvhoB6lLkcjkPHjx4rgzJq1ev8vrrr5fZ4BgwYADPnj0jKSlJPRq9KkhlsZ44cQKlUombmxtHjx5Vvw+qxlHbtm3x9PRUHyM6Oprc3FwmTJjAsmXLuHDhAhYWFvj7+2NgYKCV51o8UzYtLU29b3myWaHoBqFNmza0adOGnTt30rlzZ549e0bjxo1LPdebb76plctaGqnM2bNnz5Kbm8vNmzcxMzNj/vz5jBs3Dk9PT/72t79V2f9LbeDk5MQXX3zB2bNnq/SaE4T66OHDh8yYMYPp06dr3LAIgvieQMDAwIAHDx7g4ODAsWPHOHLkCEuXLtXYRmrgh9QAGKmBKG+//TZHjhxh+PDhnD17Vuv8U6dOZc+ePUyaNImDBw/y2muvlTnQZMqUKWzZsoWJEydy6NChUl+fakar52kQ//nnn+UaXKHaprKJEwUFBSgUCq2nm+np6RgbGxMcHMycOXPYunWrZFcUAAsLC06ePMmsWbPYtm2b+hhZWVlkZGRIdlFJSUlh2rRphIaG4uDggJ+fHx4eHowYMYKhQ4eq95XqEiOXy1EoFBw+fBgXFxfJBqxqVqhz586Vea6yusuUJHV+Vb0eHh5s3bqVRYsW0a9fv3rXGIaim8MuXbpw4MABfZciCLVaYWGheqDcxo0b9V2OUMvUmyfEQuWpGp0WFhacOXNG3fgsPqra1NSU4OBg7t69i7m5ubqv25AhQ0hLS1P3+bOysiIsLIwnT55o9L2LjIwkJydHnStanKWlJSEhIWRnZ6v78+k63+XLl4GivpPHjx/n/v37ZWYLp6SkYGBgQOfOnSv3Bv3/80k15ktKTk4GoGPHjpU6z5o1azhw4AAjRozQirMqnmG6fPlydZQTaHZFGTFiBFD0f/Ptt9/So0cPjeNIdVG5d+8eISEh7Nq1i4cPHzJu3DjJ+qS6xEyaNEkjmzU+Pl5y38zMTF566SUKCgpKPdehQ4e0usu0bt1a6yajUaNG6uup5PlV73+LFi1YuHAhn376ab2eknv8+PEEBARozOImCIKmLVu2EBYWxvHjx/XSpU2o3cQTYgkVHcBTl23bto233nqLIUOGEBcXV2bkT8mBHyUHwKhIDUSRagwXJzUgpqyBJmU1hqGoQdy+ffsyz1+ad955h9OnT/Prr7+Wut3OnTvp0aMHnTp1qtR5Sst2LZlhamxsrB4MeerUKfV2N27cAODChQvqRnRxqi4qAD4+PiQmJlZ7NmtUVBQKhYK2bduWeS6pXNZu3bpx9epV7t27B8DJkydp1aqV+ry6zi+Xy9myZQuTJ09m/fr1Ol9XXTd+/HiuX7/OlStX9F2KINRKv/76K59++ikrVqxg4MCB+i5HqIXEE2IJFR3AUxfl5+fj4eHBf//7Xz777DPWrl1bb0faXrt2jZdffvm5juHo6Ejfvn1xdXXl6NGjmJuba23z888/s3PnTvbs2fNc59IlKCiIxMREUlNT8fX1xdTUlJkzZxIeHo5SqWTw4MEAHDlyhCtXrpCVlcXGjRuJjY3VOM7UqVOZN28egYGBKBQK3NzcePz4MatXryYuLo7c3FyCgoKYPHmyVqasq6sr7u7uBAYGkpuby4YNG4iMjJSsNzIykkGDBtGoUSNefPFFdR/3wYMHl3ouJycn3NzckMlkJCUl4e3tTaNGjVizZg29e/emZ8+eXLlyhcDAwDLfM1Uf+ZkzZ/LGG2/g6OhIv379KvtfUGsNHDiQ9u3bs3//fnr27KnvcgShVlH9nHv11Vc1cqwFQYN+U9+eX3XkIsbFxWll1nbu3Lnw2rVrWrm7BQUFhRMnTix0dHQsdHR0LHzy5Ik6i3fEiBGFM2bMKFy3bp1krm5Vc3Z2LnR2di7XtklJSYUdOnQoDAkJqfI6qsO+ffsKjx8/rrEsMjKyMCgoqPDIkSOlvg57e/vCefPmqf+dmZlZmJSUVOZ+Jf3xxx+FnTp1KmzevHnhV199VXjy5MnCq1evFm7ZsqXwtddeKwQKly1bVq5jVfS6LS3D9OnTp1rbp6enl3nMkpmtUtmsujJlnyebtbznksplVSgUhX/88YdWDnRlUcdziIubN29e4WuvvVYtx65P75NQeXU1h3jp0qWFJiYmhb/99pu+SxFqsfr5SLCaBAcHa+XuSg0QCgwMpEePHoSHh9OuXTvS0tIqPFCounXv3p0bN26oZ1Cq7VJSUrh//77Gslu3bpGSkoKNjU2pT/1+++03jSfEly5dYsOGDWXuV1KnTp2IjIykWbNmbNiwgYEDB/Lqq6+yYMEC7t+/T2hoKF999VXFX1w5lJZhKtUVxNTUtMxjluyiIpXNqitTtrLZrBU5l1R3mcaNG9OpU6d6GS/2vJycnDh//ry6y4y+lWdK9Yp6nunbhYbpxIkTfPvtt3z33Xf1clCtUHVEg1iCrgE8M2bMICEhATs7O1JSUmjevDkmJiaEhITg7OxMaGgoubm5hIeHq/tWDh8+HCgaKBQXF4erqyu//PJLreh+YWxsXCPn2bBhg3qwWXHbt29n+vTpjBs3jg8++IDff/8dX19fdUrB0aNHNfrS7ty5k4EDBzJu3DiNX/rR0dEcPXoUuVzOxx9/jL29Pc7OzhQUFPD48WMePHjAnj17GDNmDOnp6Xh6enL06FE2b96s3s/Dw4O33nqLDz74QN3w9vPzw93dnXfffZexY8eSnJxMy5YtadeuHcnJyXz00Uf0798fR0dHJkyYgKOjY7W9h4sWLRLRgkKphg4dirm5ea1JmyjPlOoV9TzTtwsNT2ZmJlOnTmXs2LHMmjVL3+UItZxoEEvQNYAnNjaWTZs2ERcXx5UrVzhz5ozkAKG+ffuqfzir+l9KDRRqKKRmwoOKRYlB5eLEoqKigKIZDUtGfFlZWemMEgPpOC+VX375hU6dOnH69GlsbW2r5X0ThIpo3LgxY8aMKVff6uqSnZ3N0qVLGTZsGOvWrVMvl7rplLrhlNouICCAuXPnas1IqetcgqAyf/58/vzzT7Zu3arvUoQ6QDSIJRQfwOPg4MDYsWPx9PSUzN0dPHgwPj4+zJo1S924mjRpEj/99BNDhw4lPDycxo0bl5mrWx95eXlhb29PUFAQM2bMwN7ent9//11jm+JRYjExMRrrSj5FLx4ndvLkSa3zhYWF8d577wFFcWL9+/fn7t27NG7cGA8PD/UTfKn9Ro4cCRRFiaka0aAZ56WapASKUhNGjRoFFM2UJwi1wfjx4zl16hS3b9+u9nNJZWbrmlK9vPnVurZTTfNeXEWnbxcalt27d+Pn54ePjw9t27bVdzlCHSAaxDrMmDGD+/fv89NPP/Hw4UPs7e0ZOnQokZGRrFixgsOHD9OkSRNGjBhBWFgYmzZtYvfu3Rw6dIjHjx+zceNGIiMjcXFx4eWXX1bn6q5fv54TJ07Uy5HuJS1evBiZTMa4cePYsWMHMplM60agvFFiULk4MX9/f6ysrNi/f7/OODFdUWKgO85LNVMeUOZMeYJQU0aOHMkLL7xQI90m1qxZQ79+/dS51KD7RlHXTWfJG05d26mmeS9O3JQKuty5c4eFCxfy97//nXfffVff5Qh1hIhdK4VqAE9xUrm7LVq0UP/9hRdewMzMjBkzZk7nDG8AACAASURBVNCoUSMKCgo0fjlZWlpWb9G1kIGBgc5BUOWNEoPKxYnl5uby559/MmvWLK2Ir5YtW2JpaSkZJVaWKVOmMGXKFA4cOIBcLqdr167P9yYJQhUwNjbGycmJn3/+mUWLFlXruVatWsWqVas0lumaUl1qSnfQvuEsa7vynEto2JRKJR9++CHt27evtkHOQv0kGsTVwNraWp1b3LixeIu3bNmic92KFSt45513NCZZkJrV7rPPPuOzzz4jIyNDnaDQvXt3reOVnPHu7t27fPrpp8yfPx8TExP1ugsXLmBoaKhONZCaXW/27Nnqvw8bNoxhw4YBf82WV96Z8gShJk2dOpXhw4dz5cqVGs8k1nWjWN78aqntjh8/XqFzCQ3b119/TVxcHPHx8TRr1kzf5Qh1iGitVSPRGC5d8SixknTNKleROLHU1FQePnzI66+/LhnxVVJlosREY1iobYYNG4a1tTV+fn588cUXNXpuXVOqS03p3qVLF42aVTecpW3Xpk2bSk3fLjQMiYmJrFq1iq+++gobGxt9lyPUMaIPsaA31R0lduHCBaDoa9j6Jjw8nIMHD5KVlcX169d1bld8vWofoX5r1KgRH3zwAT///DNKpVIvNehqoJb3prMiN6eiMSwA5Obm4ubmxoABA/jkk0/0XY5QB9WbR5gTJ07Udwl69/jxY1q3bq3vMmqNCxcu0LFjR8zMzPRdSpWzsbGhoKCAS5cu4evri7e3t+R2xder9hHqPzc3N/UA3iFDhui7HEGodh4eHty5c4dDhw5J9jkXhLLUmwZxQEAAAwYMwMrKSt+l6IXq9Qt/uXDhQr15OiyXy1m2bBkXLlzAwsKCCRMm8OzZM0JCQjh//jzR0dEMGTKEyZMnk5OTA4Cvry+enp7q9WlpaeTm5jJhwgRWrlzJ+fPnsbCwwMvLi2PHjhEZGUlqaiqGhoZ4eXnRrVs3Pb9qobJeffVVbGxs+Pnnn0WDWKj3wsLC8Pb2xs/Pj44dO+q7HKGOqjcNYiiK+Wqos3mJqWy1nT59Gjc3N32XUSEFBQUolUoaNWqkMY1x8UlHfvzxRy5fvkzbtm3x8PDA19eXoUOHkpyczLRp0xg7dizffPONehIS1frt27eTk5Ojznr19PRk79697NixgzZt2qgzYVWzBa5Zs0aP74TwvKZNm8aaNWv47rvvxOAiod56+PAhM2bM4MMPP2TSpEn6Lkeow+rV9wqTJk1SR3w1tD+CpsePH/P777/z+uuv67uUCpHKdgXtSUc6d+6sta/UNOJSypsJK9Rtrq6uyOVyDh06pO9SBKHazJo1i2bNmrFp0yZ9lyLUcfXmCbG/v7++S9C7n376Sd8l1BqqWa369++v50oqRirbFf6adMTW1hYfHx9u3bqllc6hmkZ81qxZLFiwQOc5ypsJK9Rt7du35+233+bnn3/G2dn5uY/n5eXFvn37qqAyoa66c+eOvkvQsGXLFg4dOkRUVBQtW7bUdzlCHVdvGsQNtatEceKX1V9Onz5N165d680gw5KTjowaNYo///yTl156iZiYGGQyGYMHD2b16tXExcVpTUIik8nUxypvJqxQ902dOpVZs2bx6NEjyXjD8qqKBrVQ91lZWdWaayE5OZnPPvuMFStW4ODgoO9yhHrAoLCOPw7au3cvkyZNEk+1+CtpQzSMwdHRkRdffJE9e/bouxRJlb1ui086ovLs2TP1JCNyuRwDAwONSUiKry+u5EQkDZGBgQH+/v719ob66dOntGvXjq+//pr58+fruxxBqBL5+fm8+eabFBQUcPLkSYyMjPRdklAP1Ks+xLVBVlYWCxcu1FqelJTE5s2b9VBRw5SQkFDnukuUR8nGMBRNMqJq7LZo0UJyEpKSjWGo3EQkQt1iYmLC+++/z88//6zvUgShyqxcuZIrV66wZ88e0RgWqoxoEFexvLw8jh07prU8MzOTq1ev6qGihufGjRs8ePCAN954Q9+lCILeffjhh5w6dYpr167puxRBeG4nTpxg/fr1bNy4kb/97W/6LkeoR+pNH+Ly8PX1RalU4ubmxtGjR7l48SKTJk1iyZIl5OXlYWdnx+eff45SqdTKczUyMmLlypVcvnwZKysrXn75ZTw8PFi3bh0ymYyCggJ27dpF06ZN1efLzs7miy++4PTp07Rq1Yr27dvr66U3KDExMTRr1ox+/frpuxRB0Lvhw4fTtWtXtm3bhqenp8a6hIQE/Pz8uHr1Krm5uXTr1o0xY8YwduxYMbmBUOtkZmYybdo0xowZg7u7u77LEeqZevkTr6CgAIVCoTUrV3Z2NnK5HICcnBwyMzPZv38/dnZ2BAUFYW1tTU5ODikpKUybNo3Q0FAcHBzw8/MjMDCQHj16EB4eTrt27UhLSyMiIgKFQkF4eDgLFixg9erVGufbs2cPpqamHDt2jN69e9fY62/oZDIZAwYM0Lg5EYSGysDAgJkzZ+Lj46O+yVdNc9u/f3/CwsLo0KEDPXr0ICkpCScnJwYMGMDNmzf1XLkgaFqwYAE5OTls3bpV36UI9VC9bBDrynItLj8/HygahZ2QkICdnR0pKSk0b95cMs81PDxcHU81fPhwAA4dOkRcXByurq788ssv6mOqREVFMWrUKADeeuut6nipgoTjx4+L2bkEoZiZM2fy9OlTDhw4ABR1ozh48CDBwcFcuXKF//3vf2zevJmYmBguXrxIXl4ew4cPJzMz87nOGx4ezsGDByu1b1RUFMHBwcTHxzNu3DiePHmiXpeQkKC1TJfSxm+oziHGftR+AQEB7Nmzhx07dmBhYaHvcoR6qF42iFetWsXFixfZsGGDxnJjY2OePn0KwKlTp4Cip4mbNm0iLi6OK1eucObMGXWea0BAAL169QKgb9++6j7AqggrW1tbnJ2d2bNnD9988w2Ojo4a5+vbt6+6397Fixer7wULanfu3CElJUU0iAWhGAsLC8aNG8fWrVsJDw8nICCAgIAA9WQvxfXs2ZOjR4+SkZHB119//VzntbGxqXTXpVu3bpGSksL9+/eRyWTqxjyAj48PMplM5+QzxZU2fkN1DjH2o3a7c+cOH330EQsXLtT6PSsIVaVB9SF+++23mTlzJuHh4SiVSgYPHoypqSmTJ0+mZ8+e5OTkYGNjQ0ZGhlaeq5+fH3PnzuWHH35AoVDw5ptv4uTkhJubGzKZjKSkJLy9vTXON2XKFKZMmcKBAweQy+V07dpVT6+84YiJicHIyIgBAwbouxRBqFXmzJnDyJEj+eGHH7C3ty/1W6u2bdtia2vLzp07Wbt2rcY6qTEWZmZm+Pn5ERkZSWpqKoaGhnh5eXH27Flyc3Np0qQJhw4d4t69e+Tl5fHmm28SHx/PoEGDWLt2reQxixszZgwBAQG4u7ujVCpJTEykT58+AMjlclauXMn58+exsLDAy8sLExMTrfEbCoVCa8yHFDH2o3ZRKpV8+OGHtGvXjnXr1um7HKEea1AN4k6dOhEZGUlOTg7NmzdXLx8yZAhpaWnqH3wjRoxg4MCBGnmuv//+Oxs3bqRz587897//pUWLFpiamhIcHMzdu3cxNzdX91m9fPkyUDQF7vHjx7l//z7t2rWr+RfcAMlkMvr376/x/ysIQlFXr+7du3Pq1ClmzpxZ5vZGRkbcu3ePzMxMXnzxRfVy1RiLsWPH8s033+Dn58f8+fORy+UoFAoOHz6Mr68vu3btomPHjuqft1lZWURGRvLRRx9hZGREdHQ0Q4cO5fbt2+Tl5Wkds/hnuE2bNqSlpfHgwQMuX77MkCFD1N/yBQUF0aFDBzw9Pdm7dy87duygdevW6vEbq1at4tGjRxpjPg4cOMDq1at58803tV538bEfqn0F/fnmm2+Ii4vj1KlTNGvWTN/lCPVYvewyUZaSjaVGjRppPQUomedqZmbGRx99xOjRo9X9i1UsLS1LHcAlGsM159ixYw1m1qKAgACNGeh0ycrK4vr165U6x/PsK9QuBgYGzJo1i8ePH9O4se5nIV5eXtjb23Py5EkARo4cye+//65eLzXGQsXOzg4oehiQnp6ucdyhQ4cCYGpqqo5EbNWqFdnZ2aUeU8XZ2Zn9+/erJ7VRCQsLY+TIkQA4ODgQFRUlOX6jrDEfKmLsR+1x7tw5Vq5cyRdffMFrr72m73KEeq5BNogrw9ramoiICA4fPkxkZKTGExOhdrh58yZJSUmMGDFC36XUCFX/yrJcunRJqz99eT3PvkLtM2vWLAoLCyX7y6osXrwYmUxGnz59aNKkCXFxcbz00kvq9VJjLFRUUW1SMzAWf2hgYGCg3q6wsLDUY6o4OTmxd+9eLl68iK2trXp5nz591GM1zp07x6BBgyTHb5Q15kNFjP2oHVRJKAMGDGDx4sX6LkdoABpUl4mqUNqTFUG/jhw5gomJiToNpD7R1cdy586deHp60rZtWzw9PWnatKlWrranpyfnz5/n448/Jj8/n9jYWC5cuCDZD1Qul7Ns2TIuXLiAhYUF+fn5XLp0Sf31tlC3mZub07t3b+Lj48nIyMDU1FTnttevX+f111/XmuVw8ODBWmMsPDw8nqsuqWOW7NbRunVrjI2NtT7frq6uuLu7ExgYSG5uLhs2bMDIyEhr/IbUmI9Lly5p1SLGftQOS5Ys4fbt24SGhkrOtCkIVc2gUOpWvg5RfX1Wx19GlZg4cSIA+/bt03Ml+uHs7Exubi6hoaH6LqVMuq7bgoIClEoljRo10vglkJyczK+//qruY2liYoJcLufatWvs2LGDkJAQYmNj6dChA8+ePePTTz9l165dTJw4kXPnzuHr68uAAQPYvXs3wcHBpKamah1v/vz57N69m+vXr7Nq1Sp+/PFH9TlKDhitLwwMDPD398fFxUXfpdSYgwcP8t577+Hg4EBYWBjGxsZa26xbt44VK1Zw4sQJBg4cqLVeLpdrjLGQmlK8op73mE+ePNGajlxq/EbJMR+6iLEf+nPkyBFGjx7Nnj17mDx5sr7LERoI0WVCqBcKCgo4duxYne8uoStDW1cfS9XrHTJkCCdPnpTM1S5u1KhROrO2oag/piqKy93dnf79+1f3SxZq2JgxY+jYsSMnT57ktddeY/v27Vy+fJnffvuNAwcO8M4777BixQo2bdok2RgG7TEWVeF5j1myMQzS4zfKGvNR2r5C9Xv48CHTp09n2rRpojEs1CjRIBbqhdOnT/PkyRP14Jq6SleGtq4+ljdu3ADgwoULDBo0SDJXuzhVH09dx+vVqxdJSUlAUdZrYmJitbxOQX8MDAxYuHAhTZs25ebNmyxcuJDevXvzyiuv4OLigkKhIDo6mgULFui7VKEBcnd3p1mzZnz//ff6LkVoYESH2Abq3r17/Otf/6Jdu3a0adOGNm3aYGFhQdu2bdX/rkv9tsLDw7GysqJHjx76LqVaSPWxHDNmDEeOHOHKlStkZWWxceNG7t69q5Wr/ejRI2JiYlAoFOrGr65+oFOnTmXevHkEBgaiUCjYtGkTmzdvRiaTYW9vr+d3QagqM2bMYPny5SiVSpKTk8nJyUGhUNC5c2cxYFjQG29vb0JDQ4mKiqJly5b6LkdoYEQf4nqkIn2Ib9y4wbx580hLS+Phw4c8fPhQK4ZI1TCWaiwXb0ifOnWKLl26aDSYoqKiyM7OZty4cYSHh5OXl8fYsWPLrCsrK4u0tDS6d+9eof0GDRpE9+7dadmypdaThaSkJCIiIpg/f36Zxymv7Oxs/vzzT8zNzdVPXSuiMtetrj6WJQdHKZVKjVxtgGfPnmFoaKhxk1Nan83i/5bat75oiH2IVczNzSksLOTx48f6LkUQSE5Opm/fvnzyySesWbNG3+UIDZB4QiwhICAACwsLrSdiqkZes2bNyt1Qg78aeb///nuF9lPtu2LFCo1GXlU08Lp27Up4eLjGsj///JN79+6RmppKeno66enpGv++du0aUVFRpKen8+DBAwoKCjT2NzMzo3379piZmfHs2TOMjY05d+4cjRs3pm3btpw4cQIzMzMsLS11jm6/dOkSvr6+eHt7Y2Njo3UOKWlpacTHxzNv3jzJqWaravrVjIwM1q9fz549e7h58yYALVu2ZPTo0Sxfvlw9c1Z1adGihfrvxRuvJd9LqVztJk2alPt4Jf8tta9Qt126dEndEF60aBFZWVkUFBTQpUsXxo0bR9++ffVcodCQ5OfnM3XqVF5++WVWrlyp73KEBko0iCWkpKRIPrm7desW6enpuLq6lquhpqJq5K1evbpC+wHk5eVpZYZWVQNPZcOGDYwbN45u3brRpUsXunTpAsD27dv59ddfSU9Pp3nz5mzbto0TJ06gVCpxc3MjMDCQuLg4nj59yqlTp0hPT6egoIBu3bpx9epV7ty5w759+7h58yZPnz7VOKehoSFt27bl6dOnNGnShKZNmzJmzBhiY2NJS0ujY8eOKBQKTExMmDVrFmvWrNGYmvXYsWPqaWLv3r1LkyZNcHBwUDeIq3r61eTkZIYPH86ff/7JRx99xKBBg2jWrBlXr15lx44d9O/fnx9//JFp06Y913kEQUV1A/7CCy+QnZ2NlZUVcXFxLFy4UGO7inyTAkU32VOmTMHU1JTs7Gx++eUX+vXrR15eHocPH2b16tU4Ozuzffv2UmPZBKGq/Pvf/+by5cucPXsWIyMjfZcjNFANqkG8fft2YmNj1Q28tWvXajTwjh49qg5iL5nvWjyLMjo6mtzcXCZMmKCR2ern58eUKVO0sl1VObAGBgYMGDCACRMmsHLlSp0NPENDQ7y8vOjWrZv6nFXdwCsuOTlZq8EKkJ6ejrGxMcHBwRw7doytW7fSsWNH9c1Co0aNaNasGW3atCE3N1cj/mvo0KGkp6ezePFitm/fTmZmJsbGxvz666+MHz8ePz8/8vPzefr0Kc2bNychIYGjR4+Sm5vL48ePWbFihbqOTz/9lMaNG9OxY0dSU1MZNmwYpqamyOVy3N3d8fT0xNzcnFu3bpGfn49SqazS6VefPXvGmDFjaNeuHaGhoZibm6vXOTg48NFHH/HPf/6TmTNn0qNHD/VsXYLwPFQ34GZmZqSnp9OkSRPOnTuntV15v0lRyczM5PLlyxgZGbF161bc3Nxo3LgxZ86cYdeuXTg6OjJ79mwcHR05duyY+IZAqFaxsbF8/fXXbN68mZdfflnf5QgNWL1MmSgoKEChUGj9kijewJszZw5bt24lOzsbuVwOQE5ODpmZmQBYWFhw8uRJZs2axbZt2zSOk5WVRUZGBsHBwZibmyOTyRg1ahQBAQFMmzaN0NBQHBwc8PPzA8DDw4MRI0Zga2tLRkYGQUFBdOjQgaioKMaPH8+OHTuQy+UoFAoOHz6Mi4sLu3bt0jhn8QZe7969q+R9Uk3RGhQUxIwZM7C3t9eYohVQh+D369ePmJgYjXXF+xyXjP8qycjIiPj4eGbNmsXw4cP53//+x7p16zAzMyMnJ4c2bdqwYMEC9u7dy+zZs8nJyeHLL7/k73//O0OHDmXVqlXMmTMHe3t7MjIyyMzM5NGjR6xbt45bt25x584d7O3t+e233zA0NOTvf/87P/74I4MHDyYmJgaZTMaqVav47rvv2LdvHydOnODKlSvq/+/S7N69m5s3b7Jv3z6NxrBKo0aN+Prrrxk0aBCrVq0q83hCw7BhwwaSk5O1lsvlcj7++GPs7e1xdnZW/7xas2YNI0eO5O233+bOnTvlPk90dDRHjx7Fz88Pd3d33n33XcaOHUtycrLkcb/99lsKCwvZvn07Li4urFixgmHDhrFu3ToARo8eTUREBOfOnWPz5s1V9n4IQkmZmZlMnTqVkSNHMnv2bH2XIzRw9bJBrCvLFaqugQfama1Dhw6VzHaV2k8VD+bg4EBUVBSA+smitbU16enpGvtERUUxatQoAN56661SXn35qaZoHTduHDt27EAmk2lM0QqopzBNSEjA2toaY2Nj9dPkU6dOqbcrGf8lpWSk15w5c3RO16p68tylSxdGjx5N9+7dWbp0KRMmTGD27NksXryYzz//nM2bN2NgYMCkSZM4duwYnTp1wtfXlxEjRtCrVy/+9re/8ejRI9LS0ti5cyfLly/HxcUFe3t7evXqhampKS+88ALdunVj0KBBjBs3jtmzZ/P555/z3XffsWfPHvz8/HjnnXewtrYu9f10d3cnIiKCvLy8CvwvCPWVrm9eSt5IJyYmEhERgUKhIDw8nAULFrB69epyn0d1gy51Uy113D179mBoaMiHH36o80b7lVdeYdasWfj4+FTJeyEIUj7++GNycnLw8fFRT+ctCPpSL7tMrFq1SueTOqkGnurr9FOnTtGsWTOgYg08W1tbfHx8OHDgAO+//z6zZs0qNcOzT58+XLt2jT59+nDu3Dn18VVpBVL9l/v27cu1a9fo27evultHVTEwMND5wygoKIjExERSU1Px9fXF1NSUmTNnEh4ejlKpZPDgwQBa8V+xsbFaxyoZ6fXxxx+zZs0ajeivyZMnq5/oqkhNzRoZGQlASEgIPXv2xNzcnJ49e9KiRQumTp2Kg4MDU6ZMoUmTJlhZWeHg4MB///tfoGjwoNSgQdXf79+/z6+//sq9e/e4ffs2rVu35sMPPyzzfXzllVfIy8sjNTVV68ZCaDi8vLw4cOAAycnJxMfHY2Jiwk8//aS+JsLCwli8eDFQdBMFRQ2Da9eu4erqSn5+vnqCiooqflMdHx/PoUOHNI6bn5/Po0eP1NFqUVFRLFu2DCi60d67d6/6WEOHDmXz5s0oFArRr1Oocvv372f37t0cPHgQCwsLfZcjCPWzQVyayjbwpJSngefh4cFLL71ETEwMOTk59OvXr9QGni5TpkxhypQpHDhwALlcrtGn+Xlt2bJF57oVK1bwzjvv0KpVK3WDPTIykpycHI1Z0D777DON+K/u3bur1xX/KiwkJEQj0uvNN9/Uiv66cOEChoaGGikfYWFhGlOzdunShYKCAtq3b8+SJUtYunQpAJcvXwaKGgTHjx+XnH61WbNmNGvWjA4dOtCzZ88y358BAwagUCjK3O7Zs2cA5ZoFS6i/Fi9ezOLFi5k7dy5z587ltdde01hf8kbaxsYGW1tbevXqxdy5c7l58yZnzpxRd+WqiJI31SWPu3DhQgwNDdXTNZd2o/3iiy+iVCrJzs6WnAVOECrr7t27zJkzhwULFuDo6KjvcgQBaIAN4so28ACmT5+udbyyGngAHTp0UDfyVFmuUg08lWHDhjFs2DCgKAtY1cjT1cCrLk2bNsXIyEiy32zJKYFBO/5Ll+KRXlLRX1KDeKSi8Dw9PXn48CFt27bl4MGDkqPspd6risbg9ejRg7Nnz6r31RWDl5+fj5mZmXjaIQC6v3kpeSPt5uZGly5dcHNzQyaTkZSUhLe3N5cuXdLaNyQkRGPQZsmZCEtycnJSH/e3334jJSWFtm3bqrv1lHajffPmTZo1a4aZmVll3wJB0KJUKvnwww+xsLBg/fr1+i5HENQaVINYXw08kG7kVeapS001hqEon7S2kIrCCw0NxdramnfffbdaY/BcXFxwdHQkLi6O7t27S8bgXbx4kYiICJycnKp9AovScqgrGsElVB9d37xYWlpq3UibmpoSHBzM3bt3MTc3p2nTpvTr109rX6m0FKnBSMVvqlXHPXnyJJMmTcLV1ZWDBw+Sl5dX6jcp/v7+DBs2TPTtFKrUt99+i0wmIzY2Vt1FURBqgwbVIK5NDbyGpHjOcXHljcFbsmQJoBmFt379ehITExk2bJjOGDx/f38MDAyYPHmyRhSeKgbPwsKCLl26SMbgtWvXDj8/P3UUXps2bXj//ffZuXMnoBmDZ2JiwsWLF8nNza3QYKjKKi2HuqIRXIL+lJwMBYoay9XB0tKSvXv3MmTIEP75z3+yc+dOlixZwvfff4+BgYFWY3jr1q0cPXqU6OjoaqlHaJjOnTvHv/71L7788kv69++v73IEQUO9TJkQapfy5ByXFYMHmlF4K1as4OnTp9jY2OiMwUtMTCQlJUUrCk8Vg2dlZaUzBg/QGLX/xRdfYGpqypgxY/jjjz/44IMPOHfuHJaWlhw9epSMjAzCwsKqrUGTnZ3N0qVLNeKx5HI5Hh4evPXWW3zwwQfcv39fHcElCMVlZWURGhrKlClTsLS05KeffmLbtm0MHz6cI0eOkJGRwdOnTzl58iTTpk1j7ty5fPHFFzg4OOi7dKGeyM3Nxc3NjTfeeAMPDw99lyMIWkSDWKg2VZlzDJpReDKZjK5du2p0OykZg9e/f39MTEzKjMLTFYMHf43a7969OyNHjmT37t00btyYEydOkJSUxKNHj5g3bx4ffPABtra2lXqfitOVoS0VjyXVkFfdHAhCcfv376egoAAnJyegqG/xiRMnyM/PZ9SoUZiZmdGiRQsGDRpEYmIigYGBGpPjCMLz+vTTT7l9+za+vr7V3q1MECpDNIiFalOVOcfwVxReQkICmZmZvP766xrrS+YcJyYm4u3trTPrWEUVgwdoxOCB9qj94cOHY2VlxbJly/jqq68ICwujW7duVRZLpStDWyqHurSGvCAUt3v3bhwdHTVuIF9//XViYmK4e/cuYWFhhIaGkpSUxJUrV3j//ff1WK1Q34SHh/PDDz+wefNmOnXqpO9yBEFSg+pDLOhHVeQcw19ReNevX0ehUGhNkSw1ev/x48esXr1aMuu4ZcuWWFpaSsbglaW6YvB0ZWhLxWPpyrMWhOLu3btHdHQ0/v7+kus7dOhAhw4dargqoaF49OgR06dPZ+rUqXzwwQf6LkcQdDIolJoFog7Zu3cvkyZNkpzMoqGZOHEiAPv27dNzJeWzfv16LC0ttWLwAK0YPJWMjAzmzJnDgwcPdA74KT56H4r62pbMOn727JlGDB6gEYNXXpWNwavodXv79m2mTJmChYWFugG+bNky3N3dMTMz08izt1bmJQAAIABJREFUzsnJEQNIy8nAwAB/f39cXFz0XUq18fT0ZPXq1dy/f1+M6hdq3MSJE4mPj+fChQsiwk+o1cQTYkFvKhqDB0UZliEhIWzevFnncUuO3i9v1nFtjsHTFY9VWp61IEBRdwlnZ2fRGBZq3LZt2zhw4ACRkZGiMSzUeqIPsR5lZWWxcOFCreVJSUmlNvjqi0WLFlX4yZyfnx+NGzdWPw1vaKQa4GIWMUGX69evk5iYWOVfVau6QYk/DeNPZdy4cYN//OMf/POf/2To0KFVev0JQnUQT4j1KC8vT2uSByg9Z7ah27lzJxMmTJDMcBUEQdOBAwdo3bp1tTRIPvnkEwYOHFjlxxVqj5MnT7Jx48YK75efn8+UKVPo3r07K1eurIbKBKHqNagGcUBAABEREcTGxpKYmMi6deuQyWQUFBSwa9cuAJYsWUJeXh52dnZ8/vnnyOVyrUkbjh49qjV5RKdOndTHPnnypNYEEUqlUut8TZs2VddWfKKHVq1a0b59e329TbXWlStXSEhIENN9CkI5BQYGMm7cOBo3rvof9QMHDqzXfa+FIpVpEK9atYpLly6RmJgo2T1NEGqjetllQleWq1wu58aNG8THxxMREYFCoSA8PJwFCxawevVq9u/fj52dHUFBQVhbW5OTkyOZ9So1eUTxY0tNECF1vuKkcmYFTTt37qRTp05isgBBKIe7d+9y+vRpxo8fr+9ShAYkNjaWdevW4enpycsvv6zvcgSh3Oplg1hXlivAqFGjaN68OYcOHSIuLg5XV1d++eUX8vPzmTp1KgkJCdjZ2ZGSkkLz5s3LzHotPnmE6thSE0RIna84qZxZ4S/5+fns3r2b6dOna6RRCIIgLSgoCBMTE4YPH67vUoQGQi6XM336dEaOHMmcOXP0XY4gVEi97DKhK8sV/ppowdbWll69ejF37lxu3rzJmTNnkMlkbNq0CTMzM1xdXTlz5oxk1quxsTGPHj0CiiaPUI3eVh1bNUGEra0tPj4+2NjYSJ6vOKmcWeEvYWFh3L9/nw8//FDfpQhCnRAYGIijoyPGxsb6LqXWSE5OZvny5fzxxx8MGTIEd3d3XnnlFclto6Ki1DGN2dnZWFlZERcXpzEQOjw8nLy8PMaOHVtTL6FWmz9/PpmZmfj4+FR6MJ4g6Eu9bBCXh5OTE25ubshkMpKSkvD29iY7O5vJkyfTs2dPcnJysLGxoX379lqTNhgaGuqcPAKkJ4jo0qWL1vmKq66JHuqLH3/8EQcHBxErJgjl8OTJE2JiYvj555/1XUqtoVQqeffdd/nXv/6Fi4sLZ8+e5YMPPiAhIUFyKuFbt26Rnp6OmZkZ6enpNGnShHPnzmlsY2Njo9U1r6H67bff8Pf3JzAwEAsLC32XIwgV1qAaxNOnT1f/3dTUlODgYO7evYu5ubl6gNuQIUNIS0tTD2qzsrLSynoF1BMgSOXlWlpaEhISojFBhK7zXb58GdCdMysUTUoRGhrK7t279V2KINQJISEhGBoaMnr0aH2XUmvExsby6quvMm3aNAAGDRqEt7c3T548wdvbW2PAs5WVVbmOGR0dTW5uLk2aNCEyMpLU1FQMDQ3x8vKiU6dOWgOpy3vcuujll1/mxo0b5X6NSUlJREREMH/+/CqrISsrixUrVvD9999X+7mE+qfBd8a0tLTUSHto1KiRZMKDVNarrskjVKSiwUqeryTRGNa2fft2WrVqxfvvv6/vUuqU8PBwDh48qLGsoWRcN3QHDx7k7bffpmXLlvoupdYICwvT6k/9xhtvkJCQUOqA59JkZWWRkZGBXC5HoVBw+PBhXFxc2LVrV5kDqeujijT4qyNeVESZCs+jQT0hFuqe/Px8duzYwezZs0u9kRC0SX2dK34x1H/5+flERkby5Zdf6ruUWqV169akpKRoLPu///s/vL29efr0Ka6uruTn52NiYlKp49vZ2QFF3/bFx8dz6NAhrl279tzHrYs2bNjAuHHj6Natm8ZyqXhRqWjTdu3a4efnp/XUvV27dlrbnjhxQh15WnzQu4gyFSpKNIiFWi0oKIh79+4xe/ZsfZeiV9u3byc2Npb09HSaN2/O2rVrOXXqFIcOHeLevXvk5eXx5ptvEh8fz6BBg1i7dq3661wnJyfxi6EBiY2NJTMzU51aIxQZMWIEEydO5B//+AcdOnQgJSWFf/3rX7i7uwPoHPBcXqpB1YWFhYD0wO2GIjk5madPn2otLx4vumrVKh49eqSONvX09GTv3r3s2LGD5cuXazx19/X1ZdeuXbz88sta23bo0EEdeVr8nFLnEoTSNPguE0Lt5u3tzejRo+ncubO+S6kRujK009PTMTY2Jjg4mDlz5rB161bkcjlZWVlERkbSs2dPjIyMiI6OJi4ujtu3b6u/zhUZ1w3LkSNH6N69uxiYW0Lv3r1ZunQpo0eP5q233mLgwIGsXLmSyZMn83//939MmTIFZ2dnXnrpJZ3HCAkJwc7OTv1H1fiV4uTkVO7j1hdeXl7Y29sTFBTEjBkzsLe35/fff1evl4oXLS3atPhT9/T0dJ3bqiJPixNRpkJFiSfEQq2VnJxMVFSUVj/Y+mzNmjUcOHCAESNGsGHDBo11gwYNAqBfv34sX76crl27qqfkNTU15Y033gCK+rtnZ2er94uKimLZsmVA0S+GvXv31sArEfTlyJEj4umwDjNmzGDGjBncuXOH9u3bq9MlpAY8Fx+ErVKep4zDhg1j2LBhOo9bny1evJjFixczd+5c5s6dy2uvvaaxXipeVCraVKXkU3dd20pl04soU6Gi6k2DeOLEifouQe9OnTrFgAED9F1GldmyZQvW1tYN6pd7aRna165dAyAhIQFra2sAjV+yqtzPwsJCjSdX4hdDw5GWlsa5c+f4z3/+o+9SajWpwV+WlpbVcq7qOm5tZmBgIJlDLBUv6urqqhVtqovUtsePH5fcVkSZChVV5xvE1tbWODs767uMWmHAgAEMHDhQ32VUCblcjo+PD59++qlkRmhDFBQURGJiIqmpqfj6+nL69Oly7Sd+MTQcR44cwcjISExvLujVli1bJJfriheVijYtPm6k+FP3ktsWz6Zv06aNiDIVKq3ON4gHDhzIvn379F2GUMV8fHzIy8sT038Ws2LFCt555x1atWpFo0aNsLGxUa/7+uuv1X8PDAwEoGfPnupl4hdDw3DkyBGGDBlCixYt9F2KIOgk9XNIKtpUl4psK37mCeUlBtUJtY5SqWTTpk24ubnRunVrfZdTKzRt2hQjIyPMzc0l+8uVh/jFUL8VFhYSERGhHnQkCIIglF+df0Is1D8hISHcuHGDkJAQfZdSayxatEjfJQi13LVr13jw4IF6oGV1Cw0NFd/O1XPNmjXTdwmCUGPEE2Kh1vHy8mLMmDH06NFD36UIQp0RExNDixYt6Nu3b42c7/r165w6dapGziXUvFOnTnH9+nV9lyEINUY8IRZqlbNnz3L8+HGNLEpBEMoWExPD4MGDady45n6sDxgwQDwlrqcmTpzInTt39F2GINQY0SAWahVPT0969+5dY1/7CkJ9cfz4cRYuXFij5wwICJCM1xLqh/oU4ykIZRENYqHWuHv3LgEBAWzfvl38khWECrh+/Tqpqak1Grfm6OjI4sWLa+x8Qs1LSkoS3WKEBkM0iIVaY9OmTbRu3ZrJkyfruxRBqFNiYmJo3rw5/fr1q7Fz/u1vf8PFxaXGzifUPDGrpdCQiEF1Qq2QmZnJ1q1bWbRoEU2aNNF3OYJQpxw/fpxBgwaJz44gCEIliSfEQq2wadMmAObOnavnSuq2gIAALCwssLe3Vy+LiooiOzubZs2akZeXx9ixY8t1rKysLNLS0ujevTvh4eEV2nfevHmkpqZqLHv33Xd56aWXyMvLw8HBgbS0NG7fvk12djbjxo0r/4sUtJw8eZIpU6bou4wql5SUREREBPPnz5dcr7q2pa4fhULBp59+yuDBg7G2tmbt2rX4+PioJ3VISEhgzZo1GsvKovocjBo1Sn3s8syUWvyzVNb6in7WBEGoGuIJsaB3OTk5fP/99/z973/nxRdf1Hc5dVpKSgr379/XWHbr1i1SUlKwsbGp0Ffqly5dYsOGDQAV3nf16tVs2bKFF198kTFjxrBlyxYmT56sPo7q2KrahMp78uQJN27c4PXXX9d3KVUuMzOTq1ev6lxf2vVz7do1bty4gbOzM/fv30cmk3HgwAH1eh8fH2QyGbm5ueWuR3X9Fj92eRT/LJW1vqKfNUEQqoZ4Qizo3bZt23j69GmNj5CvS7Zv305sbCzp6ek0b96ctWvXcuLECZRKJW5ubhw9epSLFy8CsHPnTjw9PWnbti2enp7qY0RHR5Obm8uECRNYtmwZFy5cwMLCAn9/fwwMDJg8eTI5OTkA+Pr64unpyfnz54mOjiYtLU2978qVKzl//jwWFhZ4eXlx7NgxIiMjSU1NxdDQEC8vL7p16waAiYkJrVq1okOHDgCEhYWRm5tLSEgI58+fx9TUFAsLCxQKBevWrUMmk1FQUMCuXbuwsrKq4Xe5bjp9+jSFhYXY2dnpuxQtfn5+HDp0iHv37pGXl8ebb75JfHw8gwYNYu3atcjlcq3rycTEhC+++ILTp0/TqlUr2rdvDyB5jahIHefbb7/l6tWrhIWFATBmzBgCAgJwd3dHqVSSmJhInz59UCqVuLi4aFz7ZmZm+Pn5aV3XZ8+eJTc3l6ioKK5evcrBgwc5f/681nV7584dlixZQl5eHnZ2dpw7d079WRoyZEi1fNYEQXg+4gmxoFcKhQIvLy8++ugj2rRpo+9y9K6goACFQkFBQYHG8vT0dIyNjQkODmbOnDls3bqV7Oxs5HI5UPSUPTMzEwALCwtOnjzJrFmz2LZtm/oYWVlZZGRkEBwcjLm5OTKZjFGjRpGYmEhKSgrTpk0jNDQUBwcH/Pz88PDwYMSIEQwdOlS9b1BQEB06dCAqKorx48ezY8cO5HI5CoWCw4cP4+LiotFQKUl1HNWxX3nlFQAiIiJQKBSEh4ezYMECVq9eXdVvbb11+vRpXnrpJdq2bavXOqSuXblcTlZWFpGRkfTs2RMjIyOio6OJi4vj9u3bktfTnj17MDU15dixY/Tu3Vt9rNKuEanjfPLJJzg4ODBq1CgA2rRpQ2FhIQ8ePFA3TAsLCyWvfVXtJa9r1fWrOnbjxo0la9q/fz92dnYEBQVhbW3N3Llz1Z+lmvqsCYJQMaJBLOjVrl27uHfvHp988om+S6kV1qxZQ79+/fjss8+01g0aNAiAfv36ERMTo7EuPz9f/fcRI0YAMGTIEE6ePKl1nLCwMN577z0A3N3d6d+/PyYmJoSEhODs7ExoaKjOr5HDwsIYOXIkAA4ODuoJVFRPJ62trUlPT6/QawY4dOgQcXFxuLq68ssvv2i8HqF0Z86cqRXdJXRdu6pMcVNTU9544w0AWrVqRXZ2tuT1FBUVpW7EvvXWW+rjlHaN6LouS3J2dmb//v3s3buXSZMmAZR67Zd1XeuqaerUqSQkJGBnZ0dKSgrNmzdX76Pvz5ogCNJEg1jQm4KCAr755hvc3Nzo2LGjvsupFVatWsXFixcl+xteu3YNKBoMZG1tjbGxMU+fPgXQyAq9ceMGABcuXFA3oovr1asXSUlJQFE/ysTERLy9vRkwYAABAQH06tVLZ319+vRR13Hu3Dn18Rs1KvpRUlhYWOHXDGBra4uzszN79uzhm2++wdHRsVLHaYjOnDlD//799V2Gzmu3adOm6r+r8sULCwspLCyUvJ769u2rXqbqBgSlXyO6rsuSnJyc2Lt3LxcvXsTW1hag1Gu/rOtaV00ymYxNmzYRFxfHlStXOHPmjHoffX/WBEGQJvoQC3qzb98+bty4wcGDB/VdSp0QFBREYmIiqamp+Pr6YmpqysyZMwkPD0epVDJ48GAAjhw5wpUrV8jKymLjxo3ExsZqHGfq1KnMmzePwMBAFAoFbm5uPH78mNWrVxMXF0dubi5BQUFMnjyZmJgYZDKZel9XV1fc3d0JDAwkNzeXDRs2EBkZWeHX8tJLLxETE0OrVq1o06YNTk5OuLm5IZPJSEpKwtvb+/nerAbi5s2bpKWl1YoGcWVIXU9GRkZMmTKFAwcOIJfL6dq1K4DkNXLp0iWdx1F1ISqudevWGBsbazSYBw8ezPbt2zWufQ8Pj3LVr+u6NTU1ZfLkyfTs2ZOcnBzef/99Ro8ejUwmY/DgwTX6WRMEoXwMCsVtpqAHBQUF2NjY0Lt3b3WfvYZE9ZVteT9+69evx9LSknfeeYdWrVqpnxJBUf/h4l/JAmRkZGBqalrqMbOzs3nhhRfU/5bL5RgYGGBiYqJe9+zZMwwNDTE0NNTY98mTJ+WOqtJF6th3797F3Nxc46lidTIwMMDf37/OTjARGBiIs7MzmZmZtGjRosbOW9Xvm9T1dP/+fdq1a6e1bWnXSGWvS6lrvyKkalIqlaSlpakHBRa/3mv6s1ZZFf05JQh1mXhCLOjFrl27+O233wgICNB3KXVC06ZNMTIywtzcXGtdycYwUGZjGND6pV+8QaVap2uih6r4BS11bEtLy+c+bkNy4cIFunbtWqON4eogdT1JNYah9Gukstel1LVfEVI1NWrUSN0YBs3rvaY/a4IglE00iIUal5uby+rVq3F3d1enDAilW7Rokb5LEGqhS5cuaSQxCIIgCJUjBtUJNe6HH37g4cOHrFixQt+lCEKdJhrEgiAIVUM0iIUalZmZyVdffcXixYvFxAuC8BxycnK4ceMGffr00XcpgiAIdZ5oEAs1av369SiVSpYsWaLvUgShTrt8+TJKpVI0iAVBEKqAaBALNebevXt89913LF++XAwUEYTndOnSJUxMTOjSpYu+SxEEQajzRINYqDH/+c9/MDU1Zf78+fouRRDqvCtXrvDqq69qRPAJgiAIlSNSJoQacfXqVf73v/+xZcsWyZgwQRAqJikpSaS0CIIgVBHxaEGoEQsXLqRPnz5Mnz5d36XUSeHh4Rw+fLjazxMVFUVwcHC1n0d4fklJSXTv3l3fZVS58PBwnbNXZmVlcf369RquSBCEhkA8IRaqna+vL9HR0cTGxmrNwiSUT+/evVEqldV+nlu3bpGenl7t5xGeT35+Pn/88Ue9bBDb2NhQUFAgue7SpUv4+vqKqb0FQahyokEsVKusrCyWLl3KRx99xIABA/RdTp11/PhxFAoF77//PitXruT8+fNYWFjg5eXF0aNHUSqVuLm5cfToUS5evEinTp2IiIggNjaW5cuXExkZSWpqKoaGhnh5edGlSxcmT55MTk4OUHTTYmZmpudXKZTX77//jkKhqPUN4oCAAPV1mJiYyLp165DJZBQUFLBr1y6srKy4c+cOS5YsIS8vDzs7O7p3705ubi5vv/22xvLPP/8cT09Pzp8/T3R0NEOGDNG6hsPCwrSu9Xbt2rFs2TIuXLiAhYUF/v7+KJVKyVoEQWi4RJcJoVotX74chULBmjVr9F1KnVBQUIBCodB6QpaVlUVmZiZBQUF06NCBqKgoxo8fz44dO8jOzkYulwNF2bSZmZnI5XJu3LhBfHw8crkchULB4cOHcXFxYdeuXaSkpDBt2jRCQ0NxcHDAz89PHy9XqCRVt4Fu3brpuZK/SF27xa/DiIgIFAoF4eHhLFiwgNWrVwOwf/9+7OzsCAoKwtramkePHpGRkaG1PCcnBw8PD0aMGMHQoUMlr2Gpaz04OBhzc3NkMhmjRo0iMTFRZy2CIDRcokEsVJuzZ8/i7e3Nhg0baN26tb7LqRPWrFlDv379+OyzzyTXh4WFMXLkSAAcHByIiorSWJ+fn6/++6hRo9QDGO3s7ACwtrYmPT0dExMTQkJCcHZ2JjQ0lNzc3Op4OUI1SUpKwsLCghdffFHfpajpunZV1+GhQ4eIi4vD1dWVX375RX2tTp06lYSEBOzs7EhJSaFJkyaSy0sOxtV1DZe81sPCwnjvvfcAcHd3p3///jprEQSh4RJdJoRqoVQq+fjjjxk4cCDTpk3Tdzl1xqpVq1i1apXO9X369OHatWv06dOHc+fOMWjQIIyNjXn06BEAp06dolmzZgAacVyqvxcWFgLg7e3NgAEDmDVrFgsWLKimVyNUl+Tk5FrXXULXtau69mxtbenVqxdz587l5s2bnDlzBgCZTMamTZswMzPD1dWV/Px82rZtq7Vctb2Krmu45LXeq1cvkpKSsLW1xcfHBxsbG521CILQcIkGsVAttm7dSkJCAmfPnsXAwEDf5dQbrq6uuLu7ExgYSG5uLhs2bMDQ0JCZM2cSHh6OUqlk8ODBZR5n8ODBrF69mri4OHJzcwkKCsLDw6MGXoFQFW7evEnnzp31XUaFODk54ebmhkwmIykpST0wztTUlMmTJ9OzZ09ycnKwsrLi2bNnWsttbGx49OgRMTExyGQyyWtY6uZ76tSpzJs3j8DAQBQKBW5ubnTp0kWyFkEQGi6DQtVttCBUkdTUVHr16oW7uzvr16/Xdzm10t69e5k0aRLl/fht2bIFgHnz5gHw5MkTrdn+cnJyKpTxLJfLMTAwwMTEhOzsbF544YVy71tfGBgY4O/vj4uLi75LqZA+ffrw3nvv8cUXX+jl/M/zvt29exdzc3OaNm2qXqZUKklLS6N9+/Ya20otf/bsGYaGhhgaGlboGpZaL1WL8JeK/pwShLpM9CEWqtzs2bMxMzNj5cqV+i6lXvjjjz/Yv38/9vb26mVSU19XdMKTFi1aYGJiAtAgG8N12a1bt+jYsaO+y6gUS0tLrQZoo0aNtBrDupY3adJEHd9YkWtYar1ULYIgNEyiy4RQpbZt20ZYWBjR0dG0aNFC3+XUC507dyYiIkLfZQi1REZGBpmZmXTq1EnfpQiCINQb4gmxUGX++OMP/vGPf/DZZ59pPM0UBKHq3Lx5E6DOPiEWBEGojUSDWKgSSqWSGTNmYG1tzb///W99lyMI9datW7cA0SAWBEGoSqLLhFAlvvvuu//H3r3HVVXlj/9/AYIkaogXDCGlKRsDJS+l4g01DTM1DRVBhrw0Yua3tEYdm/EDYU7lCFZm3gZlmDQJ5aIoIuAFRRkVBC85JDSpqVjKVQQPl98f/NjD4eyjgCC39/Px8CHuy1prbzfnvM8677UWx44d48SJE5iamjZ0c4Rotq5evUrHjh2V3FkhhBCPTnqIhSI3N5eFCxdqbUtLS2P9+vUPPO8///kPH330EStWrFAmxRdC1I8bN26oDkATQghRexIQC0VRURGHDh3S2paTk8PFixf1nlNcXIynpye9evVi2bJl9d1EIVq8zMxMunbt2tDNEEKIZkUC4nq2Zs0aLl++rLM9JCQELy8vevfujUajwdfXl7FjxzJ69GiuXbsGwLVr15g+fTpvvPEGK1euJD8/n8WLFzNq1ChmzJjBzZs3CQoKIjAwEICDBw+yZs0anfLz8/N59913GTZsGC4uLhQWFqrWVyEvL4+lS5cycuRIPv300wde38qVK0lJSSEoKAhjY+O6uGVCiAe4efOmBMRCCFHHJCCuZ5cvX+bu3bs62/Pz80lPTycxMZGYmBg0Gg3R0dEsWLAAHx8fAHbt2sWAAQMICwvDxsaG7du3Y2VlRVxcHJMnTyYgIIC8vDzy8/OB8oUZcnJydMoPDw+nU6dOxMfH4+zszOeff65aX4Xt27djbm7OoUOH6N27t95rO3LkCCtXrmTNmjW88MILdXXLxCMICQkhPj5ea1tcXBzh4eFER0ezZ8+eapeVm5vLjz/+CFDjc8+fP8+kSZOYNGkS06ZNY/Xq1dy/f79adYkHk4BYCCHqngTE9cTf359hw4YRFhbGrFmzGDZsGD/99JPWMc7OzrRp04bIyEgSEhJwc3Pju+++o7i4GChfcvT06dMMGDCAjIwMjh49ytixYwEYMWIEcXFxWuVVnFe1/KioKCZOnAjA3LlzuXXrlmp9FeLi4nB2dgZg1KhRqtd369Yt3NzcmDx5Mu+8804t75KoaxkZGdy8eVNr25UrV8jIyMDBwYH+/ftXu6xz584p3zjU9Nzbt28DsGXLFpYtW8a5c+d4++23q1WXeLCbN29iaWnZ0M0QQohmRWaZqCeLFi1i0aJFeHl54eXlxYsvvqhzjKFh+eeRfv36YW9vj5eXFz///DOnTp0CID4+ni+//JIOHTrg5uaGgYEBly5dok+fPiQnJ+Po6IipqSm//fYbACdPnuSJJ57QKd/e3p60tDT69evH1q1bAXBxcdGpr0Lfvn25dOkSffv2JTU1VafdpaWleHh40KpVKzZu3FgHd0s8zObNmzl+/DhZWVm0adOGVatWcezYMUpLS/H09OTgwYPK/9W2bdvw8/OjS5cu+Pn5KWUcPnyYwsJC3nzzTZYtW0ZKSgqWlpbs3LkTAwMDXF1dKSgoACAoKAg/Pz/Onj3L4cOHyczMVM5dsWIFZ8+exdLSEn9/fw4dOkRsbCzXr1/HyMgIf39/AExNTencuTOdO3dm27Zt9OjRg/v379OqVasH1jVkyBA+/fRT4uPjKSkpITAwEGtr68d8xxunsrIybt261WR6iPPz83Wel65duxISEkJMTAzHjx/nxIkTrFixgvPnz2Ntbc3zzz/Pn/70J51nJCoqSuc5e/bZZxv4CoUQzYX0ENczAwMDDAwMHnjMlClT2L9/P+7u7ri4uGBrawuAubk5rq6uLF68mIKCAj777DMCAgKYMWMGGzdu5K233mL06NEcOHCAV155hTNnzqiWP3PmTLZv38706dPZs2cPH3/8sWp9Fdzd3fnmm2+YOnUqkZGROuX97W9/49ChQ3z33XeqSwiL2ispKUGj0VBSUqK1PSsrC1NTU8LDw/njH//Ixo0b9abLWFpacuLECebMmcOmTZuUMnJzc8nOztZJoUlKSiIjIwMPDw/27t3LiBEj2LFuVGkiAAAgAElEQVRjB4sXL2bMmDE4OTkp54aFhemk7eTn56PRaNi3bx/Tpk1TctorMzQ0pHfv3iQnJz+0Ln0pRKI8v7+oqIhOnTo1dFN0qD27as8LaKd0hYaG0qtXL6Kjo+natSuZmZmqz0h1njMhhKgt6SGuZ998843q9rfeekv52dzcnPDwcH755Rc6depE69atAXBycmL48OFkZmYq0yxFRUVx584drUA0NjaWgoIC2rRpo1p+t27diIiIIC8vj3bt2gGo1te5c2fOnz8PwNGjR1VzFU+ePImPjw+ff/45gwcPruVdEfr4+vqye/duxowZo5NC4OjoCED//v1Zvnw5Hh4eyr7KaS9jxowBYPjw4fz973+nV69eWuVERUWxaNEioDyFBsqn8oqIiCAwMJBff/2VSZMmqbYvKiqKJUuWAOVpO5s2bWL69OnKdHs2NjYkJiaqnpuTk4OtrS0lJSUPrCsyMpJLly7h5uZGcXGxzLdbSVZWFgAdOnRo4JboUnt21Z6X5cuXA/9L6YqOjlZmqHnllVfYu3cvZmZmOs+IsbFxtZ4zIYSoDekhbkS6deumBKcVDA0NdeYcVeuVrRwM61MRDD+ovsqqBsNZWVm4uroyduxY3nvvvYfWJ2rO29ub1NRU1XzaS5cuAXD69GlsbGwwNTVVBmyePHlSOS49PR2AlJQUJYiurCKFBmDr1q0kJSWxYcMGBg0aREhICPb29nrb16dPH6UdFWk78L/0nLKyMtXz4uLi0Gg0dOnS5aF19evXDxcXF7Zv387q1asZP3683va0NNnZ2UD5h+jGRu3Z1fe8wP+emb59+ypTO1YMCNX3jDzsORNCiNqSHmJRbe+++y5lZWX885//fGgaiKh7YWFhJCUlcf36dYKCgjA3N2f27NlER0dTWlrK0KFDAThw4AAXLlwgNzeXtWvXcvz4ca1yZs6cyfz58wkNDUWj0eDp6cnt27fx8fEhISGBwsJCwsLCcHV15ciRI1qzVri5uTF37lxCQ0MpLCxkzZo1xMbGqrY3NjYWR0dHDA0NefLJJ/n+++8BGDp06APrmjJlCp6ensTHx5OWlsaGDRvq6Y42PY05IFaj9rxUNX36dLy8vPj666/RaDQMGTJE9Rmp/I2IEELUNYMy+agtqumnn37izp07NZptQKgLDg5m+vTp1e7p+vzzz+nWrRuvvvoqFhYWSk8ZoJMuA+WB08OCpsopNFCe12lgYICZmZmy7/79+xgZGWFkZKR1btW0nZqqTl1VU3rqg4GBATt37mTatGn1VkddCg8P54033qCwsLBe78vD1PS+Peh5SU1NxczMjB49erBu3Tratm3LnDlzVJ8R8XjV9HVKiKZMeohFtdna2uoMwBOPR+vWrTE2NlYdTKWWLlOdHsSqAUbbtm119pmYmKie+6iDKatTV7du3R6pjuYoOzubNm3aNGgwXBsPel46dOjArFmzMDQ0pKSkhN27dwPqz4gQQtQXCYiFaAIkZ1tA9Xr+mxobGxtiYmIoLi6mVSt5SxJCNAwZVCeEEE1EcwyIK0gwLIRoSBIQCyFEE5GTk9NsA2IhhGhIjeYjucxa0PCa0uAiIVqi5txDLIQQDanRBMQA77//viz20ECmT5/e0E0QQjyEBMRCCFE/GlVAPHjwYOmhbCASEAvR+GVlZeks1COEEOLRSQ6xEEI0EdJDLIQQ9UMCYiGakZCQEK2V5aB82eTw8HCio6PZs2dPtcvKzc3lxx9/BKjVuQsXLtTZnpaWxvr166tdjtCWn5/fpObkfZRnSAghHqcWFRD7+/tz5MgR5d8FBQW4u7tTWlpa47Kq+8ZeOTCo/OYgRH3IyMjg5s2bWtuuXLlCRkYGDg4ONVpl8Ny5c8pSuzU9t6ioiEOHDulsz8nJ4eLFi9UuR2grKCjgiSeeaOhmVNujPENCCPE4Naoc4vr29NNPs3nzZkaMGAFAZGQkBgYGWsvgVld139grBwbnzp0jKCiIDRs21Lg+0bJt3ryZ48ePk5WVRZs2bVi1ahXHjh2jtLQUT09PDh48SGpqKgDbtm3Dz8+PLl264Ofnp5Rx+PBhCgsLefPNN1m2bBkpKSlYWlqyc+dODAwMcHV1paCgAICgoCD8/Pw4e/Yshw8fJjMzUzl3xYoVnD17FktLS/z9/Tl06BCxsbFcv34dIyMj/P39efLJJ5V68/LyWLlyJf/+97+xsLCQHNhHcO/evSYVEKs9Q6NHj+aDDz6gqKiIAQMG8Je//IVr165pbevevbvOs/3BBx+g0Wj49NNPiY+Pp6SkhMDAQKytrRv6MoUQzUCL6iF+/fXXiY+Pp7CwEChfp93V1RVfX1/Gjh3L6NGjuXbtGgA7duxg7ty5vPbaa0yYMIHLly+Tl5fH0qVLGTlyJJ9++ilQ/hXm4sWLGTVqFDNmzODmzZuEhITg5eVF7969ter38/Pj4MGDHDx4UG+dM2fOZPTo0QwdOpSlS5fi5OTE8uXLH+NdEg2ppKQEjUZDSUmJ1vasrCxMTU0JDw/nj3/8Ixs3biQvL4/8/HygvOcwJycHAEtLS06cOMGcOXPYtGmTUkZubi7Z2dmEh4fTqVMn4uPjcXZ2JikpiYyMDDw8PNi7dy8jRoxgx44dLF68mDFjxuDk5KScGxYWhpWVFXFxcUyePJmAgADy8/PRaDTs27ePadOmERgYqNX27du3Y25uzqFDh3R+J0TNNOaAWO3ZVXuGdu3axYABAwgLC8PGxoaCggKdbbdv31Z9tmNiYtBoNERHR7NgwQJ8fHwa5FqFEM1PiwqIW7dujbOzM/v376egoIDk5GQA1RdYtTd5tTd2fQFCeno6iYmJWvVXvDkUFxfrrTM3N5fY2Fjs7OwwNjbm8OHDJCQkcPXq1cd4p0RD8fX1pX///ixZskRnn6OjIwD9+/fXSv0BKC4uVn4eM2YMAMOHD+fEiRM65URFRTFx4kQA5s6dy0svvYSZmRkRERG4uLiwd+9e5UOj2rljx44FYMSIEcTFxQEwYMAAoHwZ3qysLK1z4uLicHZ2BmDUqFEPuQNCn9LSUoqKihptQPygZ7eymTNncvr0aQYMGEBGRgZt2rTR2WZiYqIcX/nZjoyMJCEhATc3N7777jutfUII8ShaVEAM4OHhQXBwMJGRkbzxxhtERUXpfYGt+iav9sauL0BwdnamTZs2qm140Iu6k5MTAObm5gwcOBAACwsL8vLy6vAuiMbK29ub1NRUJe+yskuXLgFw+vRpbGxsMDU15e7duwCcPHlSOS49PR2AlJQUJYiuzN7enrS0NAC2bt1KUlISGzZsYNCgQYSEhGBvb6+3fX369FHakZycrJRfkXZUVlamc07fvn2VcyrSOkTNFRYWUlZWpvd1paE96NmtLD4+ni+//JKEhAQuXLjAqVOndLbduHFD9dnu168fLi4ubN++ndWrVzN+/Ph6vSYhRMvRonKIAYYMGcI777xDXl4en3zyCWfOnMHe3h4vLy9+/vlnTp06pRxb9U2+4o29b9++yht7RYDQp08f1QBBTb9+/fTW2bp1a+XnitX7ysrKVAMN0bKEhYWRlJTE9evXCQoKwtzcnNmzZxMdHU1paSlDhw4F4MCBA1y4cIHc3FzWrl3L8ePHtcqZOXMm8+fPJzQ0FI1Gg6enJ7dv38bHx4eEhAQKCwsJCwvD1dWVI0eOaM1a4ebmxty5cwkNDaWwsJA1a9YQGxv7wHa7u7vj7u7O7t27yc/P53e/+13d35wW4N69ewCNtodYja2trc4zZG5ujqurK3Z2dhQUFODg4MDdu3e1tnl6ejJv3jydZ3vKlCl4enoSHx9PWlqajMcQQtSZFhcQGxgYMHnyZMLCwnBwcKB79+7VfoFVe2NXCxCOHj2qen7Fm8P48ePZsmWLvKiLGvnoo4949dVXsbCwUD5wxcbGUlBQoNVruGTJEq35ap977jmdsiIiIsjLy1Om8BozZgyDBw/GwMAAMzMzZV9KSgpGRkYMGzZMOTcqKoo7d+5gYWEBwDPPPKPsGzlyJCNHjgTg/PnzQPk3LEePHuXmzZt07dq1Lm9Ji9IUA2IrKyvVZ2j48OFkZmYqAyydnJx0tqk92+bm5oSHh/PLL7/QqVMnrQ4EIYR4FAZljaTr0cDAgJ07dzbYSnU1eYFVe2OvHCA8yP379zEyMsLIyKhRvag39P1vaYKDg5k+fXq1e/6/+OILnnrqKfn/qWNN6blPS0vj+eef5+zZszg4ODRoW5rSfRO1V9PXKSGashbXQ6xPt27dqn2sWi9XdYJhQGuwSE3qFC3be++919BNEA2sKfYQCyFEU9HiBtUJIURTJAGxEELUHwmIhRCiCZCAWAgh6o8ExEII0QRUBMSmpqYN3BIhhGh+GlUO8d69e/n+++8buhlCPDZTp05t6CaIJqJisRQJiIUQou41qh7iH3/8UWsSdlH/rl27RkhISEM3o8WxsbHBxcWloZvR4rm4uGBjY9PQzaiWoqIiDA0NadWqUfVjCCFEs9DoXlkHDRokvcSPUcW0OuLxGjx4sDznokbu37/fKKZoFEKI5qjRBcQhISHKCm1CCCHKFRUVNduAOC4uTlkMJi8vD2traxISEli4cKHWcdHR0RQVFTFhwoRqlXv+/Hk++ugjoHwV0Jdeeon33nsPExOTGpclhGjeGlVAPH78eBYtWtTQzWiRpJdYiMatOQfEV65cISsriw4dOpCVlYWJiQnJyck6xzk4OFBSUlLtcm/fvg3Ali1buHr1KmvXruXtt98mMDCwxmUJIZq3RhUQ9+zZU1Y+aiASEAvRuBUVFWkt7NMU5Ofns2zZMlJSUrC0tGTnzp2Ulpby6aefEh8fT0lJCYGBgdUu7/DhwxQWFmJiYkJsbCzXr1/HyMgIf39/unfvrlquqakpnTt3pnPnzmzbto0ePXpw//59pazRo0fzwQcfUFRUxIABA1i6dKlOOdbW1pSWluLq6kpBQQEAQUFB3L17V+vcv/zlL2g0GtXzhRCNW6MaVCeEEEJdY88hLikpQaPRaPW6hoeH06lTJ+Lj43F2diYpKYmYmBg0Gg3R0dEsWLAAHx+fateRm5tLdnY2+fn5aDQa9u3bx7Rp0wgMDKxWuYaGhvTu3Zvk5GSlrF27djFgwADCwsKwsbEhMjJStZyMjAw8PDzYu3cvI0aMYMeOHTrnFhQUPNL1CSEaTrMNiHNzc/nxxx/17o+LiyM8PLza5Z05c4YZM2Yoc4ECvPvuuxQXF9eqfSEhIcTHx9f4vEuXLvHJJ59obXv77bdJS0tj0qRJyp/58+eTmJiotP2rr76qVTuFEI1DY0+Z8PX1pX///ixZskTZFhUVxcSJEwGYO3cuL730EpGRkSQkJODm5sZ3331X69fQAQMGAOUztmRlZVW73JycHGxtbZV/z5w5k9OnTzNgwAAyMjKIiYlRLcfMzIyIiAhcXFzYu3cvhYWFOue2adOmzq5PCPF4NaqUibp07tw5goKC2LBhg+r+ipy16rp16xb79u3D19eXVatWAeVBdWlpaa3al5GRQVlZWY3Py8rK4t///rfWtpiYGObOnUtubi7BwcEAnD17lldffZVff/2VW7duqebjCSGajsYeEHt7e+Pt7a21zd7enrS0NPr168fWrVtxcHCgX79+2Nvb4+Xlxc8//8ypU6fIz8+vcX2GhuX9ORWvo2rlVhUXF4dGo6FLly7Ktvj4eL788ks6dOiAm5sbvXr1wsXFRaecDRs2MGjQIObMmcOCBQtUzz116lS12iGEaHyaXECslpNmYGCgk9vl5+fH2bNnOXz4MMOHD9fZX7m8FStWcPbsWSwtLfH396dt27asWLGC8+fPY21tzfPPP0+fPn2YMWMGBw4cwN3dHTs7O6WMoKAgSktL8fT05ODBg6SmpmJlZUVkZCQ3btygqKiIIUOGkJiYiKOjoxJQb9u2DT8/P7p06YKfnx9PP/20au5ZSEgIMTExHD9+nE2bNum9N8bGxnTu3BmAkSNH0qZNG+7fv1/n/wdCiMfv/v37TS6HeObMmcyfP5/Q0FA0Gg2enp4888wzeHp6Eh8fT1paGhs2bODcuXM650ZERCi9wMBDA8spU6bolJufn09sbCyOjo4YGhry5JNP6kx3aG5ujqurK3Z2dhQUFLBw4ULefvttrXIAhg4dio+PDwkJCRQWFhIWFsbHH3+sda6DgwPPPfecTjuEEI1fow6IS0pKKC0txdDQECMjI0A7J23Lli0kJSXRoUMHPDw8mDBhAqtXr2bHjh0sXryYoKAgnJycuHz5ss7+Nm3aABAWFoaVlRV+fn4EBwcTEBCAjY0NvXr1ws/Pj+XLl5OZmQmUB5zr169n/vz5HDlyRGlnXl6e0ktRUFBATk4O7du3Jzc3l9jYWObNm4exsTGHDx/GycmJq1evAmBpaUlkZCQRERFs2rQJJycnJfds9+7d+Pj4sHnzZvLz80lPTycxMZGUlBS99+vChQu89dZblJWVkZqayqxZszAzM6uX/xshxOPV2HuI1XTr1o2IiAhlSjUoD0DDw8P55Zdf6NSpE61bt6Z///465/722286295++22dbSNHjmTkyJEAOuXqK6dqWcOHDyczM5OnnnpKbzljxoxh8ODBGBgYYGZmplxT1XNNTExUzxdCNG6NOoe4ujlparldlT1of1RUFGPHjgVgxIgRxMXFER0djaOjIwCvvPKKVlkDBw7EwcGBLVu2qLa5cr6Yk5MTUP4GMHDgQAAsLCzIy8sDyl9gofzF+MSJEw/MPXN2dqZNmzZ07NhRK48Zyr86NDU15ZlnnlG+tvzggw+U9AkhRNPXFAPiChXBcGXdunWrl+upTbmGhoZKQPugctq2bat0MlRck9q5tW2HEKLhNOqA2Nvbm9TUVNasWaNsq8hJA9i6dStJSUlKbldISAj29vY65Txof58+fbh06RIAycnJODo60rdvXy5evAigOvBt1apVfPXVV2RnZwPl0/rcvXsXQGvp6covhhWLjZSVlSm9yenp6QCkpKTg6OhIv379cHFxYfv27axevZrx48cr51fkyz377LNcvHiRGzduAHDixAksLCwwNDTkiSeeoEePHtja2jJz5kwKCwtlnk0hmommHBALIURj16hTJtSo5aTdvn1bJ7fL1dWVI0eOEB8fr5r7NXv2bADc3NyYO3cuoaGhFBYWsmbNGlq3bo2Xlxdff/01Go2GIUOGaLWhXbt2rFy5kkmTJgEwevRoZs+eTXR0NKWlpQwdOrRa13LgwAEuXLhAbm4ua9eupXPnzg/NPTM0NMTX15fevXtjZ2fHhQsXCA0NVS2/Q4cOXLhwAVDPx5MVAYVoOgoKCpRULyGEEHXLoKw2Ux3UAwMDA3bu3FnthTkq56RB+eC4qrld9+/fx8jICCMjI9X9ld25cwcLCwsAUlNTMTMzo0ePHqxbt462bdsyZ86ch7apNm9Y2dnZmJuba22rTu5ZcXExv/zyC08//XSdBLY1vf9CiMfrtddeo2vXrgQEBDR0U+T1ooUIDg5m+vTptZoRSYimpsn1EFeoGtC2bdtWZ1/lEdlq+yurCIahvGd11qxZGBoaUlJSwu7du6vVptr03lQNhqE89+xhWrVqRffu3WtcnxCiaSooKOCJJ55o6GYIIUSz1GQD4vpkY2NDTEwMxcXFtGolt0gI0fDu3bsnKRNCCFFPGvWguoYmwbAQorGQHGIhhKg/EhALIUQTcO/ePUmZEEKIeiJdoEII0QQ0lxzi3NxcMjMzee6557S2p6ens3jxYqB80N6wYcOYM2eO6jiLyjQaDX/6058YOnQop06dUmYUysvLU2YCEkKIh5EeYiGEaAKaSw7xuXPntOaWr5Cdnc29e/fYsmUL69ev58qVK/z9739/aHmXLl0iPT0dFxcX3N3dMTEx4cqVK2RkZNRH84UQzZQExEII0QQ0xRzia9euMX36dN544w1WrlwJgJ+fHwcPHuTw4cOEhITg5eVF7969gfKZgTp37oyVlRVvvPEGP/zwg9Yx+fn5LF68mFGjRjFjxgxu3rzJ3//+dy5evEhUVBSffPKJ1kqkGo0GX19fxo4dy+jRo7l27VqD3AchROMnAbEQQjRyJSUl3L9/v1GnTJSUlKDRaLRWx9y1axcDBgwgLCwMGxsbCgoKWLx4MWPGjMHJyYn8/HzS09NJTEwEynuPvby8eOutt1i+fDnvvPOO1jFhYWFYWVkRFxfH5MmTCQgI4P3332fEiBE4Oztz7do1rTlzY2Ji0Gg0REdHs2DBAnx8fB77fRFCNA0tNiBOS0tj/fr11To2NzeXhQsXkpuby48//ljrOivKeZS2CCFannv37gG1m+v8cfH19aV///4sWbJE2TZz5kxOnz7NgAEDyMjIUG2/s7Ozsr1Hjx4sXLiQpUuXcuzYMUaPHq11TFRUFGPHjgVgxIgRxMXFPbBNkZGRJCQk4ObmxnfffUdxcXFdXa4QoplpsYPqcnJyuHjxYrWOLSoq4tChQ5w7d46goCDVJZVrUs6jtEUI0fIUFBQANOoeYm9vb7y9vbW2xcfH8+WXX9KhQwfc3Nw4deqUznmGhv/rl2nXrh12dnZ6j+nTpw+XLl2iT58+JCcn4+jo+MA29evXD3t7e7y8vPj5559V6xdCCGiCAfGkSZNYu3Yttra2rFu3DgsLC6ZOncqnn35KfHw8JSUlBAYGEh8fT2xsLNevX8fIyAh/f38sLS1ZuXIl//73v7GwsOCpp54Cypd9XrFiBWfPnsXS0hJ/f3+OHTtGTEwMx48fV3oh/Pz8OHv2LIcPH2bIkCGqdUZGRnLjxg2KiooYMmQIiYmJODo6smrVKq3ryMvLU22LEEJUlZ2dDZSvotmUmJub4+rqip2dHQUFBTg4OPDbb79x5MgR4uPja1yem5sbc+fOJTQ0lMLCQtasWUNOTo7e46dMmYKnpyfx8fGkpaXVujNDCNH8NeqAuKSkhNLSUgwNDTEyMgJg5MiR7Nq1iw8//JBvv/2WyMhIrTyx3bt34+Pjw8svv4xGo2Hfvn0EBQURGBiItbU15ubmHDp0CG9vb3777TcAJS/Nz8+P4OBgAgICsLKyUvLW7t69C8DixYsJCgrCycmJ/fv3q9aZm5tLbGws8+bNw9jYmMOHD+Pk5MTVq1cxNTVVrm379u2qbRFCiKqysrKAphcQOzk5MXz4cDIzM5UP/VZWVqSkpGBkZMSwYcOUY/v378/evXt1ynjrrbeUn62trYmKiuLOnTtYWFgo2wMCAgA4fvy4zjnh4eH88ssvdOrUidatW9fl5QkhmpFGnUOslpPm5uZGWFgYaWlp2NjYYGFhoTdPbMCAAUD5UsxZWVnExcXh7OwMwKhRo5Qy9eWlVc5tq0pfnU5OTkB5z8jAgQMBsLCwIC8vT+t8fW0RQoiqKgLih83J2xgZGhrqfANmYmKidHLURuVguDq6desmwbAQ4oEadQ+xWk5aly5dsLCwYPXq1UovgFqeWFZWlpJ3VjHquG/fvly6dIm+ffuSmpqqlKkvL61ybltV+uqs/KJrYGCg1F955POD2iKEEFVlZWXRqlUr2rZt29BNEUKIZqlR9xDr4+Hhwb59+3j11VeB8jyx/fv34+7ujouLC7a2tqrnubu788033zB16lQiIyOV7W5ubgQEBDBjxgw2btyo9XVbZba2tkruW3Xr1EdfW4QQoqqsrCzMzc2VD9lCCCHqlkFZ1a7LBmJgYMDOnTuZNm1arcuobp7YzZs36dq1q872qnlpau7fv4+RkZHydd+j5qbpa8vjVhf3XwhRPz755BMCAwNJS0tr6KYA8nrRUgQHBzN9+nSdbziFaI4adcpETXXr1q1ax+kLQKuTl2ZiYlKrOmvaFiGEqJCVldXkBtQJIURT0iRTJoQQoiWRgFgIIeqXBMRCCNHISUAshBD1SwJiIYRo5CQgFkKI+iUBsRBNzNSpUzEwMJA/lf5MnTq1of9b6lVzD4jj4uIIDw9X/j5z5gxfffWVznHR0dHs2bOnRmVfvnyZadOm8fLLL/Phhx9y6dIlvcfm5uby448/1rj9Qoimr1kNqhOipRg0aBCLFi1q6GY0Cv7+/g3dhHrX3APiK1euKNeYlZWFiYkJycnJOsc5ODhQUlJS7XJLS0t57bXX+Otf/8q0adM4c+YMM2bM4PTp06oLg5w7d46goCBZ4lmIFkgCYiGaIGtra5ny6v/3/fffN3QT6l11poRsjPLz81m2bBkpKSlYWlqyc+dOSktL+fTTT4mPj6ekpITAwMBql3f48GEKCwsxMTEhNjaW69evY2RkhL+/P927d9cp96effuKFF17Aw8MDAEdHRzZs2EBeXh7t27fH1dWVgoICAIKCgvDz8+Ps2bMcPnyYIUOG6JRnbm7OihUrOH/+PNbW1jz//PMsWLCAFStWcPbsWSwtLfH39+fYsWPExMRw/Phx7Ozs+Pjjj+nZsydffPEFXbp0YcaMGfVyv4UQtScpE0II0Yjl5OSQn5+PlZVVQzflgUpKStBoNFo9uOHh4XTq1In4+HicnZ1JSkoiJiYGjUZDdHQ0CxYswMfHp9p15Obmkp2dTX5+PhqNhn379jFt2jQCAwNVy42KiuKVV17RKmPgwIGYm5uTkZGBh4cHe/fuZcSIEezYsYPFixczZswYnJycVMsLDQ2lV69eREdH07VrVzIzMwkLC8PKyoq4uDgmT55MQEAA+fn5pKenk5iYiJOTEyEhIQBs376dMWPG1M0NF0LUqWYbED8sF6wiV626Kr5qu3fvnrLt3Xffpbi4uFbtCwkJIT4+vlbnCiFajuvXrwM0+oDY19eX/v37s2TJEmVbVFQUEydOBGDu3Lm89NJLREZGkpCQgJubG999912tX0MHDBgAgI2NDVlZWarlduzYkYyMDK3z9u/fz9WrVzEzMyMiIgIXFxf27t1LYWGh1nFq5UVHR1OwNrUAACAASURBVOPo6AigBNpRUVGMHTsWgBEjRhAXFweAs7Mzbdq0Ydq0aYSHh5Oeno6lpSWdOnWq1fUKIepXsw2Iz507x5o1a/Tuv3Llis4L5YPcunWLffv24evrq2yLi4ujtLS0Vu3LyMjg5s2btTpXiLrk7+/PkSNHlH8XFBTg7u5eq2c7LS2N9evX12XzWrymEhB7e3uTmpqq9bprb2+vrK63detWkpKS6NevHy4uLmzfvp3Vq1czfvz4WtVnaFj+9lWxippauWPGjGHfvn3KPczIyOCvf/0rlpaWbNiwgUGDBhESEoK9vb1O+Wrl9e3bl4sXLwIoHRp9+vRRBuolJycrAXNF+ywsLHjqqaf49NNPldQNIUTj0+RyiNVy0gwMDB6YCzZ8+HCd/ZXLq5r/1bZtW508sT59+jBjxgwOHDiAu7s7dnZ2ShlBQUGUlpbi6enJwYMHSU1NxcrKisjISG7cuEFRURFDhgwhMTERR0dHVq1aBcC2bdvw8/OjS5cu+Pn58fTTT+vkrFlbWxMSEqLko507d+4x3m3REjz99NNs3ryZESNGAOU9YwYGBsobek3k5OQoAYOoG9evX8fExISOHTs2dFNqbObMmcyfP5/Q0FA0Gg2enp4888wzeHp6Eh8fT1paGhs2bFB9XYuIiFB6gQFOnTr1wLqmTJmiU27v3r1ZunQp48aNo2PHjly4cIHNmzdjYmLC0KFD8fHxISEhgcLCQsLCwnB1deXIkSPEx8erljd48GC8vLz4+uuv0Wg0DBkyBDc3N+bOnUtoaCiFhYWsWbOGo0eP6tyHefPmqc6cIYRoHBp1QFxSUkJpaSmGhobKiODKOWlbtmwhKSmJDh064OHhwYQJE1i9erWSCxYUFISTkxOXL1/W2d+mTRsAJf/Lz8+P4OBgAgICsLGxoVevXvj5+bF8+XIyMzMBMDY2Zv369cyfP1+rRy0vL0/ppSgoKCAnJ4f27duTm5tLbGws8+bNw9jYmMOHD+Pk5MTVq1cBsLS0JDIykoiICDZt2oSTk5OSs7Z79258fHzYvHmzVj6aEHXt9ddfZ/HixRQWFmJqakpwcDBz585Fo9HofECLj4/XGcxkaWnJypUr+fe//630hoH6h83Kg43kw1313Lhxg6eeegoDA4OGbkqNdevWjYiICPLy8mjXrh0A5ubmhIeH88svv9CpUydat25N//79dc797bffdLa9/fbbOttGjhzJyJEjAXTKBZg1axazZs3i2rVrPPXUU8p7yZgxYxg8eDAGBgaYmZkpbUxJScHIyAgjIyOd8lJTU1m7di09evRg3bp1tG3bFmtra6KiorQGPj7zzDNabezYsSOenp6Ympo+wt0UQtSnRp0yUd2ctIflgj1ov1r+l1qeWIWBAwfi4ODAli1bVNtcOR/OyckJKH8DGDhwIFD+9VleXh6AMrhi+PDhnDhx4oG5dRX5aELUtdatW+Ps7Mz+/fspKCggOTmZV155RXVQkdpgpu3bt2Nubs6hQ4fo3bu3Uu7DBhuJ6rl+/bryIaOpqgiGK+vWrZsStNYlfeVaW1vrTLXWtm1bzMzMtNpoYmKidVzl8jp06MC8efMYN26c8p5SQd8sIDt37mTNmjUsXrz40S5MCFGvGnVAXN2ctIflgj1ov1r+l1qeWGWrVq3iq6++Ijs7GwBTU1Pu3r0LwMmTJ5XjKr8oV/TulJWVKb3J6enpAKSkpODo6PjA3LrafH1dX+7cuaNcu2gePDw8CA4OJjIykjfeeAMjIyO9H9CqDmaKi4vD2dkZgFGjRillPmywkaie//73v/To0aOhmyEof+ZjYmLYt28fsbGxPPnkkw89Z/r06ezduxdra+vH0EIhRG016pQJNWo5abdv335gLphartjs2bMBVPO/WrdurZMnVlm7du1YuXIlkyZNAmD06NHMnj2b6OhoSktLGTp0aLWu5cCBA1y4cIHc3FzWrl1L586ddXLWGqOvv/6aFStW8NRTT9G/f3/lj52dnc5XhaJpGDJkCO+88w55eXl88sknQPmgInt7e7y8vPj55585deoUWVlZOoOZ+vbty6VLl+jbty+pqalKmRUfNvv06aM62EhUz08//VTrgWeifrRq1eTeOoUQD9HkfqvVctKqkwumtr9C1fwvtTyxcePGMW7cOOWciRMnKgFB9+7diY2NpaCgQLXn67PPPlN+Dg0NBcDOzo4lS5aQnZ2Nubm5sl8tB+6tt96qo7tXN+bNm0ffvn1JTk4mOTmZwMBAZS7Rrl270rdvX+VPv379HilITktLIyYmhnfeeeeBx+Xm5vLRRx/pDFqp7vktnYGBAZMnTyYsLAwHBwdAfZBSVlaWzrnu7u64u7uze/du8vPz+d3vfgeof9isOthIPNzPP/8sPcRCCFHPmlxAXKFqTlrbtm119pmYmDxwf2WV8786dOjArFmzMDQ0pKSkhN27d1erTbX5GrhyMFyhW7duNS7ncerSpQuvv/46r7/+urItJyeHc+fOcebMGc6cOUNYWBifffYZJSUltG/fnt69eyu9yC+88AIvvfRStfIHqztrQVFREYcOHar1+QJ8fHy0Fkl42OCnyoOZjh49ys2bN+natauyvzqDjcSD3b59m5ycHGxtbRu6KUII0aw12YC4PlXkiRUXF8tXYw+xZs0aJk2axLPPPsvQoUOVdJFJkyYpaS2fffYZN2/eJCwsjHXr1lFaWkqrVq2wtLTkiSeewNjYmA4dOijTJOXl5enMWvCwGQsq8lMB1fNF7VX3A1rlYLiyprjkcGPx3//+F0ACYiGEqGeSzPcAEgw/3OXLl5UBhZWNHDmSiIgI7Ozs+PHHH/H09MTT05OioiLWrl3LkCFDeP7557l79y6ZmZkkJCTw4osvYmdnx5gxY0hJSWHx4sU8++yzQM1mLNA364EQTc1PP/2EoaEhTz/9dEM3RQghmjUJiEWt+Pv7M2zYMMLCwpg1axbDhg3jp59+Uva7ubkRFhZGWloaNjY2nDhxgoSEBP7whz9w/PhxbG1tcXV15c9//jO3b98mJCSEcePGMXXqVK5evcrp06eZOHEin3/+OVu3bmXZsmWkp6ezZ88eevXq9cAZC/TNeiBEU5OWlsbTTz+tlf4lhBCi7kkXqKiVRYsWsWjRIry8vPDy8uLFF1/U2t+lSxcsLCxYvXo1b731Fjdv3nzgjAUWFhb06NEDb29vTE1N6d69OyNGjODjjz8mKSmJoqIi9u7dy8aNGykrK6Nt27bcuHGDjh070rlzZ63cVH2zHgjR1Pzwww/06tWroZtRr6KjoykqKmLChAk12rdhwwYsLS2ZPHkyAL/++itLlixh06ZNGBsb13u7hRDNiwTE4pEYGBjoXUHLw8OD999/nw0bNpCXl1etGQtAd9aCl19+mWXLljF37lxefvllfv31V5ycnIiNjSUtLY1Zs2ZRWlqKkZERQ4cOpWfPnmzbto1t27ZhYGCgpF00N35+fpw4caKhm9HgTp48yaBBgxq6GfXihx9+UJbUbq4cHBwoKSmp8b4JEyYwatQoRo8eTfv27Vm6dCmDBw+WYFgIUSsSEItH8s033+jdN3XqVKZOnQrUbMYCGxsb1VkLqs5Y8PHHHwPlg+hSUlK4ePEiFy5c4MyZM/z888/85z//wcTEhKtXr/KHP/xBa87kJ554os7vxeN24sSJZh0MVse1a9e4du1aQzejXpSVlfGf//wHLy+vhm5KrakNhu3atSshISHKgNi//OUvFBYW8uabb7JixQrOnz+PtbU1zz//PD169KCwsBATExOdJcOfffZZ/t//+3/83//9H9OnTyc9PZ1//OMfqkuOW1lZ4erqSkFBAQBBQUHExsbKMuJCCIUExOKxqsmUcmqzFqjNWNCuXTutGS4ANBoNaWlpyjRwZ86cYffu3dy9e5dWrVrRs2dPrQD5xRdf1Jqarz6VlJRQVlZWJ4M2Bw0axPfff18HrWqagoODmT59ekM3o15cvXqV/Pz8JpMyUVJSQmlpKYaGhsrSxxWDYf38/AgODiYgIIDly5drDYj99ttvKSgoIDQ0lF69euHn58fy5cvJzMzEwsJCmd+9YsnwoKAgAgMD8fX1Zf78+YwYMYKYmBiCg4MxMDDQWnJ89+7d+Pj4sHTpUjw8PJgwYQKrV69mx44dtGnTRpYRF0IoZFBdHcjNzWXhwoVa29LS0li/fn0DtUgYGxtjZ2fHH/7wB7744guOHTtGTk4O6enp7N69m6lTp5KVlcUnn3zCsGHDaNeuHVZWVkyYMAFvb2/27NnDrVu36qw9v/32G8uXL+f3v/89rVq1wtjYmJ49e7JkyZJHqickJERJW2mJf5prMAzl6RIAv//97xu4JdXj6+tL//79WbJkibJN3/LdoDsgNjo6WlnN8JVXXtEpv+qS4VC+6uGf/vQn7OzslA8OakuOm5mZERERgYuLC3v37qWwsFC1DUKIlkt6iOuA2qIQsiBE42NkZMQzzzzDM888ozVI5/r161o9yUFBQcoCFZWXp65YVMTOzq5G9SYnJ/P6669TWlrK7Nmz6du3L4aGhiQnJxMQEEBgYCAREREMHDiwRuUuXrxYSUlpyfz9/Ru6CfXi4sWLWFpa0rFjx4ZuSrV4e3vj7e2ttU3f8t2gu4R33759uXjxInZ2dsTHx+uUX3XJ8AqtW7fG1NRU+bfakuMbNmxg0KBBzJkzhwULFuhtgxCi5WpyAXHl3LOkpCSdXDFra2uuXbvGBx98QFFREQMGDOD9999XzWMLCgqitLQUT09PDh48SGpqKt27d1fKP3HiBMuWLSMlJQVLS0v+9a9/sXr1ap36KsiCEE2TlZWV0jtcISsrS8lHPnPmDN9//z2+vr6UlpZibm6OnZ2dVspFr169VN9cs7Ozee2117C3tyckJIQnn3xS2TdlyhSWLFnCjBkzeP3117l48SKdO3eudrsHDx7M4MGDH+3im4HmmjKSlJRE3759G7oZj0Rt+W59pk+fjpeXF19//TUajYYhQ4bUqk61JceffPJJfHx8SEhIoLCwkLCwMGbPnl3byxJCNEONOiBWy0mrnHumliu2efNmdu3axYABA/jTn/5EYGAg27dvV81jy8vLU3obCgoKyMnJ0So/NDSUTp06ER8fz5YtW/j8888pLi7Wqa9C5QUhvL29+e233xrkvolH16FDB5285NzcXFJTU5Ug+fjx42zYsIH79+/Trl07+vTpo/Qi9+/fn5deeokvvviCkpISnWC4Qrt27fjuu+/4/e9/z9///nc+++yzx3mZohFLTk5m4sSJDd2MR6K2fDfAW2+9pfz89ttvA5CamsratWvp0aMH69ato23btsyZM0enzMoDcAFeffVVXn31VeXfagN4ofwDpIGBAWZmZuTl5dGuXbu6vlwhRBPWqL8vUstJg//lfanligHMnDmT06dPM2DAADIyMjh69KjePLYKFedWLj8qKkp5Q5o7dy63bt1Sra+CLAjRvLVv356hQ4fy3nvv8c9//pPTp0+TnZ3NyZMn+fzzz7GzsyMpKYmlS5cybNgwzM3N+eKLL3Bzc1MNhiu0bduWP/zhD0RERDzGq6mZmuTEnzlzhhkzZnDv3j1l27vvvqvz+yL0u3fvHv/5z3+afA9xheos392hQwfmzZvHuHHjlHzfR9GtWzclGIby3zMzMzMACYaFEDoadQ+xWk4a/C/vSy1XDCA+Pp4vv/ySDh064ObmhoGBgWoem6mpqdKLe/LkSWUqrory7e3tSUtLo1+/fmzduhUAFxcXnfoqyIIQLc8TTzzBwIEDtfJ/NRoNP/zwA8nJySxYsIAXXnjhoeXY2dnh5+dHWVmZ3nmdG1JNcuJv3brFvn378PX1ZdWqVUD5h8XS0tL6bGKzkpKSQnFxMf369Wvopjw2NjY2xMTEUFxcXCczsAghRE006VcdtVwxKP/KzNXVFTs7OwoKCli3bh3vvPOOTh7b6NGjmT17NtHR0ZSWlmp9PQ7lPc3z588nNDQUjUbDli1bmDVrlk59FaouKPG73/3u8dwI0agYGxvTp08f+vTpwwcffKB3YYHKSkpKMDQ0rPNgeNKkSaxduxZbW1vWrVuHhYUFU6dO1cm9j4+P15nn1dLSUjUnXm1u2WPHjim5959//jkzZszgwIEDuLu7aw1CLC0t1ZkPNioqisjISG7cuEFRURFDhgwhMTERR0dHVq1apTqvbOXc/eYoKSmJ9u3ba63A2FJIMCyEaAhN7pWncu6ZvlwxJycnhg8fTmZmpvImrpbH1r17d2JjY5V5Lqvq1q0bERERWvlmavV17tyZ8+fPA6guKCGar7S0NGJiYnjnnXdU9z/33HOkpKQA5TnIH330EV999ZXO+ZcvX+a55557pLao5dyPHDmSXbt28eGHH/Ltt98SGRmpmnv/8ssv68zzam1trZoTrza3rJWVlZJ7f+TIEYyNjVm/fj3z58/nyJEjShszMjJ05oM1NjYmNzeX2NhY5s2bh7GxMYcPH8bJyYmrV69y/vx51bECzdnZs2fp27dvo/y2QAghmqNGnUNcXVVzxaA87aHqLA/68tgeNg9l1Xwztfoqk2C45XhYKsGbb77Jjh07lN5Pten5kpKSCAwM5M0333yktqjl3Lu5uREWFkZaWho2NjZYWFjozb2vOs+rvpx4fXPLVp3TdeDAgTg4OLBlyxZlm775YJ2cnIDyD7kV6ScWFhbk5eXpbW9zlpiYqPx/CCGEqH9NrodYiJpYs2YNkyZN4tlnn9XaXtepBPrSCC5dukRhYSGvv/46//jHPwDt6fnatGnDmTNnaN++PYsWLXqka1XLue/SpQsWFhasXr1a+XZFLfc+KytLZ55XfTnx+uaWVZt2btWqVQwZMoTs7GwAvfPBVv6AWdErWlZWRllZmd6xAs1VTk4OFy5cUObCFkIIUf+aRQ+xEPpcvnyZu3fv6myvSCUA+Pbbb3F2dtZKJViwYAE+Pj7k5+crqQTTpk1TpvGrSCXo3bs38L80gri4OCZPnkxAQAD5+fn8/PPPJCUlUVhYiKOjI7/88gtz587lhx9+oEePHhw8eJCioiKioqLqbeS7h4cH+/btU6ammjJlCvv378fd3R0XFxdsbW1Vz3N3d+ebb75h6tSpREZGKtvd3NwICAhgxowZbNy4USuNqap27dqxcuVKbty4AcDQoUPZunUrc+bMITs7m7CwsIe2v7rtbS4SEhIoLS3VWsRCCCFE/ZIeYtEs+fv7s3v3bi5fvkxiYiJmZmb885//VIIpNzc3pkyZwsSJE7VSCS5duoSbm5uy3CtopxIkJiaSlpbGsmXLgPJUguDgYKKiopRUhREjRrBp0yZmzpyJs7MzdnZ2nDlzhi+//JKPP/6YiIgIzMzMsLOz45133qGwsJDnn3++3u7F1KlTtVa0U8u979+/v7K/8jyvajnxanPLVh78NW7cOMaNG6f8e+LEiUqv85gxYx44H2zleZhDQ0OVn9Vy95ur48eP07NnT7p06dLQTRFCiBZDAmLRLC1atIhFixbh5eWFl5cXL774otb+uk4leFgagampKbNmzeKf//wnM2fOpHv37syYMYN169Zx6dKlx3FLdHTr1q1ax+nLia/O3LJq2rZtq/xck17x6ra3qTt27JjOjDfif+Li4sjLy2PSpEk6+3Jzc8nMzOS5554jOjqaoqIirRUoH+T8+fN89NFHQHkKz0svvcR7772HiYlJjdoXEhKCpaUlw4YN02nzE088UaM2zZ8/n+vXr2tte+2117C1ta1ROUKIh5OAWDRrBgYGekfqe3h48P777yvT56lN45eVlaVzntr0empL1B49elS1XpmeT+ij0Wg4deoUnp6eDd2URuvKlSuqv5cA586dIygoiA0bNuDg4FCtKQ8r3L59G4AtW7Zw9epV1q5dy9tvv01gYGCN2peRkaF8eK7aZjc3txq1ycfHh+LiYpYtW8awYcMYP348ZmZmFBYW1qgcIcTDSUAsmrVvvvlG7766TiV4UBoByPR84uGSkpIoKChoNvnDmzdv5vjx42RlZdGmTRtWrVqFra2t6iDUPXv26Bx77NgxSktL8fT05ODBg6SmptKxY0dAfU5rPz8/zp49y+HDh8nMzKSwsJA333xTp65Dhw7pDJaF8m9yOnfuTOfOndm2bRs9evTg/v373L9/X6eMgwcP6rTtgw8+AGDbtm34+fnRpUsX/Pz8lPtx+PBhCgsLMTEx0am/a9eurFixgvPnz2Ntbc3zzz/P0qVLgfLZWSwsLLCysgLKX2sqytE3h7ePj0+Lm79biEchg+qEqOJh0+pVUAtma5JGIMGwqComJgYrKyt69uzZ0E2psZKSEjQajVbPZVZWFqampoSHh/PHP/6RjRs3AuqDUNWOzcvLIz8/H4CCggJycnKUsivmtN67dy8jRoxgx44dLF68mDFjxuDk5ERubq4ycFNtwGvVwbJVGRoa0rt3b5KTk1XLeFDbLC0tOXHiBHPmzGHTpk3K9oo2qdUfGhpKr169iI6OpmvXrmRmZuq915XLqZjD287OTpnDOyEhgR07dugMEhZC6NdiA+K0tDTWr19frWNzc3NZuHBhrc8XQojqOHjwIGPHjm2SC3KozYMNKL3d/fv3VxZp0TeXtdqxFarOP61vTuuq9NVVdd5tNTk5Odja2uotQ1/bxowZA8Dw4cM5ceKEatlV64+Ojlau/5VXXlE9R42+ObyjoqJa3PzdQjyKFhsQP2xBhcr0LahQ3fOFEOJh7t69y8mTJ5Vgqqnx9vYmNTWVNWvWaG2vGDR6+vRpbGxsgP8NQgW0BqFWPdbU1FSZNvHkyZNa5VbMaR0SEoK9vb3edumrq+pg2ari4uLQaDR06dJFtYwHtS09PR2AlJQUvekvaoN1K95T4uPj9V5PVfrm8H7hhRdwcXFh+/btrF69mvHjx1e7TCFaoiaXQ1zXCyoAehdViImJ4fjx40pvQOUFFSqfL4QQj+rQoUPcv39fa1XA5iAsLIykpCSuX79OUFAQgOog1JCQEJ1jzc3NmT17NtHR0ZSWlmrNvjF06FB8fHxISEigsLCQsLAwXF1dOXLkiFZAqVZXbGysaltjY2NxdHTE0NCQJ598ku+//15vGUZGRnrbduDAAS5cuEBubi5r167l+PHjD71P06dPx8vLi6+//hqNRsOQIUNqdb8rvPLKK/ztb3/TGiQshNDPoEzfx+PHzMDAgJ07dzJt2jRlW0lJCaWlpRgaGmJkZATA2rVrKS4u5sMPP2Tw4MFERkaSmJjIiRMn+Pjjj9m9ezf79+/n5Zdf5tixYwQGBhIUFERaWhrW1tbcuXOHP//5z3h7e/Pbb7+xbt06/vWvf3Hz5k0+/PBDgoODuXz5MlZWVnz77beEh4dz9+5dRo4cycKFC1XPbw7U7r9onCoGAla8Wbd0zeV+vPfeexw9epTk5OSGbspDVff14vPPP6dbt268+uqrWFhY6KxmWHkQ6oOOLSgo0FoWvEJ+fr7OnNb379/HyMhIec9Qq6u21MrQ17bs7GzMzc2rXXZqaipmZmb06NGDdevW0bZtW+bMmfNI7QUeaf7u4OBgpk+frrcXXYjmpFGnTKjlpLm5uREWFkZaWprWggpquVJVc7Ti4uJwdnYG0OqF0Zcf5uzsrPVCp+98IZo7ybmvf9HR0crrUHPRunVrjI2N6dSpk+rS3pWDywcdqxZwQvmc1hUL6FTMaW1iYqITDFetq7bUytDXtpoEwwAdOnRg3rx5jBs3TsmNrgvVHSQsREvXqFMmvL298fb21tpW1wsqwMMXVaig73whmjvJua9fV65c4dKlS3z55ZcN3ZQ69d5779XLsc2RjY0NMTExFBcX06pVo35rFqJZapK/dXW5oAKo54epLaogCyqIpkZy7puGsLAw2rVrx/Dhwxu6KaKBSTAsRMNokr95db2ggrW19QMXVZAFFURToJZzP3LkSHbt2sWHH37It99+S2RkJDExMcr8pLt378bHx4eXX35ZmRc1KChImcTf3NycQ4cOKTnz8L85ZP38/AgODiYgIAArKyvS09NJTExURt5v375d9XyhKywsjPHjx8tX20II0UAadQ5xTT3KggpQ/RwzCYZFYyQ5903TnTt3iI+P54033mjopgghRIvVrAJiIVoytXlg9eXcq81Pqi/nHlDNuQf1eV0r6DtfaNuzZw9GRkaMGzfusdb766+/kpeX91jrFEKIxkoCYiGaOQ8PD/bt28err74KlOfc79+/H3d3d1xcXLC1tVU9z93dnW+++YapU6cSGRmpbHdzcyMgIIAZM2awceNGJdCu7vlCW1hYGKNGjaJ9+/b1XtcPP/yAh4cHHTp0oEuXLrRv357u3buzdOlSbt++Xe/1CyFEY9Ukc4iFENUnOfeN17179zh48CB+fn71XteuXbvw8PCgZ8+efPzxx9jb21NUVMTJkyfZuHEj27dv58CBA7zwwgv13hYhhGhspIdYiBZKcu4b3oEDB7h37x4TJkyo13ouXLiAm5sbc+bM4cyZMyxcuJCRI0fi7OyMt7c3Fy9exNbWltdff5179+7Va1uqKzc3lx9//LHW50dHR7Nnz556qa9iXu3ExEQmTZrEnTt3lH2nT59Wtj2oDWr7ajNfd0W7K8rTaDS8//77hISEsHTpUgoLC6t9PUK0ZI2qh9jf37/JrzYlhBDVtWPHDoYNG6YzJV1cXJyy8lpeXh7W1tYkJCRoLXgSHR1NUVFRtYJpX19fevfuja+vL++//z5fffWVsi8tLY2YmBiCg4Pp2bMn//jHP3j33Xfr7iJr6dy5cwQFBdV6yWEHBwdKSkrqpb6KebW7detGfPz/x969h1VZ5vvjfwMDEagganjMtPMGJBBTAQVDHXZKDISKIJtSUkgrse+YU40bNtZUBHiYQXQMQmZACREPKKEsoFUongXzIgLKAwlWtHMSmwAAIABJREFUIIslgkvg9we/9QyL9SxYIGfer+vyGvdzuO97LfY18/Hhft4fKVJTUxEQEAAAiIuLg1QqRX19fbtrEDvXlbxu5bpDQ0PR2NiIoqIilJaWYuvWrXjmmWdgYGCg9echGsr6TUHcXV15qGu8vLwwadKkvl4G0ZAhk8lw5MgRbNu2Te3c9evXUV1djZEjR6K6uhoGBgZqLZ21Lfiam5tx7NgxfPrpp1AoFBqbprz55ptwc3PD0aNHu60glsvl2LRpEy5fvgxzc3Ps378f9+7dU8uxzs7OVsvBjoyMxKVLl5CTk4O5c+fC29sbdXV1AICEhARkZGQgPT0dt27dQkNDAxwcHJCfnw97e3t8/PHHyMnJQX19PQwMDNTGnjp1qtp4redzcHBQy+o2MTERzdVevHgxUlJSEBAQgKamJly4cAHTpk0DAGENLi4uePfdd9HQ0AA7Ozt8+OGHwjlPT0+1cRUKhVZZ4U899ZSwbnNzc0ydOhUSiQRXr15FRkYG4uLiEBcXB319fa0/D9FQ1W8KYj4ZJqLBIiIiAu7u7njqqadUjrcuEOvr69HY2Ag3NzeEhYWpFCvaaK/gmzx5slAA1dfXo7a2Fs8++6xwr6amKc8//zz+9a9/dekzi+VgHzp0CKNHj4ZUKsWePXtw4cIF/PDDD2o51mPGjFHLwd6wYQMSEhLg7OyMkpIS+Pn5wc3NDeHh4UhKSoK+vj5kMhmysrKwZs0a6OvrIycnB87Ozrhx4wZkMhnq6upgZGSkNra/v7/aeK3nO378uFpWt52dnWiu9pgxY1BZWYnbt2/jypUrmDt3Lk6fPg0AwhoOHDgAOzs7/PnPf0Z8fDzq6uqEc2J53dpmhYeFhQnrnjhxIu7cuYP169dDT08Prq6uCAsLQ3Nzs+h4mj4P0VDFPcRERN2spKREaFDSWusC8e7du7C3t8fFixeFYmXt2rUIDQ3Vag6ZTIY7d+5ALpcLhdLSpUsRHx+vUgCtWbMGAKBQKIR7WxdhVlZWwvGGhoYuNwcRy8HOyMjAK6+8AgAICAjAjBkzNOZYt83Bbs3Y2BiHDx+Gl5cXjh49KuyLdXZ2BtDyoujMmTMBtOxtbxsn13ZsTeMpiWV1t5er7eXlhQMHDiA5ORnLli1T+25WrFiBc+fOwc7ODmVlZR3mdWubFa6tzn4eoqGo3zwhJiIa6KKiopCamoqSkhLk5+fD2NgYe/fuFaLtMjIyEBwcjFu3bqG4uBhhYWFIT09HUVERfHx88ODBAxgbG3d63taFUn5+vtqYRkZGOH/+PGxtbQG0FGGbNm0C0FIMJScnAwDOnz+v8iS5M0JCQhASEqJyzNLSEsXFxbC1tUVcXBysra2FHOtp06aJ5lgrc7Bbi4mJwaxZs7Bq1SqsXbtWON66eNfR0RHubztG27E1jadka2sLS0tLBAYG4tq1azh79ixKSkpQVFQEGxsbtVxtT09PeHl5oaGhQfiOW5NKpdi+fTtGjhwJHx8fnD17VjinzOtuPa7Y/NXV1e1+R+3p7OchGopYEBMRdZPg4GAEBwcjMDAQgYGBeOGFF1TOKwvEnJwcGBgYYPz48aLFilwu79S8bQultmPW1dVh586d8Pb2BiBehF24cAGZmZnYt2/fw34NghUrViAoKAgHDx6EQqGAv78/HnvsMQQEBODgwYOor69HREQEsrKy1O6dMmUKcnNzIZVK4ejoiNDQUOTl5aG+vh5paWnw8/Pr8rrExvP29hbm8/T0hL+/P6RSKYqLixETE4OZM2fC19cXqampkMvlePLJJ4XxRo0aBUNDQ6G4b8vU1BTe3t6wsLBAXV0drK2tcenSJQAted1txxWbX9MTYeX3NGLECEyYMEH0ms5+HqKhSKe5s//UJKI+pcwU5r77Fv3x+wgKCkJgYCCsra1VjpeXlyMoKAjffvstRowYgbKyMshkMvj7+2PYsGFCsVJYWKjyUt1zzz0HPz8/PPHEE8JYq1evxr1792BkZIT79+9j7dq1yM7OxoEDB7BlyxaVMV9++WV89tlnsLa2xp07d3DixAn4+vrC3Nwccrkcw4cPx+nTp/HMM8/gxIkTwtNWTXR0dLB//34sXbpUq+9DmZjRWusca03u378PPT096OnpQS6XQ0dHB8bGxqLjdZbYeK3nA6CS1a3U1VztpqYmVFZWanx5TWxcsfnFtF23Jp39PMotICwTaChgQUw0wPRFAaiM5nrzzTc7vLaoqAgHDhzABx98IBx74403sGPHDhgaGgrHlNFi7u7uD7W2/lgQt+fixYuwtbVFTk4OnJychOPaFj+dUV5ejn379mHjxo1Yvnw5zpw5g/Lycri7u8PCwgJVVVUoLCxEVlYWXFxckJycDFNT0w7H7WxBTAMTC2IaSrhlgog61Jmc0urqapw5c0bl2MmTJ4UXg5SU0WJDza5du/Dcc89h7ty5Ksc1/bq7qx48eIAtW7bgn//8J7Zu3Yq33noL9+7dw5dffokjR45g7969+MMf/gArKyscPHgQbm5uHT4ZJiIarFgQEw1i7u7u2Lp1K6ZMmYK///3vMDMzw5IlS7TKODU3NxeN5pLL5Wo5st9++y1OnjyJ7777Drt379a4npSUFOG6d999t7e+hn5DLpcjKSkJISEhPVp81tbWYtmyZfjmm2+EYhcAHn30UQQFBSEoKKjH5iYiGogYu0Y0SDQ2NkKhUKg0a5g3bx4OHDgAAPj3v/8NV1dXlUguZcyXWHSXpmiutLQ0jB8/HhKJBB4eHoiNjYVcLkdpaSny8/PbXaO21w1WiYmJaGhowIoVK3psjvLycsydOxeXLl1Cbm5uj7eFJiIaDFgQEw0SYjmwPj4+SEtLQ3FxMSZNmgQzMzOtM0415ZRqypF1dXWFkZERRo0ahXv37qmsTVdXV8heVV43FO3evRtLlizBmDFjemT8y5cvY9asWXjw4AFOnz6N6dOn98g8RESDDQtiokEiJCQEBQUFiIiIEI499thjMDMzQ3h4OF577TUALZFcXl5eSExMRHh4OBYtWgRAPbpLGc0FQCWnVJkjC0A0R/app57C1atXcevWLQDAqVOnYGZmJpxX/udQc+nSJZw/f15olNHdMjIyMGfOHDz33HP49ttv8fjjj/fIPEREg9HQ/F8moiHEz88Px44dwx//+EcALZmkx48fh6+vL7y8vISmEW35+vpi586dWLJkCdLT04XjPj4+iI2NxfLly7Fr1y6h0FbS1dVFWFgYrKys4OTkBDc3N0RGRvbY5xsooqOj8fzzz8PBwaHbx962bRsWL16MJUuW4NixYzAxMen2OYiIBjPGrhENMN0VM6ZtzJemnNKOcmQfPHiA8vJyPP744z36AtlAiF27c+cOJk2ahI8++ghvv/12t43b2NiIDRs2YMeOHdi8ebNap7iewti1oYGxazSUMGWCaIjSNuZLU2h/R00V/vCHP2Dy5MmdXtdgtGvXLujo6MDf37/bxrx79y58fHzw9ddf49///jeWL1/ebWP3NmUm9fDhw1FbW4uJEyciLy8Pb731lsp1mZmZaGho0PpFQZlMhg8++AA7duxQOd6ZXG0iGhpYEBMR9SCFQoF//OMfWL16dbdtZbh16xZeeeUV/PTTTzhx4gTmzJnTLeP2FWUmtbIzn4GBAS5evKh2nbW1tUqKSkcaGhqQnZ2tdrwzudpENDSwICYi6kHJycn45ZdfsHbt2m4Z78qVK1i8eDH09fWRl5eHZ555plvG7QlyuRybNm3C5cuXYW5ujv3796OpqUktB1tbOTk5qK+vh4GBgVpu9uTJk9XGbb0dqLa2VjRXm4gI4Et1REQ9avv27e2+vNgZJ0+ehKOjIyZMmNDvimGxHOxDhw5h9OjRkEqlcHV1xYULF0RzsLUlk8lw584d0dzsjsbVlKtNRASwICYi6jG5ubk4c+YM1q9f/9BjxcbG4uWXX8bChQuRlZXVY1nGXSWWg52RkYFXXnkFABAQEIAZM2ZozMHurLa52R2NqylXm4gI4JYJogHp9OnTQrrCUHf69GnMmjWrr5chKjIyEo6Ojg+1vubmZoSGhiI0NBRvv/02tm7d2qOpHV0VEhKilnJhaWmJ4uJi2NraIi4uDtbW1rC1tYWlpSUCAwNx7do1nD17FnK5vNPztc3NFhu3NWWuto2NjUquNhERwIKYaMCZPXt2Xy+hX5k1a1a//E5+/PFHHD16FMnJyV0eo6GhAStXrkRycjJ27dqF1atXd+MKe96KFSsQFBSEgwcPQqFQwN/fH1OnToW/vz+kUimKi4sRExODwsJCtXsPHz4sPAUGoFbgtuXp6ak2bmu+vr7w9fVFamoq5HI5nnzyye75kEQ0KDCHmIioB7zxxhvIzs7GDz/8AD09vU7fX1VVBQ8PDxQWFuLAgQOYN29eD6yyazqbQ6yMVGtN2xzszupoXE252qSOOcQ0lPAJMRFRN7t+/Tr27t2L6OjoLhXDpaWlWLRoEe7fv4/vvvsOzz//fA+ssve0LYYB7XOwO6ujcVkME5EYvlRHRNTN/va3v2Hs2LHw8/Pr9L2nTp3C7NmzYWJiglOnTg34YpiIaCBgQUxE1I1u3bqFL7/8Eu+//z4MDAw6de9XX32Fl156CY6OjsjOzoa5uXkPrZKIiFpjQUxE1I3+9re/YfTo0Xjttdc6dd+2bdvg7e2N1atXIyUlBUZGRj2zQCIiUsM9xERE3aSiogJ79uzBZ599pvXLYg8ePMC6deuwZ88ebNu2DevWrevhVRIRUVssiImIukl4eDhMTEywatUqra6vra3FsmXLIJVKcfDgQbi5ufXwComISAwLYiKibnD79m3ExMRgy5YtePTRRzu8vry8HIsWLcLt27eRk5OD6dOn98IqiYhIDPcQExF1g48//hgjRozAmjVrOrz27NmzsLOzQ1NTE06fPs1imIioj7EgJiJ6SD///DNiYmLwv//7vx2+DJeWlgZnZ2dYWVlBKpXi8ccf76VV9q3i4mJER0d365gymQxvvfVWr8xFRIMbC2Iioof017/+FRMmTMDKlSvbvW7btm149dVXsXz5cqSnp8PExKSXVtj3ampqcPXq1W4ds6GhAdnZ2b0yFxENbtxDTET0EAoLC5GYmIikpCSNucONjY0IDg7G3//+d2zevBkhISG9u8g+Ultbiy1btuDMmTMwMzPDuHHjAAByuRybN2/GpUuXYG5ujqioKGRnZyMrKwu//PIL9PT0EBUVhbFjx6pd9+233+LkyZP47rvvIJFIOpyLiEgbfEJMRPQQNm3aBCsrK3h5eYmev3v3Ljw8PLB79278+9//HrTFcGNjIxQKBRobG4VjiYmJMDU1RXZ2NqysrITjaWlpGD9+PCQSCTw8PBAbGwu5XA6FQoFjx45h6dKliI+P13hdaWkp8vPzVebXNBcRkTZYEBMRdZFUKsWxY8fw+eefQ1dX/b9Ob926BScnJ+Tl5eHkyZNYvnx5H6yyd4SFhWH69OnYuHGjcEwikcDV1RUA8NJLLwnHMzIysHDhQgCAk5OT8KTXzs4OADBp0iRUV1drvM7V1VVtr7amuYiItMGCmIioizZt2gRnZ2fMnz9f7dyVK1cwa9Ys1NTU4NSpU3B0dOyDFfaekJAQFBQUICIiQjhmY2ODoqIiAEBBQYFwfNq0acLxixcvwt7eHgCEf1Q0NzdrdV1rmuYiItIG9xATEXVBWloaTp06hVOnTqmdO3nyJLy8vGBpaYm0tDSMHj26D1bY93x9feHr64vU1FTI5XI8+eSTAAAfHx8EBATg4MGDqK+vR0REBLKystTuF7vum2++6dRcRETa0GlW/lOciIi0cv/+fVhZWeGFF17A/v37Vc7FxsYiMDAQHh4eiI+Ph6GhYR+tsufo6Ohg//79WLp0qVbXV1RUYOzYsWrHq6qqYGZm1uH92l7X3lzUecnJyVi2bBlYJtBQwC0TRESdFBkZiRs3buDTTz8VjjU3NyMkJAQBAQHYsGED9u3bNyiL4a7QVKBqW+Rqe117cxERtYdbJoiIOqGiogJ/+9vf8Je//AVPPPEEgJY83JUrVyIlJQVffvkl/ud//qdvF0lERJ3CgpiIqBM2bNiA0aNH489//jMA4Pfff4eHhweuXLmCjIwMzJs3r49XSEREncWCmIhIS8eOHUNSUhKOHDkCQ0NDlJSUYNGiRVAoFPjuu+/w/PPPq1wvkUhQW1uL4cOHo7a2FhMnTkReXp5au+HMzEw0NDTAzc1Nq3XIZDJ88MEH2LFjh8rx4uJinDx5Em+++ebDfVAioiGGBTERkRZkMhkCAwPh4+ODxYsXIy8vD3/6058wdepUHDp0CObm5mr3XL9+HdXV1Rg5ciSqq6thYGCAixcvql1nbW2t0tCiI2xZTETUvVgQExFpEBERAXd3dzz11FN47733cO/ePURFRSEhIQGvv/46TE1NMW7cOIwePRoKhQKffPIJpFIpGhsbER8fr/U8OTk5qK+vh4GBgVr74smTJ6uN+8gjjwj39lXL4qioKHz11Ve9Mhf1jZs3b/b1Eoh6DVMmiIg0KCkpwd27dyGRSLBr1y5s374dSUlJ8Pf3h52dHW7fvo1FixbhwoULOHnyJBQKBTIzM7F27VqEhoZqPY9MJsOdO3dE2xd3NG5ftCz28vLCxIkTe2Uu6jsTJ07U2JKcaLDhE2IiojaioqKQmpqKkpIS5OXl4YcffsDChQuRk5ODL774AnZ2doiOjoauri4CAgIAAOvWrUNRURF8fHzw4MEDGBsbd2nu1u2L8/PzkZ6e3u64EokEmzZtAtDSsjg5OfkhPrl2+GSYiAYbFsRERG0EBwcjODgYgYGB+Pnnn/Hrr7/i7t27SExMRFpaGr7//nsUFxfD1tYWcXFxsLa2hq2tLSwtLREYGIhr167h7NmzkMvlnZ67bftisXFbU7YstrGxYctiIqIuYkFMRKTBDz/8gG+++QaTJk1CWVkZcnNzYWtrCxsbGwQFBeHgwYNQKBTw9/fH1KlT4e/vD6lUiuLiYsTExKCwsFBtzMOHDwtPgQGoFbhteXp6qo3bGlsWExE9PLZuJiISceXKFcyYMQN6enqYOnUqjh49iscff1zlGmWkWmvl5eUYPXq0yotv3aGjcdmymIio61gQExG1IZfL8fzzz+OXX36Bi4sLUlJSMGLEiL5eFhER9RCmTBARteHs7IybN29i2bJlSE9PZzFMRDTIsSAmImrl5s2b+OGHH7BmzRokJiZCX1+/r5dEREQ9jAUxEVErEydORGVlpdrLa12VmZmJI0eOdOleiUSCQ4cOIT8/H+7u7qiqqhLOnTt3Tu2YJsXFxYiOjm53DplMptZSuqN7iYgGCxbERERtGBkZddtY1tbWmD59epfuvX79OsrKylBRUQGpVIrU1FThXFxcHKRSKerr6zscp72Wzso52A6aiIYyxq4R9SM6Ojp9vYRBrbPvELdu3dxaU1MTvL29UVdXBwBISEhARkaGWtvlp556SqUtc3p6Om7duoWGhgY4ODggPz8f9vb22LJli9p4I0eOVJlz8eLFSElJQUBAAJqamnDhwgVMmzYNQMtLgJs3b8alS5dgbm6OqKgoGBsbq7V01ra9dF+1gyYi6issiIn6mfXr12P27Nl9vYxB5dSpU9i6dWun71O2bm6rrKwMfn5+cHNzQ3h4OJKSkqCvry+0XU5ISEB8fDzCwsIgk8lQV1cHIyMjyGQyZGVlYc2aNdDX10dOTg6cnZ3x3XffqY335ptvqsw5ZswYVFZW4vbt27hy5Qrmzp2L06dPAwDS0tIwfvx4REZGIjk5GbGxsRg1apTQ0jkkJAS//fabShvo1NRUhIaGwsHBQe3ztW4HrbyXiGgwY0FM1M/Mnj0bS5cu7etlDDqdKYhbt27Oz8+HsbEx9u7diylTpgAAjI2NcfjwYcTHx+PXX3+Fu7s79PX11dout+Xs7AwAMDU1xcyZMwEAZmZmaGpqUhtPjJeXFw4cOIDLly9j9erVQkGckZGBjRs3AgCcnJywe/dujBo1Sq2lc0dtoJX6oh00EVFf4h5iIqI2goODIZVK4e7ujtjYWEilUqEYBoCYmBjMmjULKSkpsLS0FI63bbvcVuumGsrtMc3Nzdi/f7/oeG15enoiOTkZBQUFsLW1FY5PmzYNRUVFAICLFy/C3t5eaOkMQGjpbGtrCy8vLyQmJiI8PByLFi0SnUfsXiKiwYxPiImINNDR0RHd1+3o6IjQ0FDk5eWhvr4eaWlp8PPz6/I8tra2iIuLUxlvw4YNateNGjUKhoaGsLe3Vznu4+ODgIAAHDx4EPX19YiIiIC+vr5aS2exNtBi7aXZDpqIhhp2qiPqR3R0dLB///5e2TKRn5+Pjz/+GHFxcTAzMwPQEuUVFhamcqw1mUyGyspKPP300+2ey8zMRENDA9zc3Hr8c2gjOTkZy5Yt6/RLde2Ry+XQ0dGBsbGxaAvnvhivqqpK7ecm1tJZ2/bSbAdNREMFt0wQDVFdifIqLCxEREREh+ceJmpsoBg2bJiwB/dhi+HuGk/sHzFiBe2ECRM6LIY13UtENBhxywTREKYpyislJQUmJibw9/fHiRMnUFBQgHfffReRkZG4dOkSsrOzsXPnTpWYMOW5nJwcVFZWor6+Hq+++qpaHFh2drZoPBkREVFf4RNioiFszJgxaG5uxu3bt5GTk4O5c+eiubkZd+/ehVwuBwDU1dWhpqYGALBhwwYsWLAAkyZNgp+fH44ePQonJyckJSUJ55ydnSGTyXDnzh0hDkwikcDDwwOxsbGQy+VCPNnSpUs1ZuESERH1FhbEREOcMspLuc+2rQcPHqgdU8aOeXl54ejRoxq3WGRkZGDhwoUAWuLAJBIJAKjEk1VXV3fXRyEiIuoSFsREQ5xYlNcjjzwiNKRQZt22pil2rC2xODCg43gyIiKi3sSCmGiIU0Z5zZs3Tzjm6OiIr7/+GvPnz8f58+eF41OmTEFubi5MTU0RFxeHVatWCVsjlOekUqlwvY+PD2JjY7F8+XLs2rULr732Wm9+NCIiIq0wdo2oH+nN2DVtKFsOt3b//n3o6enh3r17ajFhynN6enoq94jFgfWmnohdIyKiwYMpE0SkUdtiGAAMDAwAtMSEKSljwpTn2urLYpiIiKgj3DJBREREREMaC2IiIiIiGtJYEBMRERHRkMY9xET90JIlS/p6CYPKzZs3+3oJRETUj/EJMVE/lJKSwiKuG4llKRMRESnxCTFRPxUcHNxv4tcGOh0dnb5eAhER9WN8QkzUTy1btgw6Ojr80w1/iIiI2sMnxET90P79+/t6CYPKqVOnsHXr1r5eBhER9VMsiIn6IW6V6H4siImISBNumSAiIiKiIY0FMdEQIpPJ8OOPP3Z4PjMzE0eOHOn02G+99ZbKseLiYkRHR3dprTQwLVmypM/3jPNP5/4w5pGIWyaIhpTCwkIkJCQgJiam3fOhoaFobGzs1NgNDQ3Izs5WOVZTU4OrV692eb00MM2aNQvBwcF9vQzSQlRUVF8vgahfYEFMNEAlJSUhPT0dt27dQkNDAxwcHJCfnw97e3t8/PHHSEhIQFNTE/z9/XHixAkUFBQgLy8Ply5dQk5ODubOnQtvb2/U1dUBABISEhAZGYlLly7B3NwcU6dOxauvvorNmzcLx6KiojB27FgkJSUhKysLv/zyC/T09BAVFQUTExMAQG1tLbZs2YIzZ87AzMwM48aN68uvifrAxIkTuQ9+gPjqq6/6eglE/QK3TBD1c42NjVAoFGpPbOVyOWQyGbKysmBhYQF9fX3k5OQgLy8PN27cQG1tLeRyOQCgrq4ONTU12LBhAxYsWABnZ2eUlZXBz88PR48ehZOTE5KSkoTzEydOxJ07d5CWlobx48dDIpHAw8MDsbGxwtwKhQLHjh3D0qVLER8fL6wrMTERpqamyM7OhpWVVe99UURERF3EgpionwsLC8P06dOxceNGtXPOzs4AAFNTU8ycORMAYGZmhtraWpXrHjx4oHavsbExDh8+DC8vLxw9ehT19fVq12RkZGDhwoUAACcnJ0gkEuGcnZ0dAGDSpEmorq4WjkskEri6ugIAXnrppc58VCIioj7BgpionwsJCUFBQQEiIiLUzj3yyCPC35UNKJqbm9Hc3AxDQ0PcvXsXgHjr4piYGMyaNQspKSmwtLQUnXvatGkoKioCAFy8eBH29vbCOV1dXWG+1mxsbIR7CgoKtP6cRB3Jz8+Hu7s7qqqqhGPnzp1TO9ZaT75IeuXKFbi7u8Pd3R1Lly5FeHg47t+/3+FcmijXIJFIcOjQoU6thYgeDgtiokHKxcUFX3/9NebPn4/z588DAKZMmYLc3FxIpVI4OjoiLi4Oq1atErZHKM8r/0fbx8cHsbGxWL58OXbt2oXXXnutw3l9fX2xc+dOLFmyBOnp6T35EWmIqaiogFQqRWpqqnAsLi4OUqlU9DccQMuLomL/mGx73traGtOnT+/Uen7//XcAwJ49e7Bp0yYUFhbijTfe6HAuTZRruH79OsrKyjq1FiJ6OHypjmiAav0/vJ9++qnw94MHDwp/z8rKQl1dHYyMjIRjly9fhp6eHvT09DB79mzo6OjA2NgYtbW1GD58uMp5oGXbRFVVFczMzETnnjdvHubNmweg5YkZAHzzzTeoqKjA2LFju/lT01C3ePFipKSkICAgAE1NTbhw4QKmTZsGAL3+IikAGBoaYsyYMRgzZgy+/PJLPPHEE7h//z50dHTwySefQCqVorGxEfHx8cJc2dnZ2Llzp8o6Ro4ciZycHJXC/ubNm3j33XfR0NAAOzs7fPjhh738bRMNHXxCTDTItS6GAcDAwEAodocNGwZjY2MAwPDhw9XOK7UuhrXFYph6wpgxY9Dc3Izbt28LRa5y205fvUiqpKurCysrK1y8eBEnT56EQqFAZmYm1q5di9DQUGF2xcyBAAAgAElEQVSuSZMmqa0DaNlScefOHWG8AwcOwM7ODmlpaZg0aZJQQBNR92NBTEREA4qXlxcOHDiA5ORkLFu2TPSa3nyRtLWamhpMmTIF6enpyMvLg4+PD/bt26eyHm3WAQArVqzAuXPnYGdnh7KyMrV/3BJR92FBTEREA4qnpyeSk5NRUFAAW1tb4XhfvUiqJJFIoFAo8Nhjj8HW1hZeXl5ITExEeHg4Fi1a1Kl1AIBUKsX27duRl5eH77//HmfPntV4LRE9HO4hJiKiAWXUqFEwNDRUKVaBlhdJV65ciczMTDQ1NcHR0VHtRdLQ0FDk5eWhvr4eaWlp8Pb2Rm5uLkaMGIEJEybAx8cHAQEBOHjwIOrr69t9CQ5o2advb28PXV1dmJiYCI0uPD094e/vD6lUiuLiYsTExGDcuHHIzc3F6tWrERcXp7KODRs2qI1tamoKb29vWFhYoK6uDtbW1t33JRKRCp1mTf/UJaJep6Ojg/3797PLVzdT/mqd/3XX85YsWQKgbzugtX2R9P79+8KLonK5XO1F0tbnldq+SNpV5eXlGD16tBCRqJzr3r17ausQ09TUhMrKyh7r+Ngffl5E/QGfEBMR0aAi9iKp0rBhw4S/t36RtK3uKIYBYMKECaJrEVuHGF1dXbY/J+oF3ENMREREREMaC2IiIiIiGtJYEBMNIYOpja1MJsNbb72ldry4uBjR0dGdWjsREQ1t3ENMNIQUFhYiISEBMTEx7Z4PDQ1FY2Njp8Zu3cb2xo0b2Lp1K9544w3RBgbarMXa2hqNjY3IzMwUzXxtaGhAdna22vGamhpcvXq1U2un7hcZGYlTp0719TKoA6dPn8asWbP6ehlEfY4FMdEAlZSUhPT0dNy6dQsNDQ1wcHBAfn4+7O3t8fHHHw/6NrZr1qwRztXW1mLLli04c+YMzMzM+BJSP3Dq1CkWW/3czZs3cfPmzb5eBlG/wIKYqJ9rbGxEU1MTdHV1VWKh5HI5ZDIZsrKysGbNGujr6yMnJwfOzs64ceMGamtrhZix1m1sExIS4OzsjJKSEvj5+cHNzQ3h4eFCG9uEhAS1NraRkZFITk5GbGws3n//fZU2tgkJCYiPj8f8+fNV1t26jW1VVZXQxjY1NVVoY5uQkCC0sW29jjfffBMymQx1dXUwMTEB8J82tn/+858RHx+Pe/fuCXMlJibC1NQU2dnZCAkJwW+//dYLPxnqyKxZsxjn1Y+11+mPaKjhHmKifi4sLAzTp0/Hxo0b1c45OzsDaAnwnzlzJoCWuKja2lqV6wZjG9tHH31UOCeRSODq6goAeOmll0Tvp96XkpICHR0d/umnf1gME/0HnxAT9XMhISEICQkRPacM+wdamnoALW1lm5ubYWhoKDwpPX36tEoBCfynfeyqVauwdu1a0fGVbWynTZv20G1sLS0tERgYiGvXrqm0oNVmHcB/2tiOHDkSPj4+uHjxonDOxsYGRUVFsLGxQUFBgcYxqPds2LBBaPpA/ZdyuxPRUMeCmGiQGuxtbC0sLIRzvr6+8PX1RWpqKuRyOZ588snu/TKp02bPno3Zs2f39TKoA9zSQtSCrZuJ+pGeaN08lNrYVlRUYOzYsWrH2bq597AV8MDCnxdRC+4hJhrkxNrYKovdYcOGwdjYGIBqG9vWxTDQvW1sW2/zUM4ltg4xHbWxFSuGaXDRNksbQKfztPPz8+Hu7o6qqirh2Llz59SOaZrv+PHjnc7vZm42Uf/AgpiIiAaMwsLCdrfutD5vbW2N6dOnaz12RUUFpFIpUlNThWNxcXGQSqUaX/ZsPd/Nmzdx/fp1recDmJtN1F9wDzEREfWJnszSzsnJQWVlJerr60XztLOzs0WztBcvXoyUlBQEBASgqakJFy5cwLRp0wAACoVCY552Tk4OACA9PR2pqakYMWIEPv/8c5ibm6vNbWxszNxson6GT4iJiKjHNTY2QqFQqHRAbJ2lbWFhIWRp5+XlCVnacrkcgGqW9oIFC+Ds7IyysjL4+fnh6NGjcHJyErK0ledlMplKnrZEIoGHhwdiY2NVsrSXLl0qdFQcM2YMmpubcfv2baHoVu49P3nypJCnvXbtWiFPWzmfUlZWFpYsWYL4+HjRuVvnZltZWfXeD4GINGJBTEREPU5TnnZPZ2kDmvO0NWVpe3l54cCBA2qNK9rL01ZSNqgxNzdHVVWV6NzMzSbqf7hlgoiIepymPO2eztIGNOdpa8rS9vT0hJeXFxoaGmBrayscby9PW+zzaJrbyMiIudlE/QwLYiIi6pceJktbKpUK44jlaWdlZWmcd9SoUTA0NFRpRAO0n6fder7WxObW19dnbjZRP8McYqJ+pCdyiIk5xL2pJ3JtuyNLG+j5PO2283U0t6bc7N7EHGKiFtxDTDTIdTaLtTWJRIJDhw4B6FpGq1JHWavKeWQyGd56661O30+DW3dkaQM9n6fdHrG5+7oYJqL/YEFMNMh1Nou1tevXr6OsrAxA1zJalTrKWlXO09DQgOzs7E7fT0RE9DC4h5hogGpqalLLYM3IyFDLVj1//jzq6+thYGDQbuar2HhtacpovXv3LjZs2KBV1qpYlquY2tpaZrUSEVGv4BNion5OLL8VgGgGq1i2qjKLtaPMV7Hx2tKU0ZqRkaF11qpYlqsYZrUSEVFvYUFM1M9pym/VlMGqKVsVaD/zVdtMV7GM1pycHK2zVrXJcgXArFYiIuo1LIiJ+rmQkBAUFBQgIiJC5bgygzUlJQWWlpbCcU3ZqkD7ma+axmvL09MTycnJKCgoEDJan3/+eRQVFQGAkLVqY2MjHGudtWprawsvLy8kJiYiPDwcixYtEp1H0/1ERETdjXuIiQYosQxWPz+/bh1v5cqVateJZbR6eHjggw8+0CprVSzLtbCwUG0eX19fZrUSEVGvYA4xUT/S2RxisQzWh/Gw43Uma7Vtlqsm3ZHVyhzi3sNc24GFPy+iFtwyQTSAiWWw9uV4nclabZvlqgmzWocehUKB9evXIykpCevXr0dKSopW98lkMvz4449aXds62/rWrVt4/fXXYWdnh6VLl4q2ZO6K8+fPY/ny5bh3755wbN26dRr3zRNR32FBTERE/UpRURFKS0thaWmJ0tJSeHl5aXVfYWGh2l57TZTZ1vfv34eLiwtefPFF5Obm4q9//SuCg4OF+MGHcfv2bRw7dgxhYWHCMYlEgqampocem4i6F/cQExFRnxDLvh45ciQ+//xzXL16FfPnz8ewYcOQkZEBFxcXtfxqU1NTbNq0CZcvX4a5uTkePHiAwsJC5OTkwMHBQe16ExMTtWzr1NRUmJubIygoCABgZWWF6Oho/P777zAyMhLNzZZKpWp535MnTxbN116+fDm+/vpr+Pr6wsLCot3PnpGR0W5WuNhaJk6c2Ms/NaLBiU+IiYja4F7j7ieWp60p+3r9+vVwcnJCRkYGnJyc4OrqKppffejQIYwePRpSqRSurq5wdnbGggUL4OzsLHq9WLZ1UVGREO+Xn5+PdevWYffu3cjPzwcgnpstlvetKV9bX18f0dHRCAoKUvn/K0054u1lhWub4U1EnceCmIiojb/85S9wc3PD6dOn+3opg4ZYnra22deAeH51RkYGXnnlFQBAQEAAZsyY0e71YtnWZmZm+OmnnwAAzz77LIKCgmBiYgKpVKpxHEA977u9fO2ZM2fC2toae/bs6fCzt5cVrm2GNxF1HrdMEBG1MWfOHEgkEsyePRvz58/HX/7yl4duDiKTyVBZWYmnn366w/OZmZloaGiAm5ubVmNfuXIFH3zwAYCWrOkZM2bgnXfegYGBQZfWopxfmTbi7u4uOsYHH3yAHTt2CMeKi4tRWloqGpEXEhKCkJAQlWPK7OtVq1Zh7dq17X5GW1tbWFpaIjAwENeuXcPZs2dRWlqK4uJi2NraIi4uDnK5vN3rS0pKUFRUBBsbGyHb2sXFBdu2bUN5eTkmTJiAESNGQCqVwsbGRuM41dXVannfYte19vHHH8PBwQF37txp97O3lxXe0RxE1HV8QkxE1MaiRYtw5swZSKVSGBoawsXFBba2tti7d69aC21tdfTCV+vz1tbWmD59utZj//777wCAPXv2YNOmTSgsLMQbb7zR5bUo579+/TrKyspEr2loaEB2drbKsZqaGshkMq3X7ejoiLi4OKxatQp37txBWlqaxms9PT1x/Phx+Pr6wsvLC1OmTMGKFSuQmJiIZcuW4ciRI/Dw8EBubi6kUqno9b6+vti5cyeWLFmC9PR0AICFhQU2b94MNzc3LFq0CFZWVnBxcWl3Xm3X19rw4cOxZcsW3Lp1q9OfvbNrIaLOYw4xUT/S2Rxi0k5Xc4gjIiLg7u6O2tpaREVFITExEc899xzmzp2LmpoaVFRUiL78lJCQgKamJvj7++PEiRMoKChAXl4eLl26hC+++AJz585Ve6EqICBAOF9ZWYn6+nq8+uqr2Lx5My5dugRzc3NERUUhOztb7YWu8vJyREdHY//+/QBaXth64oknUFJSAh0dHbUXsd55551215KZmYn6+no0NzejuroaS5YswbvvvouGhgbY2dnhww8/xK+//op58+bh1KlTKi+qXb58GTY2Nlrn2nY2+1osv7r1fffv34eenh709PQ0Xt9eNvb48eOFJ7Mdzavt+jTpau53Z+boCHOIiVrwCTHRICeRSHDo0CHhP8+fP6/ya26g5VfkR44c6dS4MpkMb731lsqx1tmug0FJSQnu3r0LGxsb7N27F5cvX4atrS127dqFtLQ0vPLKK3j22WfVXn6qra0Vfn1fV1eHmpoabNiwQXjhS+yFqtbnZTKZ8NRw/PjxkEgk8PDwQGxsrOgLXW3p6urCysoKFy9eFH0Rq6O1KOdXOnDgAOzs7JCWloZJkyapRJKJvajWGZ3NvhbLr259n4GBgVAMa7q+vWxssWJY0zgPcx3Q9dzvzsxBRNphQUw0yCl/7a38z9u3b+PixYsq13T2V/SA5l+ZX7169aHX3NeioqIwZ84cpKWl4fXXX8ecOXPw008/wcLCAnv37sVHH32E6dOn4y9/+Qv27duHsrIy3LlzR3j5qTWxF5+0fZksIyMDCxcuBAA4OTlBIpEAUH+hS0xNTQ2mTJnS4YtY2qxlxYoVOHfuHOzs7FBWVgYjIyPhnNiLakREAw0LYqIBSi6XY926dZgzZw68vLyEWKuwsDAsXLgQLi4uuHnzplZj5eTk4MSJE0hKSkJAQABefvlluLm5oaSkpMMxa2tr8d5772HevHn45JNPeuKj9rrg4GBIpVK4u7sjNjYWUqlUZb/mqFGjsGzZMvz888+wsbHB4cOHMXnyZBQUFODXX3+FoaEh7t69CwCiSRXKF6pSUlJgaWmpcR3Tpk1DUVERAODixYuwt7cHALUXutqSSCRQKBR47LHHYGtrCy8vLyQmJiI8PByLFi3q9FqkUim2b9+OvLw8fP/99yovc9nY2AhrVL6oRkQ00DBlgqifa2xsRFNTE3R1dVV+Fdw6g3XPnj24cOECfvvtN+HX46mpqQgNDYWDg0OHc8hkMtTV1QmNCI4dO4aEhATEx8fD3t5ebcx//vOfwr2tf2UeEhKC3377rUe+h76go6Oj8VfoAPDYY4/BwcEB77zzDn755Rds2rQJ//3f/w1vb2/88MMPyMzMRFNTExwdHTFlyhThhS9HR0eEhoYiLy8P9fX1SEtLg7e3t3BeycfHBwEBATh48CDq6+sRERGBrKws0bVkZWXB3t4eurq6MDExEfaEenp6wt/fH1KpFMXFxYiJicG4cePaXYufn5/K2KampvD29oaFhQXq6upgbW2NmpoaAICvry98fX2RmpqqkvJARDSQsCAm6ufCwsKQmpqKBQsWqCQDZGRkIDg4GEBLBisArFu3DkVFRfDx8cGDBw+E/Ymd0frX8fn5+UhPT293TIlEgk2bNgFo+ZV5cnJylz5nf7Rz507R460THD799FPh74GBgYiPj8eWLVtQUVEBLy8vbN68Gc899xwA4PLly8ILX7Nnz1Z7oUp5fs6cOcKYGRkZqKqqgpmZGQBg6tSpwrl58+Zh3rx5AKDxHyKmpqY4dOiQ2otYHa2lrblz56KyshLjxo0DAIwZMwZXrlwBAHzzzTfCi2rKl7SIiAYSbpkg6udCQkJQUFCgFpNlaWmJ4uJiAEBcXBwuXLjQ4a/HtSGWr9remPyV+X888sgjWL16NUpLS7Fnzx5cvHgRFhYWcHNzw9mzZ1Ve+BJ7oartC2FKymL4YbR9EaujtbSlq6srFMNiNL2oRkQ0ELAgJhqg2mawvvDCC1rnlB4+fBh2dnbCn/biyDoaUyzbdajT19fH//zP/+D7779HWloaKisr8eKLL8LR0bHTaR5ERNTzmENM1I90JYdY7Ffc3ZlTqu2YmrJd+4Ou5hB3p2+//Raffvopjh49CgcHB7z33ntYvHhxu3uUByLm2g4s/HkRteATYqIBTuxX3D2RU9rRmP21GO4vlE+HpVIpRo4cCXd3d7zwwgvYu3evaDTbUHX8+HE+RSeiXseCmIioFykL48uXL8Pa2hqrVq3Cs88+i23btmnMIx5Kbt68ievXr/f1MohoiGFBTETUB6ysrLB3714UFxdj8eLF2LRpE5544gmEhIRAJpP19fJ6hViWNgCkp6fDxcUFHh4eKC0tRUpKCgIDA2FlZQW5XI4NGzbgpZdewvLly1FRUQEASEpKwooVK+Di4gJHR0e89957cHZ2xvvvvy96z82bN7Fs2TL86U9/wpYtW4T1tL2uvXEBdDn7m4j6FxbERER9aMqUKdi2bRt+/vlnBAYGIioqCk8++SRCQkJQVVXV18vrNsrGMcqiF1DN0nZ1dcWFCxeEc1lZWViyZAni4+Mhl8tRWlqK/Px80XbWQEsxK5PJkJWVBQsLC5V22l988YXaPWLtqDW1ytY07o0bN0RbYxPRwMOCmIioHzA3N0dISAhKS0uxdu1a7NixA5MnT8Y777yD8vLyvl7eQwsLC8P06dOxceNG4VhGRgZeeeUVAC1Z2jNmzAAAzJ8/H0DLd6L8R4GrqyuMjIw0trMGAGdnZwAt2cszZ84E0BJZd/LkSbV7xNpRaxpb07i1tbUdtsYmooGBjTmI+pmoqCi+8d3NBtKvsUePHo2QkBD8v//3//DFF18gPDwcMTExWLZsGT788EM888wzfb3ELgkJCUFISIjKMWWWtq2tLeLi4mBtbQ0Aoi9vKvOxle2sp02bptLOuu19yvSO5uZmPPPMM2r3KNtRjxw5Ej4+Pjh79qzGsTWN29zcDFtbW1haWiIwMBDXrl1TaWtNRAMHC2KifsTLy6uvlzAoTZw4ccB9t8OGDcM777yDoKAg7Nu3Dx999BGef/55vPzyywgNDYWtrW1fL/GhrVixAkFBQTh48CAUCgX8/f1x/vz5du8Ra2fdkUWLFuGzzz5Tuef69etq7ajHjRundatsJbHW2EQ08DCHmIhoAGhqakJ6ejpCQ0Nx4cIFLFq0CO+//z5mz57d10tT0ZVcW03totvTup11V+9pampSaUf9MGP3RPZ3b2AOMVEL7iEmIhoAdHV1hRbQhw4dwu+//w57e/tB0f2us8Uw0LV21m3v0dSOuitj90T2NxH1HhbEREQDiI6ODtzc3JCXl6fS5MPGxgZ79+5VSXEgIiLtsCAmIhqglE+HL1y4ACsrK6xcuRLPPvssdu/eDYVC0dfLIyIaMFgQExENcMoW0D/88ANcXFywbt06PP3009i2bRvq6ur6enlERP0eC2IiokHiySefxK5du/Djjz/C3d0d77//vtD97s6dOx3e39zcjPLycpSWlrKNNBENKSyIiYgGmcmTJwvd7958801s27YNjz/+ON555x3cunVL7fqqqiq8++67GDt2LCZOnIinnnoKw4cPx4IFC5CTk9P7H4CIqJexICYiGqTGjBmDkJAQXL9+HWFhYfjqq68wZcoUrFmzBtevXwcAlJSUwMbGBvv27cP69evx7bff4ty5c0hISICenh5eeuklfPbZZ338SYiIehZziImIhoi6ujrs2bMHERERqKiowPLly3HmzBkMHz4cx48fF40b2759O9avX4/jx4/jj3/8Y4dzMNd2YOHPi6gFnxATEQ0RRkZGePvtt1FSUoKYmBgUFBSgtLQU+/bt05i9+/bbb8PT01Ot7XJPUigUWL9+PZKSkrB+/XqkpKRodZ9MJsOPP/6o1bXFxcWIjo4GANy6dQuvv/467OzssHTp0m5tv5yeno4lS5Zg4cKF2LZtW5fHSUlJgVQq7fA6iUSCQ4cOdXkeoqGKBTER0RCjr6+P119/HVZWVnBycsKUKVPavf61115Dfn4+qqqqemV9RUVFKC0thaWlJUpLS7Vuu11YWKhVK2cAqKmpwdWrV3H//n24uLjgxRdfRG5uLv76178iODi4W9I5qqurER4ejn/84x/48ssvcerUKXzzzTddGqusrAwVFRUdXnf9+nWUlZV1aQ6ioewPfb0AIiLqGzdu3MBzzz3X4XXPPPMMmpubcePGjS51cdOkqakJ3t7eQvGZkJCAkSNH4vPPP8fVq1cxf/58DBs2DBkZGXBxccEnn3wCqVSKxsZGxMfHw9TUFJs2bcLly5dhbm6OBw8eoLCwEDk5OXBwcFC73sTEBFu2bMGZM2dgZmaGcePGITU1Febm5ggKCgIAWFlZITo6Gr///juMjIygUCjUxpFKpcjKysIvv/wCPT09REVFYfLkyWrXyeVy3Lt3Dzo6Ohg/fjx27NiBmpoaeHt74//+7//wzDPPYNu2bXjssccAtDxNvnXrFhoaGuDg4ID8/HzY29vj448/BgB8+eWXiIyMxGOPPYbIyEiYm5tj8+bNuHTpEszNzREVFdVtPxuioYZPiImIhqhHHnkEDQ0NHV6njGAzNDTs8lyNjY1QKBQqnfTKysrg5+eHo0ePwsnJCUlJSQCA9evXw8nJCRkZGXBycoKrqytOnjwJhUKBzMxMrF27FqGhoTh06BBGjx4NqVQKV1dXODs7Y8GCBXB2dha9PjExEaampsjOzoaVlRWAlqfRrq6uAID8/HysW7cOu3fvRn5+PgCIjiOXy6FQKHDs2DEsXboU8fHxotc999xz8Pb2xpw5c2BnZ4fo6GiYm5vD2dlZ2AaSmJiIBQsWQC6XQyaTISsrCxYWFtDX10dOTg7y8vJw48YNAIC5uTlOnTqFVatWYffu3UhLS8P48eMhkUjg4eGB2NjYLv98iIY6FsREREPUf/3Xf+HMmTMdXpefnw9jY2NMnjy5y3OFhYVh+vTp2Lhxo3DM2NgYhw8fhpeXF44ePdpu9nF6ejry8vLg4+ODffv24cGDB8jIyMArr7wCAAgICMCMGTPavV4ikQjF70svvQQAMDMzw08//QQAePbZZxEUFAQTExNhv67YOABgZ2cHAJg0aRKqq6tFr/v1118REBCAoqIiHDhwAOXl5YiKisLSpUtx6NAhlJaWwtzcHKNHjwYAODs7AwBMTU0xc+ZMYX21tbUAgAULFgAA5s6di1OnTiEjIwMLFy4EADg5OUEikXTpZ0NE3DJBRDRkeXt7IyoqCmlpafjTn/4kes29e/cQEREBDw+Ph3pCHBISovZiXkxMDGbNmoVVq1Zh7dq17d5va2sLS0tLBAYG4tq1azh79ixKS0tRXFwMW1tbxMXFQS6Xt3t9SUkJioqKYGNjg4KCAgCAi4sLtm3bhvLyckyYMAEjRoyAVCqFjY2NxnGqq6uhq9vyPEkZ1CR23fnz53Hy5EmEh4dj8uTJWL16NUJDQ4XtGp988gn8/PyENT/yyCPC33V0dITxlXOUlpYCAC5fvgx7e3uYmZmhqKgI06ZNw8WLF2Fvb9/pnwsRtWBBTETUBTKZDJWVlXj66afbPZeZmYmGhga4ublpPfaVK1fwwQcfAGgpkmbMmIF33nkHBgYGnVoHAGF+Y2Nj1NbWwt3dXTg3Y8YMrFy5En5+fpg7dy7S09NV7v3uu+8QEBCA33//HR999JHW69eWo6MjQkNDkZeXh/r6eqSlpWHDhg2i13p6esLf3x9SqRTFxcWIiYnB7NmzERQUhIMHD0KhUGD79u2Ijo6GVCoVvX7mzJnw9fVFamoq5HI5nnzySVhYWGDz5s1wc3PDuHHj8PPPP2Pp0qXCC4Ri41RXV2u1PhsbG+zduxd2dnawsrLCtWvXhO9xxYoVWLNmDXbs2KH19/X111/j+++/h0wmw9atW/Hoo48iICAABw8eRH19PSIiIrr80h7RUMccYiKiLvjuu++QkJCAmJiYds9VVlaisbER48eP13rs3NxcREZGYs+ePbhx4wa2bt0KHR0dxMfHd2odAIT5MzMzUV1djeDgYJXzCoUCK1euxL/+9S9YW1tj7ty5ePTRR1FcXIzjx4/jkUceQU5OjvDEtCOdzbWVy+XQ0dERCvbhw4e3e315eTlGjx6t8jS19X3379+Hnp4e9PT0NF5fUVGBsWPHio49fvx44elsR/Nqu766ujrU1tbC3NxcOJadnY0jR44gMjKy3fHaunPnDkxNTVWOVVVVdfllR+YQE7XgE2IiGjIiIiLg7u6Op556SuV4UlJSu2/4JyQkoKmpCf7+/jhx4gQKCgqQl5eHS5cuITs7Gzt37lRJSoiMjMSlS5eQk5ODyspK1NfX49VXX1VLBMjOzlZLK1CuzdDQEGPGjMGYMWPw5Zdf4oknnsDdu3cRGRmpkmTQeq65c+eqpTbk5OSo7M29efMm3n33XTQ0NMDOzg4ffvghIiMjkZeXhzlz5uDs2bP4+eef0djYCAsLC7z44otaF8NdMWzYMOHvHRXDADBhwgS1Y63va/sUXex6sWJY07XanOvoOiMjIxgZGQn/9/79+9v9R0x72hbDALo1+YNoqOJLdUQ0ZJSUlODu3btqxzt6w7+2ts6pmg4AACAASURBVFbYn1pXV4eamhps2LABCxYswKRJk9SSEpTnnJ2dIZPJcOfOHdFEALG0AjG6urqwsrLCP//5T7Ukg9ZziaU2KOdXOnDgAOzs7JCWloZJkyYJxfOjjz6KHTt24LXXXsPbb7+N27dvw83NTXjSSt1n2bJlOHr0KCZOnNjXSyGi/x8LYiIa9KKiojBnzhykpaXh9ddfx5w5c4RkAaWO3vBXUqYMKGmblKApEaBtWoEmNTU1KCwsFE086MxaVqxYgXPnzsHOzg5lZWUqTy4BiCYxEBENdiyIiWjQCw4OhlQqhbu7O2JjYyGVStW6s7X3hr+hoaHwZPn06dMq9ymTElJSUmBpaalxDdOmTUNRUREAqCQCtE0rECORSKBQKODg4AAvLy8kJiYiPDwcixYt6vRapFIptm/fjry8PHz//fdqbYptbGyEdSqTGIiIBjvuISaiIUNHR0f0hamOuLi4YOXKlcjMzERTUxMcHR0xZcoU5ObmYvXq1YiLi1NJSvD29kZubq6QZQsAPj4+aokAWVlZGufMysqCvb09dHV1YWJigq+++gojRoxQSzIYN26cMJdYakPrWC+g5Qm4t7c3LCwsUFdXB2tra9TU1AjnfX191ZIYiIgGO6ZMEBFpqa6uTmWLgTLRQNmet3VSQtu0A6WHSQRQaptk0HoubVIbmpqaUFlZiXHjxmmcQ1MSQ0eYWjCw8OdF1IJPiImItNR2v60y0UAsKUEsMxjonkSAtkkGrefSJrVBV1e33WIY0JzEQEQ0GHEPMRERERENaSyIiYio38vMzMSRI0e6dK9EIsGhQ4eQn58Pd3d3oQsdAJw7d07tmCbFxcWIjo7u9jlkMhl+/PFHjfO2Pv8w3wMRacaCmIiI+j1ra2tMnz69S/dev34dZWVlqKiogFQqRWpqqnAuLi4OUqlUY1xeazU1Nbh69Wq3z1FYWIiIiAiN87Y+/zDfAxFpxj3ERETUJ5qamtQ6640cORJJSUlqHfzOnz+P+vp6GBgYtNtVUGzM1hYvXoyUlBQEBASgqakJFy5cwLRp0wC0NGhp203Q2NgYW7ZswZkzZ2BmZoZx48ZBoVDgk08+UekYqO0c7XU91NRtsDs6HxJR+/iEmIiIelxjYyMUCgUaGxuFY2Kd9QCIdvBTdtzrqKugpjGVxowZg+bmZty+fVsoQJVhS2LdBBMTE2Fqaors7GxYWVkBAE6ePKnWMVDbOdrreqip22B3dz4kInUsiImIqMeFhYVh+vTp2Lhxo3Csvc567XXwa6+roDbd+ry8vHDgwAEkJydj2bJlwnGxboJinfvS09Pb7RjY3hytid3XW50PiUgVC2IiIupxISEhKCgoUNkr215nvfY6+LXXVVCbbn2enp5ITk5GQUEBbG1theNi3QTFOvfZ2tq22zGwvTna63rY0XfS2sN0PiQidSyIiYioTzg6OiIuLg6rVq0StgH0xpijRo2CoaEh5s2bp3Lcx8cHsbGxWL58OXbt2oXXXnsNvr6+2LlzJ5YsWYL09HQALcXu8ePH4evrCy8vL7U24O3N4eLigq+//hrz58/H+fPnAUDoeqjsNth2/a3Pt7dWIuo6dqojIqJu09nOZ9p01uushx1TrJugWOe+th0DO0NT10NN3QZ7qvMhO9URtWDKBBER9RltOuv19phiBaZY5762HQM7Q1PXQ6D3Ox8SEbdMEBEREdEQx4KYiIiIiIY0FsRERERENKSxICYiIiKiIY0FMRERERENaSyIiYiIiGhIY0FMREREREMaC2IiIiINoqKikJubK/zfdXV18PX1RVNTU7v3ZWZm4siRI6LnZDIZfvzxxw6vI6Lew4KYiIhIg/+vvfsPquq+8z/+vN6vQkBTJBgiSLbYpH9UA1NgNxRooDUYGk0NikhQho7axJTJZJfsuG7XdSB2HScpMu12tjjJaFlmxCDqVUEpwgXmriysVlhsdh2ysqNGEtMWhHtze+Fyud8/styAXBASCep9Pf469/Pj/Xmfe/7gfc98OOfxxx/nnXfe8Xyurq7GYDAwZ87kfz6jo6OJjY312nfp0iWKioruOE5Evjp6U52IiMyKDz/8kDfeeIOBgQHi4uLYuXMnTqeTvXv3YrFYcLlclJaWEhQUxM6dOzl//jxLly4lMjKSJ598kuHhYXJzczl79iwdHR288cYbXudbLBbq6+vp7u7GaDRSXFzMY489xo4dO/jP//xPQkNDee+99xgeHh43d/Xq1eTn5+NwOPD396eiooLNmzeTmZmJ3W4HoKysjIULF1JZWUldXR3nzp1j586dOBwOcnJyyMrKGjN23759tLe309jYyM2bN3E4HKxbt45du3bR3t5OaGgoxcXFNDQ0jMv7iSeemM1LJvLA0h1iERGZcS6XC6fTicvl8rQdPXqUuLg4TCYTERER2O126urqcDqd1NbWkpeXR2FhIUePHiUsLIx/+7d/Y/HixfT09GC1WrHZbMBn2xj6+voAvM632Ww4nU5Onz5NZmYmpaWlnDhxgpCQECwWC2lpaVy8eNHrXD8/P9LS0jhz5gx2u522tjaWLl1KTk4OVVVVJCcnU15eDoDNZuPKlSu0trbS39/PrVu36OrqGjc2Pz+f1NRUUlJSPONMJhNhYWGYzWbS09M5cOCA17xFZGaoIBYRkRm3e/duYmNj2b59u6dt06ZNXLhwgbi4OLq6uggICKC6uprm5mays7M5fPgwQ0ND1NXVkZqaisFg4Pnnnx8Xe2hoyHPsbT5AXFwcABEREfT29lJTU8MPf/hDALZu3cpf/uVfTjg3JyeHiooKqqurefHFF3n44Yc5efIkGRkZVFVV4XA4POunpaUREBDg+RwYGDjh2NFqampYuXIlAMnJyZjNZq95i8jM0JYJERGZcQUFBRQUFIxps1gs/PKXv2ThwoVkZ2dz/vx5YmJiWL58Odu2bePq1aucP3+e//3f/6Wzs5Nvf/vbdHZ2AuDv788f//hHAFpaWnjooYcAvM7v7e317Pl1u90ALF++nM7OTmJiYjh48CDR0dFe5wIkJibyk5/8BKvVyj/90z9RUlJCfHw8W7ZsIS8vb8w53b63eLKxo0VFRXH58mWioqJoa2sjISFhTLyRvEVkZqggFhGRWREUFERWVhbLli3DbrcTHR3Nk08+SW5uLhaLhc7OTk9BuXbtWo4fP053dzdRUVGsWLGCzZs3U1tby/DwMElJSQCsXbt23Hxvd1Y3bdrEq6++yvHjx3E6neTm5rJ06dJxcwEMBgPp6emYTCaio6P55JNPKCwspLm5GYfDgclkIj8/3+s5JiUljRublZVFU1MTFovFMy47O5utW7dy/PhxHA4HRUVF1NfXz8C3LiLeGNz62SkiInfJ+vXrAThy5MiUxg8PD3Pz5k0WL148pv3GjRuEhITg5+fnafvDH/7Af//3f1NRUcGvfvUr4LP9w6O3KEw23xur1cqCBQumPddms2EwGAgMDPQa405jBwcHMRqNGI3GMWN7enoIDg6eNOe7abrXS+RBpTvEIiIya+bMmTOuGAYIDw8f17Zo0SI6Ozvx9/f3tHkrhiea7423QnYqc+fPnz9pjDuNnTdvntexX2UxLCKfU0EsIiL3jcTERBITE2c7DRF5wOgpEyIiIiLi01QQi4iIiIhPU0EsIiIiIj5NBbGIiIiI+DQVxCIiIiLi01QQi4iIiIhP02PXRETknmI2mz0vsLBaraxZs2bCMd76Xn31Vbq7u8e0Pf/887zyyiszlrOI3N9UEIuIyD3l2rVr9Pb2snDhQq+vXR49xpvCwkKGhobYsWMH3/3ud1m1ahWBgYEzmbKI3OdUEIuIyKwYHh4mKysLu90OQFlZGQsXLhw3zul0snfvXiwWCy6Xi9LS0kn7lixZAkBgYCDBwcGEhYWRlZXFm2++yTe/+U1+8Ytf8Oijj2Kz2Th37hy9vb0EBASwZ88elixZMmE8EXlwaQ+xiIjMOJfLhdPpxOVyedq6urrIycmhqqqK5ORkysvLvc6tq6vD6XRSW1tLXl4ehYWFU+obLSUlhcrKSgAOHTpEamoqvb29+Pv7c+LECV5++WX2798/5Xgi8mDRHWIREZlxu3fv5tixY6SmplJUVAR8dgf35MmTlJaW8oc//MHrfmCA6upqLl++THZ2NkNDQ2O2P0zWN1pmZiY/+MEP2LBhA6GhoYSEhACQkJAAQGxsLD/96U+x2WxTiiciDxYVxCIiMuMKCgooKCgY01ZSUkJ8fDxbtmwhLy9vwrkxMTEsX76cbdu2cfXqVc6fP4/NZpuwz5vg4GAWL17M3r17ycnJ8bRfvnwZgAsXLhARETHleCLyYNGWCRERmRVJSUkcPHiQLVu2cOvWLUwmk9dxa9eu5cyZM2zcuJGMjAwiIyOn1He7TZs2cezYMV544QVPm8lkIi0tjb/+67/mH/7hH6YVT0QeHAa32+2e7SREROTBsH79egCOHDkypfE2mw2DwUBgYKDnUWsTuXHjBiEhIfj5+U2rb0RDQwOnTp1i3759ALz11luEh4fz3HPPERwczJw5n98jmkq8B8F0r5fIg0pbJkREZNbMnz/fczxZMQwQHh7+hfoA3nvvPcrKyigpKfG0+fn5MXfuXM9+4unEE5EHiwpiERF54G3YsIENGzaMaXv99ddnKRsRuddoD7GIiIiI+DQVxCIiIiLi01QQi4iIiIhPU0EsIiIiIj5NBbGIiIiI+DQVxCIiIiLi01QQi4jIrDhz5gynTp36ytf9n//5HzIzM/mrv/or/vZv/9bz+maz2cyJEyeora2dMK/i4mKampo8n+12Oxs3bmR4eHjSNVtbW1mzZg09PT2etgsXLoxrG62/v58PPvhgwpgj/ZPlKyJTo4JYRERmxYcffsi1a9e+0jWHh4d5/vnneeGFF7BYLKxdu5aXXnoJl8vFtWvX6OrqIjo6mtjYWK/zH3/8cd555x3P5+rqagwGw5i33Hnz8ccfY7FYOHbsmKft4MGDWCwWHA6H1zmXLl2iqKhowpgj/ZPlKyJToxdziIjIrKmurubYsWM8/PDD/PznP+cb3/gGZWVlDA8Pk5uby9mzZ+no6CAsLIzq6mo++ugjBgYGSExMpLW1lYSEBPbs2cPw8DBZWVnY7XYAysrKqKmpob6+nu7uboxGI8XFxXz00Ud861vfIicnB4CEhARKSkqwWq2enBobG3E4HMybN2/c/NWrV5Ofn4/D4cDf35+Kigq2bt3qdf36+nrq6uo4d+4cP/vZz1i9ejWVlZWe8RcvXiQqKsoz/vZzbm5upr29nYaGBn7961+Pib1w4UL27dtHe3s7oaGhLF26lHXr1rFr1y5PW3FxMQ0NDePO4YknnvgqL7HIfUF3iEVEZMa5XC6cTicul2tcX319PevXr6e0tBQAq9WKzWYDPtuS0NfXh81mo7+/n/r6epYtW8bcuXNpbGykubmZ69ev09XVRU5ODlVVVSQnJ1NeXo7NZsPpdHL69GkyMzMpLS2lpqaGZ599dsz6Tz/9NEFBQZ7P/f393Lp1y+t8Pz8/0tLSOHPmDHa7nba2Np599tkJ179y5Qqtra0ALFq0CLfbzSeffEJjYyPPPPMMbrd7wnPOz88nNTWViIiIcbEBT/+SJUu4desWJpOJsLAwzGYz6enpHDhwwOs5iMh4KohFRGTG7d69m9jYWLZv3z6mfaQ4DQ0N9bqXdmhoyHOckpICQFBQEE8//TQAwcHBWK1WAgMDOXnyJBkZGVRVVXm2IcTFxQEQERFBb28vjzzyCF1dXWPWOHPmDNevX/ea9+3zAXJycqioqKC6upoXX3wRo9E44fppaWkEBAR44mVkZHD06FEqKirGvUra2zkDE8a+XU1NDStXrgQgOTkZs9k84TmIyFgqiEVEZMYVFBTQ0dExbk+sn5/fuLH+/v58+umnALS0tHgdazAYAHC73bjdbkpKSoiPj6eyspLly5d7xo3s7R25E5uamsrp06fp7u4GoKuri3/8x38kNDTUa963zwdITEzk/fffp7S01LP14k7rj1i7di0VFRV0dHQQExNzx3OeLPbtoqKiPP8g2NbWRkJCwoTnICJjqSAWEZF7yooVK/jtb3/Ls88+y+9+97spzUlKSuLgwYNs2bLFs33Am6eeeoq/+7u/4wc/+AHf//73+c53vsOuXbuYN2/elPMzGAykp6dz/fp1oqOjp7X+I488gr+/P9/73vfueM6RkZE0NTURFBTkNfZI/8iTKLKzszlw4AAvvfQS+/fv50c/+tGUz0nE1xnc+skoIiJ3yfr16wE4cuTIl45lt9vHbDe4E5vNhsFgIDAwEKvVyoIFCyYd/+GHH7J48WKMRuOXTfULre/N7ec8ODiI0Wjkz3/+s9fYI/2jz6Gnp4fg4OAprXc3r5fI/UxPmRARkXvSdIphgPnz53uOp1KMLlmyZNo53c31vbn9nEfuXE8U29ud7akWwyLyOW2ZEBERERGfpoJYRERERHyaCmIRERER8WkqiEVERETEp6kgFhERERGfpoJYRERERHyaCmIRERER8WkqiEVE5J7W39/veRvb3WI2mzlx4gQAra2trFmzhp6eHk//hQsXxrVNNafRfbW1tZw6dWrKefX39/Paa68B8Pvf/541a9awZs0aMjMzefvttxkcHJxyLBGZOhXEIiJyT7t06RJFRUV3Nea1a9fo6uoC4OOPP8ZisXDs2DFP/8GDB7FYLDgcjmnnNLovOjqa2NjYKec1MDBAQ0MDAH/6058AePfdd9mxYweXLl3ixz/+8ZRjicjU6U11IiIyK5xOJ3v37sViseByuSgtLWXJkiW8+eabLFy4kJ/85CesWbOGq1evYrfbaWxsJDExcdyclpYW6urqOHfuHD/96U+pr6+nu7sbo9FIcXExS5cuJSsrC7vdDkBZWdm4XFavXk1lZSVbt25leHiYixcvEhUVRVlZGY899hi5ubmcPXuWjo4O3njjDfbt20d7eztms5mSkpIxsUf6GhsbuXnzJg6Hg3Xr1rFr1y7a29sJDQ2luLiYhoaGcbl+7WtfG5OXv78/ixYtYtGiRfzmN7/h61//OoODg17fUCciX5zuEIuIyIxzuVw4nU5cLpenra6uDqfTSW1tLXl5eRQWFgKQn5/P/v37ef3114mNjaWkpITU1FRSUlK8zrHZbFy5coXW1lZsNhtOp5PTp0+TmZlJaWkpXV1d5OTkUFVVRXJyMuXl5ePyW7RoEW63m08++YTGxkaeeeYZ3G43VqsVm80GgN1up6+vz5Njamoqjz/++LjYI30pKSn09/dz69YtTCYTYWFhmM1m0tPTOXDggNdcJzNnzhyeeuop2tra7tZlEZH/o4JYRERm3O7du4mNjWX79u2eturqapqbm8nOzubw4cMMDQ0BMH/+fF577TX+9V//lb//+78fE2eiOWlpaQQEBAAQFxcHQEREBL29vQQGBnLy5EkyMjKoqqqacBtERkYGR48epaKigg0bNozrH1lrtKnGrqmpYeXKlQAkJydjNpu95nonfX19REZG3nGciEyPtkyIiMiMKygooKCgYExbTEwMy5cvZ9u2bVy9epXz588DYLPZ+PWvf01WVhZvvfUWK1asmHSOzWZjzpzP7++MHLvdbgBKSkqIj49ny5Yt5OXlTZjj2rVrycjIYGBggJiYGOCzLQuffvopAC0tLTz00ENj5kw1dlRUFJcvXyYqKoq2tjYSEhK85joZs9mM0+nk0UcfveNYEZke3SEWEZFZsXbtWs6cOcPGjRvJyMjw3Pn8m7/5G7Zt28avfvUrjh8/Tk9PD01NTVgslgnnTCYpKYmDBw+yZcsWz/YFbx555BH8/f353ve+52lbsWIFv/3tb3n22Wf53e9+52mPjIykqakJt9s9LvZIn8Vi8YzPzs7mwIEDvPTSS+zfv58f/ehHU/qO6uvrSUhIICkpiaKiIo4cOTKleSIyPQb3VH6WioiITMH69esBplW43bhxg5CQEPz8/CYcMzg4iNFoxGg0TnnOaDabDYPBQGBgIFarlQULFkw5P/hs//DIlozbc/rzn/88Lvbt+Y7o6ekhODh4WmvPpC9yvUQeRNoyISIisyo8PPyOY25/qsJU5ow2f/58z/F0i2FgXDE8OidvsSd6CsS9VAyLyOe0ZUJEREREfJoKYhERERHxaSqIRURERMSnqSAWEREREZ+mglhEREREfJoKYhERERHxaSqIRURERMSn6TnEIiJy3+jv7+fmzZs8+eSTd+yvra1lYGCAF154YUqxX331Vbq7u8e0Pf/887zyyitfOm8RubepIBYRkfvGpUuXKCsro6Sk5I790dHRuFyuKccuLCxkaGiIHTt28N3vfpdVq1YRGBh4t1IXkXuYCmIREZkV5eXlVFdX89FHHzEwMEBiYiKtra0kJCSwZ88eysrKGB4eJjc3l7Nnz9LR0UFzczPt7e00NjbyzDPPkJWVhd1uB6CsrIx9+/Z5+m/evInD4WDdunXs2rWL9vZ2QkNDKS4upqGhgfr6erq7uzEajRQXF/PEE08AEBgYSHBwMGFhYWRlZfHmm2/yzW9+k1/84hc8+uij2Gw2zp07R29vLwEBAezZs4clS5awd+9eLBYLLpeL0tJSlixZMptfr4hMg/YQi4jIjHO5XDidzjF3bG02G/39/dTX17Ns2TLmzp1LY2Mjzc3NXL9+HavVis1mA8But9PX10d+fj6pqamkpKTQ1dVFTk4OVVVVJCcnU15ePqa/v7+fW7duYTKZCAsLw2w2k56ezoEDB7DZbDidTk6fPk1mZialpaVe805JSaGyshKAQ4cOkZqaSm9vL/7+/pw4cYKXX36Z/fv3U1dXh9PppLa2lry8PAoLC2f+SxWRu0YFsYiIzLjdu3cTGxvL9u3bx7SnpKQAEBQUxNNPPw1AcHAwVqt1zLihoaFxMQMDAzl58iQZGRlUVVXhcDi8rl1TU8PKlSsBSE5Oxmw2AxAXFwdAREQEvb29XudmZmZy4sQJrly5QmhoKCEhIQAkJCQAEBsbS1NTE9XV1TQ3N5Odnc3hw4e95isi9y5tmRARkRlXUFBAQUHBuHY/Pz/PscFgAMDtduN2u/H39+ePf/wjAC0tLTz00ENj5paUlBAfH8+WLVvIy8ubcO2oqCguX75MVFQUbW1tnmJ2zpw5nvUmEhwczOLFi9m7dy85OTme9suXLwNw4cIFIiIiiImJYfny5Wzbto2rV69y/vz5yb4OEbnHqCAWEZF70ooVK9i8eTO1tbUMDw+TlJREZGQkTU1NWCwWkpKSKCwspLm5GYfDgclkIisry9M/Ijs7m61bt3L8+HEcDgdFRUXU19dPOY9Nmzbxyiuv8M///M+eNpPJxMWLF+nu7qasrIy/+Iu/IDc3F4vFQmdn54T/9Cci9yaDe7KfxiIiItOwfv16AI4cOXLXYtrtdgICAjyfBwcHMRqNGI1GbDYbBoOBwMBArFYrCxYsGNM/Wk9PD8HBwdNev6GhgVOnTrFv3z4A3nrrLcLDw3nuuecIDg723GkGuHHjBiEhIWPufN/LZuJ6idyPdIdYRETuaaOLYYB58+Z5jufPn+85XrBgwbj+0b5IMfzee++Ne8ybn58fc+fO9ewnHi08PHzaa4jI7FNBLCIiMoENGzawYcOGMW2vv/76LGUjIjNFT5kQEREREZ+mglhEREREfJoKYhERERHxaSqIRURERMSnqSAWEREREZ+mglhEREREfJoKYhERua/09/fzwQcfTNhfW1vLqVOnvPYVFxfT1NTk+Wy329m4cSPDw8OTrjlZzNH5TDZORO5dKohFROS+cunSJYqKiibsj46OJjY21mvf448/zjvvvOP5XF1djcFgGPO2uenGHJ3PZONE5N6lF3OIiMiseOeddzh37hy9vb0EBASwZ88eIiMjqayspK6ujnPnzvHv//7v7Nq1i/b2dkJDQykuLmbfvn20t7dz9uxZWlpasFgsuFwuSktLWbJkCY2NjTgcDubNm0d9fT3d3d0YjUaKi4tZvXo1+fn5OBwO/P39qaioYPPmzWRmZmK32wEoKytj4cKFY/LYuXMnDoeDnJwcsrKyxowdyaexsZGbN2/icDhYt27duLwbGhrG5fPEE0/M5iUQkf+jO8QiIjLjXC4XTqcTl8vlaevt7cXf358TJ07w8ssvs3//fgBsNhtXrlyhtbUVk8lEWFgYZrOZ9PR0Dhw4QH5+PqmpqQwNDeF0OqmtrSUvL4/CwkLgsy0Mt27dwmaz4XQ6OX36NJmZmZSWluLn50daWhpnzpzBbrfT1tbG0qVLycnJoaqqiuTkZMrLy8flMRKzq6tr3NiRfFJSUjzjvOXtLR8RuTeoIBYRkRm3e/duYmNj2b59+5j2hIQEAGJjY8fs7U1LSyMgIICamhpWrlwJQHJyMmaz2TOmurqa5uZmsrOzOXz4MENDQ+PWjYuLAyAiIoLe3l4AcnJyqKiooLq6mhdffJGHH36YkydPkpGRQVVVFQ6HY1weIwIDAyccO9pEeXvLR0RmnwpiERGZcQUFBXR0dIzb+3v58mUALly4QEREhKd9ZE9vVFSUZ0xbW5ungAaIiYkhIyODQ4cO8fbbb7Nq1apx647EcbvdnrbExETef/99SktLycnJoaSkhPj4eCorK1m+fLnX+SMmGzvaRHl7y0dEZp/2EIuIyKwxmUxcvHiR7u5uysrKxvVnZ2ezdetWjh8/jsPhoKioCH9/f5qamli1ahXvvvsuFouFzs5OSkpKprSmwWAgPT0dk8lEdHQ0n3zyCYWFhTQ3N+NwODCZTOTn53udm5SUNG5sVlYWTU1NWCyWSfOur6//Yl+SiMw4g1s/U0VE5C5Zv349AEeOHLnj2Lfeeovw8HCee+45goODJ33SQ09PD8HBwZ7Pg4ODGI1GjEYjN27cICQkBD8/vy+ct81mw2AwEBgYSX24dQAABeJJREFUiNVqZcGCBdMaOzqfyfK+10zneok8yHSHWEREZoWfnx9z584lJCTkjmNvLyrnzZvnOQ4PD//SucyfP99zPFkxPNHY0fmMdi8XwyLyORXEIiIyK15//fXZTkFEBNA/1YmIiIiIj1NBLCIiIiI+TQWxiIiIiPg0FcQiIiIi4tNUEIuIiIiIT1NBLCIiIiI+TQWxiIjcN/r7+/nggw+m1F9bW8upU6emHPv3v/89a9asYc2aNWRmZvL2228zODj4hXMZWd9sNnPixIkJY7z22mtj2jo7O/mXf/mXKectIl+eCmIREblvXLp0iaKioin1R0dHExsbO+XYf/rTnwB499132bFjB5cuXeLHP/7xF85lZP1r167R1dXldczAwAANDQ1j2vr6+viv//qvKectIl+eXswhIiKzory8nOrqaj766CMGBgZITEyktbWVhIQE9uzZQ1lZGcPDw+Tm5nL27Fk6Ojpobm6mvb2dxsZGnnnmGbKysrDb7QCUlZWxb98+T//NmzdxOBysW7eOXbt20d7eTmhoKMXFxTQ0NFBfX093dzdGo5Hi4mIA/P39WbRoEYsWLeI3v/kNX//61xkcHMRgMLB3714sFgsul4vS0tIxa3nLpbGxEYfD4TnfDz/8kDfeeIOBgQHi4uLYuXOnp89qtfKzn/2M//iP/yA4OJjFixd/hVdCRHSHWEREZpzL5cLpdOJyuTxtNpuN/v5+6uvrWbZsGXPnzqWxsZHm5mauX7+O1WrFZrMBYLfb6evrIz8/n9TUVFJSUujq6iInJ4eqqiqSk5MpLy8f09/f38+tW7cwmUyEhYVhNptJT0/nwIED2Gw2nE4np0+fJjMzk9LS0nE5z5kzh6eeeoq2tjbq6upwOp3U1taSl5dHYWHhHXMZWX/E0aNHiYuLw2QyERER4SmeAQ4dOkRQUBANDQ089dRTM3glRMQbFcQiIjLjdu/eTWxsLNu3bx/TnpKSAkBQUBBPP/00AMHBwVit1jHjhoaGxsUMDAzk5MmTZGRkUFVVNeZu7Gg1NTWsXLkSgOTkZMxmMwBxcXEARERE0Nvb63VuX18fkZGRVFdX09zcTHZ2NocPHx6Xz1Ry2bRpExcuXCAuLo6uri4CAgI8fWazmbS0NAC+//3ve81FRGaOCmIREZlxBQUFdHR0jNtz6+fn5zk2GAwAuN1u3G43/v7+fPrppwC0tLSMi1lSUkJ8fDyVlZUsX758wrWjoqK4fPkyAG1tbSQkJACf3QEeWc8bs9mM0+nk0UcfJSYmhoyMDA4dOsTbb7/NqlWrpp2LxWLhl7/8Jc3Nzbz//vucP3/e0/ftb3/bk2NHR8eE5yIiM0N7iEVE5J60YsUKNm/eTG1tLcPDwyQlJREZGUlTUxMWi4WkpCQKCwtpbm7G4XBgMpnIysry9I/Izs5m69atHD9+HIfDQVFREfX19V7XrK+vJyEhgTlz5vC1r32NI0eOALB27Vpyc3OxWCx0dnZSUlLC4sWLJ80lJydnTOygoCCysrJYtmwZdrud6Oho+vr6ANi4cSMbN27k2LFj2Gw2vvGNb8zQtyoi3hjcE/00FhERmab169cDeArJu8Fut4/ZXjA4OIjRaMRoNGKz2TAYDAQGBmK1WlmwYMGY/tF6enoIDg7+UrncuHGDkJAQz53tO+Vyu+HhYW7evDnhP819/PHHPPbYY18qx+mYieslcj/SHWIREbmnjS6GAebNm+c5nj9/vud4pAAd3T/aly2GAcLDw6eVy+3mzJkz6RMkvspiWEQ+pz3EIiIiIuLTVBCLiIiIiE9TQSwiIiIiPk0FsYiIiIj4NP1TnYiI3FUtLS2epxfIva2lpYX4+PjZTkNk1qkgFhGRu+Y73/nObKcg0xAfH69rJoKeQywiIiIiPk57iEVERETEp6kgFhERERGfpoJYRERERHyaCmIRERER8WkqiEVERETEp6kgFhERERGfpoJYRERERHyaCmIRERER8Wn/Dzgy20mIiIiIiMyW/w/Z8I4Dd7JM/AAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Run this if you made an the viz \n",
+    "Image(output_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2002219",
+   "metadata": {},
+   "source": [
+    "## Query and Load your Database\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "80c56acd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,079 INFO sqlalchemy.engine.Engine SHOW VARIABLES LIKE 'sql_mode'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - SHOW VARIABLES LIKE 'sql_mode'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,080 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,083 INFO sqlalchemy.engine.Engine SHOW VARIABLES LIKE 'lower_case_table_names'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - SHOW VARIABLES LIKE 'lower_case_table_names'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,084 INFO sqlalchemy.engine.Engine [generated in 0.00123s] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - [generated in 0.00123s] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,087 INFO sqlalchemy.engine.Engine SELECT DATABASE()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - SELECT DATABASE()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,088 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load and parse aruguments\n",
+    "arguments = parse_variables(args).set_arguments()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0c68648e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,956 INFO sqlalchemy.engine.Engine SHOW VARIABLES LIKE 'sql_mode'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - SHOW VARIABLES LIKE 'sql_mode'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,957 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,959 INFO sqlalchemy.engine.Engine SHOW VARIABLES LIKE 'lower_case_table_names'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - SHOW VARIABLES LIKE 'lower_case_table_names'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,960 INFO sqlalchemy.engine.Engine [generated in 0.00099s] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - [generated in 0.00099s] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,963 INFO sqlalchemy.engine.Engine SELECT DATABASE()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - SELECT DATABASE()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:31:58,964 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:31:58] sqlalchemy.engine.Engine - [raw sql] ()\n",
+      "\n",
+      "UPGRADE AVAILABLE\n",
+      "\n",
+      "A more recent version of the Synapse Client (2.5.1) is available. Your version (2.4.0) can be upgraded by typing:\n",
+      "    pip install --upgrade synapseclient\n",
+      "\n",
+      "Python Synapse Client version 2.5.1 release notes\n",
+      "\n",
+      "https://python-docs.synapse.org/build/html/news.html\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Run your chosen query. Depending on if saving local or on synapse, check for output accordingly.\n",
+    "sql_query(arguments['data_dir'],\n",
+    "          arguments['rdb_jsonld_filename'],\n",
+    "          arguments['path_to_configs']).run_sql_queries(arguments)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bc21993",
+   "metadata": {},
+   "source": [
+    "### MySql Query Playground"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b608e703",
+   "metadata": {},
+   "source": [
+    "If you want to try out some new queries use this area below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "bb772278",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:38:35,864 INFO sqlalchemy.engine.Engine SHOW VARIABLES LIKE 'sql_mode'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:38:35] sqlalchemy.engine.Engine - SHOW VARIABLES LIKE 'sql_mode'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:38:35,865 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:38:35] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:38:35,868 INFO sqlalchemy.engine.Engine SHOW VARIABLES LIKE 'lower_case_table_names'\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:38:35] sqlalchemy.engine.Engine - SHOW VARIABLES LIKE 'lower_case_table_names'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:38:35,869 INFO sqlalchemy.engine.Engine [generated in 0.00128s] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:38:35] sqlalchemy.engine.Engine - [generated in 0.00128s] ()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:38:35,873 INFO sqlalchemy.engine.Engine SELECT DATABASE()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:38:35] sqlalchemy.engine.Engine - SELECT DATABASE()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-03-02 15:38:35,875 INFO sqlalchemy.engine.Engine [raw sql] ()\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: [2022-03-02 15:38:35] sqlalchemy.engine.Engine - [raw sql] ()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Connect to your MySql database. Do not change this area, just run it :)\n",
+    "path_to_json_ld = sql_helpers.get_data_path(args['data_dir'], args['rdb_jsonld_filename'])\n",
+    "\n",
+    "rdb_model = RDB(\n",
+    "    path_to_json_ld=path_to_json_ld,\n",
+    "    requires_component_relationship = \"requiresComponent\"\n",
+    ")\n",
+    "\n",
+    "json_data_model = load_json(path_to_json_ld)\n",
+    "\n",
+    "var = sql_helpers.parse_config(args['path_to_configs'], 'sql_config.yml')\n",
+    "connection = str(\"mysql://{0}:{1}@{2}/\".format(var['username'],\n",
+    "    var['password'], var['host'])) + rdb_model.schema_name\n",
+    "\n",
+    "sql_model = SQL(rdb_model, connection)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c38cdf78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = 'SELECT * FROM `Biobank`'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "cfc5cbd0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>specimenFormat</th>\n",
+       "      <th>specimenType</th>\n",
+       "      <th>tumorType</th>\n",
+       "      <th>biobankId</th>\n",
+       "      <th>biobankURL</th>\n",
+       "      <th>specimenTissueType</th>\n",
+       "      <th>specimenPreparationMethod</th>\n",
+       "      <th>diseaseType</th>\n",
+       "      <th>biobankName</th>\n",
+       "      <th>resourceId</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>RNA,whole tumor,DNA</td>\n",
+       "      <td>human tissue</td>\n",
+       "      <td>malignant peripheral nerve sheath tumor,schwan...</td>\n",
+       "      <td>674650f1-dcd7-4342-8c1a-d17b141b4954</td>\n",
+       "      <td>https://dhartspore.org/request-biospecimens.html</td>\n",
+       "      <td>tumor,blood,bone,cerebrospinal fluid,brain</td>\n",
+       "      <td>Cryopreserved, RNA later, Formalin-fixed, Ethanol</td>\n",
+       "      <td>Neurofibromatosis type 1</td>\n",
+       "      <td>CTF Biobank</td>\n",
+       "      <td>e4e60a43-9073-4dfa-a629-76b472451b7f</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>whole tumor,DNA,whole cell lysate,RNA</td>\n",
+       "      <td>cell lines,human tissue,xenograft tumors</td>\n",
+       "      <td>malignant peripheral nerve sheath tumor,plexif...</td>\n",
+       "      <td>d6f86049-4dc0-4543-bf99-0311eb44cb6e</td>\n",
+       "      <td>https://www.hopkinsmedicine.org/kimmel_cancer_...</td>\n",
+       "      <td>tumor,blood</td>\n",
+       "      <td>Flash frozen, FFPE</td>\n",
+       "      <td>Neurofibromatosis type 1</td>\n",
+       "      <td>The Johns Hopkins NF1 Biospecimen Repository</td>\n",
+       "      <td>17ad02e9-22c2-429e-8f1f-361adba1e0d7</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          specimenFormat  \\\n",
+       "0                    RNA,whole tumor,DNA   \n",
+       "1  whole tumor,DNA,whole cell lysate,RNA   \n",
+       "\n",
+       "                               specimenType  \\\n",
+       "0                              human tissue   \n",
+       "1  cell lines,human tissue,xenograft tumors   \n",
+       "\n",
+       "                                           tumorType  \\\n",
+       "0  malignant peripheral nerve sheath tumor,schwan...   \n",
+       "1  malignant peripheral nerve sheath tumor,plexif...   \n",
+       "\n",
+       "                              biobankId  \\\n",
+       "0  674650f1-dcd7-4342-8c1a-d17b141b4954   \n",
+       "1  d6f86049-4dc0-4543-bf99-0311eb44cb6e   \n",
+       "\n",
+       "                                          biobankURL  \\\n",
+       "0   https://dhartspore.org/request-biospecimens.html   \n",
+       "1  https://www.hopkinsmedicine.org/kimmel_cancer_...   \n",
+       "\n",
+       "                           specimenTissueType  \\\n",
+       "0  tumor,blood,bone,cerebrospinal fluid,brain   \n",
+       "1                                 tumor,blood   \n",
+       "\n",
+       "                           specimenPreparationMethod  \\\n",
+       "0  Cryopreserved, RNA later, Formalin-fixed, Ethanol   \n",
+       "1                                 Flash frozen, FFPE   \n",
+       "\n",
+       "                diseaseType                                   biobankName  \\\n",
+       "0  Neurofibromatosis type 1                                   CTF Biobank   \n",
+       "1  Neurofibromatosis type 1  The Johns Hopkins NF1 Biospecimen Repository   \n",
+       "\n",
+       "                             resourceId  \n",
+       "0  e4e60a43-9073-4dfa-a629-76b472451b7f  \n",
+       "1  17ad02e9-22c2-429e-8f1f-361adba1e0d7  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = sql_model.run_sql_query(sql_model, [query])\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0ba1d18",
+   "metadata": {},
+   "source": [
+    "### Other helpful things:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ca2a068",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/create_load_sql_db_nf.py
+++ b/scripts/create_load_sql_db_nf.py
@@ -107,17 +107,28 @@ class sql_create_load():
                         assert output is not None
                     except:
                         breakpoint()
-        
-    def create_schema_viz(self, output_path: str) -> None:
+      
+    #def create_schema_viz(self, output_path: str) -> None:
         ''' Generate a ERD diagram depicting the sql model.
         Args: self: containing the sql model.
              output_path (str): relative or aboslute path where figure should be stored.
         Returns: ERD Diagram saved to output path as a png.
         '''
-        output_path = str(Path(output_path).resolve())
-        output = self.sql_model.viz_sa_schema(output_path)
+    #    output_path = str(Path(output_path).resolve()) + 'nf_research_tools.rdb.model.png'
+    #    output = self.sql_model.viz_sa_schema(output_path)
 
-        assert output == output_path
+    #    assert output == output_path
+    
+    def create_schema_viz(self, output_path: str, rdb_jsonld_filename: str) -> None:
+        ''' Generate a ERD diagram depicting the sql model.
+        Args: self: containing the sql model.
+             output_path (str): relative or aboslute path where figure should be stored.
+        Returns: ERD Diagram saved to output path as a png.
+        '''
+        output_path = os.path.join(str(Path(output_path).resolve()), rdb_jsonld_filename.split('.')[0] + '.rdb.model.png')
+        graph = self.sql_model.viz_sa_schema(output_path)
+
+        return output_path
 
 class parse_variables():
     def __init__(self,
@@ -192,5 +203,5 @@ if __name__ == '__main__':
             sql_create_load(arguments['data_dir'], arguments['rdb_jsonld_filename'], arguments['path_to_configs']).update_db_tables(arguments['rdb_data_dir'])
 
     if arguments['create_schema_viz']:
-        sql_create_load(arguments['data_dir'], arguments['rdb_jsonld_filename'], arguments['path_to_configs']).viz_sa_schema(arguments['output_path'])
+        sql_create_load(arguments['data_dir'], arguments['rdb_jsonld_filename'], arguments['path_to_configs']).create_schema_viz(arguments['output_path'])
 


### PR DESCRIPTION
This PR makes available a Jupyter Notebook that allows users to create, update, visualize and query a local MySql database, and export their queries to Synapse. It is currently only tested to work with how things are structured with the NF Tools Registry Database. The notebook includes all the instructions to download and structure all the associated files necessary to create the database. The notebook also includes a small "playground" to test out queries.

To run:
- Type `juypter notebook` in the command line.
- When browser opens navigate to `schematic/scripts/Create, Load and Query Relational Database.ipynb`
- Read instructions included in notebook and follow all download and installation instructions.
- Only need to create and update the database when you are either changing the data model or manifest data, respectively.
- Be careful when using the query section and uploading to Synapse. It is recommended to play with a Staging Synapse site first to test queries before saving them to the NF Synapse Folder.
- As long as all the files are in the anticipated folder structure and names and SynapseIds are correct everything should run without any issue.

