### PR TITLE
change syn id of matching manifest to allow test to past

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -123,7 +123,7 @@ class TestManifestValidation:
         assert GenerateError.generate_cross_error(
             val_rule = 'matchExactlyOne',
             attribute_name='checkMatchExactly',
-            matching_manifests = ['syn27600102', 'syn27648165']
+            matching_manifests = ['syn29862066', 'syn27648165']
             ) in errors
         
         assert GenerateError.generate_content_error(


### PR DESCRIPTION
This PR is related to the bug mentioned [here](https://github.com/Sage-Bionetworks/schematic/issues/690) Please let me know if the change makes sense. 