### PR TITLE
simple change to autofill components

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -448,7 +448,7 @@ class ManifestGenerator(object):
             else:
                 self.additional_metadata["Component"] = [self.root]
 
-            return
+        return
 
     def _get_additional_metadata(self, required_metadata_fields: dict) -> dict:
         """Add additional metadata as entries to columns.

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -436,14 +436,19 @@ class ManifestGenerator(object):
             updates self.additional_metadata if appropriate to
             contain {'Component': [self.root]}
         """
-
         if "Component" in required_metadata_fields.keys():
             # check if additional metadata has actually been instantiated in the
             # constructor (it's optional) if not, instantiate it
             if not self.additional_metadata:
                 self.additional_metadata = {}
-            self.additional_metadata["Component"] = [self.root]
-        return
+            if self.is_file_based:
+                self.additional_metadata["Component"] = [self.root] * max(
+                    1, len(self.additional_metadata["Filename"])
+                )
+            else:
+                self.additional_metadata["Component"] = [self.root]
+
+            return
 
     def _get_additional_metadata(self, required_metadata_fields: dict) -> dict:
         """Add additional metadata as entries to columns.


### PR DESCRIPTION
This is a bit of a riff on @BrunoGrandePhD's imcore branch that autofills the component values when ManifestGeneration `is_file_based`. 

Let me know what you think! I am not super aware of possible side-effects of this change. 

Seems to work fine on the CLI: https://docs.google.com/spreadsheets/d/1hokVh-RzZAhHNbwfzjbrF9ssqxhDNReWmujl9jt42ps/edit#gid=0

Testing on our staging DCA as well...