### PR TITLE
add get_asset_view_table endpoint

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -445,3 +445,32 @@ paths:
           description: Check schematic log
       tags:
         - Synapse Storage
+  /storage/assets/tables:
+    get:
+      summary: Retrieve asset view table as a dataframe.
+      description: Retrieve asset view table as a dataframe.
+      operationId: api.routes.get_asset_view_table
+      parameters:
+        - in: query
+          name: input_token
+          schema:
+            type: string
+            nullable: false
+          description: Token
+          example: Token
+          required: true
+        - in: query
+          name: asset_view
+          schema:
+            type: string
+            nullable: false
+          description: ID of view listing all project data assets. For example, for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.(i.e. master_fileview in config.yml)
+          example: syn23643253
+          required: true
+      responses:
+        "200":
+          description: A list of json
+        "500":
+          description: Check schematic log. If the fileview dataframe is too big, 
+      tags:
+        - Synapse Storage

--- a/api/routes.py
+++ b/api/routes.py
@@ -259,8 +259,9 @@ def get_asset_view_table(input_token, asset_view):
     # get file view table
     file_view_table_df = store.getStorageFileviewTable()
 
-    # convert pandas dataframe to json 
-    file_view_table_js = file_view_table_df.to_json(orient="records")
-    parsed = json.loads(file_view_table_js)
+    # convert pandas dataframe to csv
+    path = os.getcwd()
+    export_path = os.path.join(path, 'tests/data/file_view_table.csv')
+    file_view_table_df.to_csv(export_path, index=False)
 
-    return parsed
+    return export_path

--- a/api/routes.py
+++ b/api/routes.py
@@ -17,6 +17,8 @@ from schematic.schemas.generator import SchemaGenerator
 
 from schematic.store.synapse import SynapseStorage
 
+import json
+
 
 # def before_request(var1, var2):
 #     # Do stuff before your route executes
@@ -246,3 +248,19 @@ def download_manifest(input_token, dataset_id, asset_view):
     manifest_local_file_path = manifest_data['path']
     
     return manifest_local_file_path
+
+def get_asset_view_table(input_token, asset_view):
+    # call config handler
+    config_handler(asset_view=asset_view)
+
+    # use Synapse Storage
+    store = SynapseStorage(input_token=input_token)
+
+    # get file view table
+    file_view_table_df = store.getStorageFileviewTable()
+
+    # convert pandas dataframe to json 
+    file_view_table_js = file_view_table_df.to_json(orient="records")
+    parsed = json.loads(file_view_table_js)
+
+    return parsed

--- a/api/routes.py
+++ b/api/routes.py
@@ -17,8 +17,6 @@ from schematic.schemas.generator import SchemaGenerator
 
 from schematic.store.synapse import SynapseStorage
 
-import json
-
 
 # def before_request(var1, var2):
 #     # Do stuff before your route executes

--- a/tests/data/test_config.yml
+++ b/tests/data/test_config.yml
@@ -1,7 +1,7 @@
 definitions:
   creds_path: "../../credentials.json"
   token_pickle: "token.pickle"
-  # synapse_config: "../../.synapseConfig"
+  synapse_config: "../../.synapseConfig"
   ### Note: this key is required for people who use Synapse token authentication approach. 
   ### If you run into errors similar to KeyError: 'synpase_config', you might want to consider adding this key. 
 

--- a/tests/data/test_config.yml
+++ b/tests/data/test_config.yml
@@ -1,7 +1,7 @@
 definitions:
   creds_path: "../../credentials.json"
   token_pickle: "token.pickle"
-  synapse_config: "../../.synapseConfig"
+  # synapse_config: "../../.synapseConfig"
   ### Note: this key is required for people who use Synapse token authentication approach. 
   ### If you run into errors similar to KeyError: 'synpase_config', you might want to consider adding this key. 
 


### PR DESCRIPTION
This PR is related to issue #640.

Questions: 
1) `getStorageFileviewTable` function returns a pandas data frame. Should I have the API endpoint return a list of JSON? An example: 
`[
  {
    "benefactorId": "syn23643250",
    "createdBy": 3413689,
    "createdOn": 1608090921792,
    "currentVersion": 1,
    "dataFileHandleId": null,
    "dataFileMD5Hex": null,
    "dataFileSizeBytes": null,
    "etag": "01a3fc4c-661f-40f7-9062-2ac104250f67",
    "id": "syn23643254",
    "modifiedBy": 3413689,
    "modifiedOn": 1608090921792,
    "name": "DataTypeX",
    "parentId": "syn23643250",
    "projectId": "syn23643250",
    "type": "folder"
  },
  {
    "benefactorId": "syn23643250",
    "createdBy": 3413689,
    "createdOn": 1608090994622,
    "currentVersion": 1,
    "dataFileHandleId": 69739787,
    "dataFileMD5Hex": "219dbd37cad107ecca4c380ff1fb7971",
    "dataFileSizeBytes": 6,
    "etag": "a7b39be0-b83a-4abe-98af-d404c5922dcf",
    "id": "syn23643255",
    "modifiedBy": 3410110,
    "modifiedOn": 1612260891055,
    "name": "Sample_A.txt",
    "parentId": "syn23643254",
    "projectId": "syn23643250",
    "type": "file"
  }
]`
Each dictionary here is a row in the data frame. The keys here are columns. 

2) When I experimented the endpoint with HTAM master file view, it crashed. I think if the data frame is too big, we might want to think of a different way to handle. 