### PR TITLE
modify the manifest submit endpoint to handle token authentication

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -167,6 +167,13 @@ paths:
             nullable: true
           description: Dataset SynID
           required: true
+        - in: query
+          name: input_token
+          schema:
+            type: string
+            nullable: true
+          description: Token
+          required: true
       operationId: api.routes.submit_manifest_route
       responses:
         "200":

--- a/api/routes.py
+++ b/api/routes.py
@@ -147,12 +147,19 @@ def submit_manifest_route(schema_url):
 
     data_type = connexion.request.args["data_type"]
 
+    input_token = connexion.request.args["input_token"]
+
+    if input_token == 'None':
+        input_token = None
+
+
     metadata_model = MetadataModel(
         inputMModelLocation=jsonld, inputMModelLocationType="local"
     )
-
-    success = metadata_model.submit_metadata_manifest(
-        manifest_path=temp_path, dataset_id=dataset_id, validate_component=data_type,
+    
+    # return id of the manifest 
+    synapse_id = metadata_model.submit_metadata_manifest(
+        manifest_path=temp_path, dataset_id=dataset_id, validate_component=data_type, input_token=input_token
     )
 
-    return success
+    return synapse_id

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -280,6 +280,7 @@ class MetadataModel(object):
         validate_component: str = None,
         use_schema_label: bool = True,
         hide_blanks: bool = False,
+        input_token: str = None
     ) -> bool:
         """Wrap methods that are responsible for validation of manifests for a given component, and association of the
         same manifest file with a specified dataset.
@@ -289,6 +290,7 @@ class MetadataModel(object):
             validate_component: Component from the schema.org schema based on which the manifest template has been generated.
         Returns:
             True: If both validation and association were successful.
+            Synapse ID: If no validation is needed.
         Exceptions:
             ValueError: When validate_component is provided, but it cannot be found in the schema.
             ValidationError: If validation against data model was not successful.
@@ -297,7 +299,8 @@ class MetadataModel(object):
         #TODO: avoid explicitly exposing Synapse store functionality
         # just instantiate a Store class and let it decide at runtime/config
         # the store type
-        syn_store = SynapseStorage()
+        syn_store = SynapseStorage(input_token=input_token)
+        result=None
 
         # check if user wants to perform validation or not
         if validate_component is not None:
@@ -328,7 +331,7 @@ class MetadataModel(object):
                 )
 
                 logger.info(f"No validation errors occured during validation.")
-                return True
+                result = True
             else:
                 raise ValidationError(
                     "Manifest could not be validated under provided data model. "
@@ -336,7 +339,7 @@ class MetadataModel(object):
                 )
 
         # no need to perform validation, just submit/associate the metadata manifest file
-        syn_store.associateMetadataWithFiles(
+        result = syn_store.associateMetadataWithFiles(
             metadataManifestPath=manifest_path,
             datasetId=dataset_id,
             useSchemaLabel=use_schema_label,
@@ -347,4 +350,4 @@ class MetadataModel(object):
             "Optional validation was not performed on manifest before association."
         )
 
-        return True
+        return result

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -120,7 +120,7 @@ class SynapseStorage(BaseStorage):
             try:
                 syn_api.default_headers["Authorization"] = f"Bearer {input_token}"
             except synapseclient.core.exceptions.SynapseHTTPError:
-                raise ValueError("Please make sure that your token is correct")
+                raise ValueError("No access to resources. Please make sure that your token is correct")
             return syn_api
 
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -48,6 +48,7 @@ class SynapseStorage(BaseStorage):
         self,
         token: str = None,  # optional parameter retrieved from browser cookie
         access_token: str = None,
+        input_token: str = None
     ) -> None:
         """Initializes a SynapseStorage object.
         Args:
@@ -65,6 +66,7 @@ class SynapseStorage(BaseStorage):
         """
 
         self.syn = self.login(token, access_token)
+        self.syn_api = self.api_login(input_token) 
 
         try:
             self.storageFileview = CONFIG["synapse"]["master_fileview"]
@@ -107,6 +109,20 @@ class SynapseStorage(BaseStorage):
             syn.login(silent=True)
 
         return syn
+
+    @staticmethod
+    def api_login(input_token=None):
+        if not input_token:
+            print("no token is provided")
+        if input_token:
+            syn_api = synapseclient.Synapse()
+
+            try:
+                syn_api.default_headers["Authorization"] = f"Bearer {input_token}"
+            except synapseclient.core.exceptions.SynapseHTTPError:
+                raise ValueError("Please make sure that your token is correct")
+            return syn_api
+
 
     def getPaginatedRestResults(self, currentUserId: str) -> Dict[str, str]:
         """Gets the paginated results of the REST call to Synapse to check what projects the current user has access to.


### PR DESCRIPTION
This PR is related to #590 

Goal: allow users to put in token to submit manifest. Based on Milen's feedbacks, the "manifest/submit" end point will now return the synapse id of the submitted manifest. 


Future items:
1) Figure out a way to handle errors better when the token is not correct. Currently, if the token doesn't work, the system will return "No access to resources. Please make sure that your token is correct". Based on Milen's comments, we might also want to encrypt the token in the future. 