### PR TITLE
modify download/manifest endpoint to make it return a json

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -115,6 +115,13 @@ paths:
           description: this dataset_id should be the parent ID of the manifest.
           example: syn28268700
           required: true
+        - in: query
+          name: as_json
+          schema:
+            type: boolean
+            default: false
+          description: if True return the manifest in JSON format
+          required: false
       operationId: api.routes.download_manifest
       responses:
         "200":

--- a/api/routes.py
+++ b/api/routes.py
@@ -16,6 +16,8 @@ from schematic.models.metadata import MetadataModel
 from schematic.schemas.generator import SchemaGenerator
 
 from schematic.store.synapse import SynapseStorage
+import pandas as pd
+import json
 
 
 # def before_request(var1, var2):
@@ -231,7 +233,7 @@ def get_component_requirements(schema_url, source_component, as_graph):
 
     return req_components
 
-def download_manifest(input_token, dataset_id, asset_view):
+def download_manifest(input_token, dataset_id, asset_view, as_json):
     # call config handler
     config_handler(asset_view=asset_view)
 
@@ -243,5 +245,12 @@ def download_manifest(input_token, dataset_id, asset_view):
 
     #return local file path
     manifest_local_file_path = manifest_data['path']
+
+    # return a json (if as_json = True)
+    if as_json: 
+        manifest_csv = pd.read_csv(manifest_local_file_path)
+        manifest_json = json.loads(manifest_csv.to_json(orient="records"))
+        return manifest_json
+
     
     return manifest_local_file_path


### PR DESCRIPTION
This PR is related to the issue mentioned [here](https://github.com/Sage-Bionetworks/schematic/issues/651) and [here.](https://github.com/Sage-Bionetworks/schematic/issues/632) Based on my discussion with @lakikowolfe , for the release administrator app, returning a local CSV file path might not be sufficient. We need to add an additional parameter for **download/manifest endpoint** to return the manifest in JSON format. 