### PR TITLE
modify convert command in cli

### DIFF
--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -44,7 +44,6 @@ def schema():  # use as `schematic model ...`
 @click.option(
     "--output_jsonld",
     "-o",
-    type=click.Path(exists=True),
     metavar="<OUTPUT_PATH>",
     help=query_dict(schema_commands, ("schema", "convert", "output_jsonld")),
 )
@@ -68,5 +67,9 @@ def convert(schema_csv, base_schema, output_jsonld):
         )
 
     # saving updated schema.org schema
-    base_se.export_schema(output_jsonld)
-    click.echo(f"The Data Model was created and saved to '{output_jsonld}' location.")
+    try:
+        base_se.export_schema(output_jsonld)
+        click.echo(f"The Data Model was created and saved to '{output_jsonld}' location.")
+    except:
+        click.echo(f"The Data Model could not be created by using '{output_jsonld}' location. Please check your file path again")
+


### PR DESCRIPTION
This PR is related to the bug reported [here](https://github.com/Sage-Bionetworks/schematic/issues/505)

When we are using the convert command in CLI (with flag -o), we are using  `type=click.Path(exists=True)` to check if the file path exists. Thus, if user enters a file path with the name of the new json-ld file that they want to create, their command will fail. I simply removed this line `type=click.Path(exists=True)` and added in `try` and `except` logic to handle file paths that do not exist. 