### PR TITLE
create an endpoint for downloading manifest

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -86,6 +86,45 @@ paths:
                 type: string
       tags:
         - Manifest Operations
+  /manifest/download:
+    get:
+      summary: Endpoint to download an existing manifest
+      description: Endpoint to download an existing manifest
+      parameters:
+        - in: query
+          name: input_token
+          schema:
+            type: string
+            nullable: false
+          description: Token
+          example: Token
+          required: true
+        - in: query
+          name: asset_view
+          schema:
+            type: string
+            nullable: false
+          description: ID of view listing all project data assets. For example, for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.(i.e. master_fileview in config.yml)
+          example: syn23643253
+          required: true
+        - in: query
+          name: dataset_id
+          schema:
+            type: string
+            nullable: true
+          description: >
+            Dataset ID. If you want to get an existing manifest, this dataset_id should be the parent ID of the manifest.
+          required: false
+      operationId: api.routes.download_manifest
+      responses:
+        "200":
+          description: A manifest get downloaded. 
+          content:
+            text/csv:
+              schema:
+                type: string
+      tags:
+        - Manifest Operations
   /model/validate:
     post:
       summary: Endpoint to facilitate manifest validation

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -105,20 +105,20 @@ paths:
             type: string
             nullable: false
           description: ID of view listing all project data assets. For example, for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.(i.e. master_fileview in config.yml)
-          example: syn23643253
+          example: syn28559058
           required: true
         - in: query
           name: dataset_id
           schema:
             type: string
             nullable: true
-          description: >
-            Dataset ID. If you want to get an existing manifest, this dataset_id should be the parent ID of the manifest.
-          required: false
+          description: this dataset_id should be the parent ID of the manifest.
+          example: syn28268700
+          required: true
       operationId: api.routes.download_manifest
       responses:
         "200":
-          description: A manifest get downloaded. 
+          description: A manifest gets downloaded and local file path of the manifest gets returned.
           content:
             text/csv:
               schema:

--- a/api/routes.py
+++ b/api/routes.py
@@ -228,3 +228,18 @@ def get_component_requirements(schema_url, source_component, as_graph):
 
     return req_components
 
+def download_manifest(input_token, dataset_id, asset_view):
+    # call config handler
+    config_handler(asset_view=asset_view)
+
+    # use Synapse Storage
+    store = SynapseStorage(input_token=input_token)
+
+    # download existing file
+    manifest_data = store.getDatasetManifest(datasetId=dataset_id, downloadFile=True)
+
+    #return local file path
+    manifest_local_file_path = manifest_data['path']
+    
+    return manifest_local_file_path
+


### PR DESCRIPTION
This PR is related to [this issue](https://github.com/Sage-Bionetworks/schematic/issues/632). The endpoint will return the location of the manifest that gets downloaded. 