### PR TITLE
Commented out the part related to test PYPI in publish workflow (publish.yml)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       - '*'
-    branches: [develop]
+    branches: [main]
 
 jobs:
   test_pypi_release:
@@ -74,10 +74,10 @@ jobs:
       #----------------------------------------------
       #    publish to testpypi
       #----------------------------------------------      
-      - run: poetry config repositories.testpypi https://test.pypi.org/legacy/
-      - run: poetry config pypi-token.testpypi ${{ secrets.TWINE_TEST_TOKEN }}
-      - name: Publish package to test Pypi
-        run: poetry publish -vvvv --build -r testpypi
+      # - run: poetry config repositories.testpypi https://test.pypi.org/legacy/
+      # - run: poetry config pypi-token.testpypi ${{ secrets.TWINE_TEST_TOKEN }}
+      # - name: Publish package to test Pypi
+      #   run: poetry publish -vvvv --build -r testpypi
 
       #----------------------------------------------
       #    check tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to Test PyPI and PyPI
+name: Publish to PyPI
 on:
   push:
     tags:


### PR DESCRIPTION
This PR is related to the issue #628 (and the previous PR #646 ). Due to credentials issue, we are currently not publishing to test PYPI. Also, instead of listening to the push requests on `develop` branch, we are listening to the push requests on `main` branch. 