### PR TITLE
Fix error in list validation from Issue #648

### DIFF
--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -196,13 +196,13 @@ class ValidateAttribute(object):
         errors = []
         manifest_col = manifest_col.astype(str)
         # This will capture any if an entry is not formatted properly.
-        for row_num, list_string in enumerate(manifest_col):
+        for i, list_string in enumerate(manifest_col):
             if "," not in list_string and bool(list_string):
                 list_error = "not_comma_delimited"
                 errors.append(
                     GenerateError.generate_list_error(
                         list_string,
-                        row_num=str(row_num + 2),
+                        row_num=str(i + 2),
                         attribute_name=manifest_col.name,
                         list_error=list_error,
                         invalid_entry=manifest_col[i]


### PR DESCRIPTION
This PR fixes the bug raised in Issue #648. The error was caused by how the rows were referenced when validating that the entry was a list. 

@allaway I was able to reproduce your error, and this PR should fix the issue you saw.

Note, that when providing a single value when there is a `list` validation applied, you will need to enter it with a comma after or else you will encounter a Schematic validation error saying the entry is not formatted with a comma. For example `icNF97.2a,`.