### PR TITLE
add github workflow to automate release processes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,100 @@
+name: Publish to Test PyPI and PyPI
+on:
+  push:
+    tags:
+      - '*'
+    branches: [develop]
+
+jobs:
+  test_pypi_release:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    steps:
+      #----------------------------------------------
+      #       check-out repo and set-up python     
+      #----------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      
+      #----------------------------------------------
+      #          install & configure poetry         
+      #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.1.1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      #----------------------------------------------
+      #       load cached venv if cache exists      
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      #----------------------------------------------
+      # install dependencies if cache does not exist 
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+        
+      #----------------------------------------------
+      #    install your root project, if required 
+      #----------------------------------------------      
+      - name: Install library
+        run: poetry install --no-interaction
+
+      #----------------------------------------------
+      #    get current pushed tag
+      #----------------------------------------------      
+      - name: Show GitHub ref
+        run: echo "$GITHUB_REF"
+
+      - name: Get current pushed tag
+        run:  |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo ${{ env.RELEASE_VERSION }}
+          
+      #----------------------------------------------
+      #    override version tag 
+      #----------------------------------------------      
+      - name: Override version tag
+        run: poetry run python3 override_version.py
+        shell: sh
+
+      #----------------------------------------------
+      #    publish to testpypi
+      #----------------------------------------------      
+      - run: poetry config repositories.testpypi https://test.pypi.org/legacy/
+      - run: poetry config pypi-token.testpypi ${{ secrets.TWINE_TEST_TOKEN }}
+      - name: Publish package to test Pypi
+        run: poetry publish -vvvv --build -r testpypi
+
+      #----------------------------------------------
+      #    check tag
+      #----------------------------------------------      
+      - name: Check Tag
+        id: check-tag
+        run: |
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo ::set-output name=match::true
+          fi
+      #----------------------------------------------
+      #    publish to pypi
+      #----------------------------------------------  
+      - name: Publish package to Pypi
+        if: steps.check-tag.outputs.match == 'true'
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          PYPI_USERNAME: __token__
+        run: |
+          poetry publish --username $PYPI_USERNAME --password $PYPI_TOKEN

--- a/override_version.py
+++ b/override_version.py
@@ -1,0 +1,13 @@
+import toml
+import os 
+
+data = toml.load("pyproject.toml")
+#get release version 
+RELEASE_VERSION = os.getenv('RELEASE_VERSION')
+# Modify field
+data['tool']['poetry']['version']=RELEASE_VERSION
+print('the version number of this release is: ', RELEASE_VERSION)
+#override and save changes
+f = open("pyproject.toml",'w')
+toml.dump(data, f)
+f.close()


### PR DESCRIPTION
This PR is related to [this issue](https://github.com/Sage-Bionetworks/schematic/issues/628) here. 

Notes: 
1) The `override_version.py` can get environment variables from GitHub actions based on `git tag` and change the version in `.toml` file. 
2) When users tag a commit that fits into the format of `v*.*.*` (i.e. `v1.1.23`), we will publish that commit to PYPI and test PYPI.
3) When users tag a commit that DOES NOT fit into the format of `v*.*.*` (i.e. `v1.1.23.post1`), we will only publish that commit to test PYPI.
4) This workflow assumes that commit has passed all the required test
5) If users simply push to the `develop` branch without attaching a tag, this workflow won't get triggered. 
6) Still we would need to add environment variables to GitHub. ($PYPI_USERNAME, $PYPI_TOKEN, and TEST PYPI token)