### PR TITLE
add restrict_rule and manifest_record_type parameter to submit endpoint

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -228,6 +228,13 @@ paths:
           description: Manifest storage type.
           example: 'table'
         - in: query
+          name: restrict_rules
+          schema:
+            type: boolean
+            default: false
+          description: If True, validation suite will only run with in-house validation rule. If False, the Great Expectations suite will be utilized and all rules will be available.
+          required: true
+        - in: query
           name: input_token
           schema:
             type: string

--- a/api/routes.py
+++ b/api/routes.py
@@ -160,12 +160,12 @@ def submit_manifest_route(schema_url, manifest_record_type=None):
     input_token = connexion.request.args["input_token"]
 
     if data_type == 'None':
-        manifest_id = metadata_model.submit_metadata_manifest(
-            manifest_path=temp_path, dataset_id=dataset_id, validate_component=None, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules
-        )
-    else: 
-        manifest_id = metadata_model.submit_metadata_manifest(
-        manifest_path=temp_path, dataset_id=dataset_id, validate_component=data_type, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules)
+        validate_component = None
+    else:
+        validate_component = data_type
+
+    manifest_id = metadata_model.submit_metadata_manifest(
+        manifest_path=temp_path, dataset_id=dataset_id, validate_component=validate_component, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules)
 
     return manifest_id
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -159,10 +159,6 @@ def submit_manifest_route(schema_url, manifest_record_type=None):
 
     input_token = connexion.request.args["input_token"]
 
-    manifest_id = metadata_model.submit_metadata_manifest(
-            manifest_path=temp_path, dataset_id=dataset_id, validate_component=data_type, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules
-        )
-
     if data_type == 'None':
         manifest_id = metadata_model.submit_metadata_manifest(
             manifest_path=temp_path, dataset_id=dataset_id, validate_component=None, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules

--- a/api/routes.py
+++ b/api/routes.py
@@ -155,17 +155,19 @@ def submit_manifest_route(schema_url):
 
     manifest_record_type = connexion.request.args["manifest_record_type"]
 
+    restrict_rules = connexion.request.args["restrict_rules"]
+
     metadata_model = initalize_metadata_model(schema_url)
 
     input_token = connexion.request.args["input_token"]
 
     if data_type == 'None':
         manifest_id = metadata_model.submit_metadata_manifest(
-            manifest_path=temp_path, dataset_id=dataset_id, validate_component=None, input_token=input_token
+            manifest_path=temp_path, dataset_id=dataset_id, validate_component=None, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules
         )
     else: 
         manifest_id = metadata_model.submit_metadata_manifest(
-        manifest_path=temp_path, dataset_id=dataset_id, validate_component=data_type, input_token=input_token)
+        manifest_path=temp_path, dataset_id=dataset_id, validate_component=data_type, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules)
 
     return manifest_id
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -142,7 +142,7 @@ def validate_manifest_route(schema_url, data_type):
     return errors
 
 
-def submit_manifest_route(schema_url):
+def submit_manifest_route(schema_url, manifest_record_type=None):
     # call config_handler()
     config_handler()
 
@@ -153,13 +153,15 @@ def submit_manifest_route(schema_url):
 
     data_type = connexion.request.args["data_type"]
 
-    manifest_record_type = connexion.request.args["manifest_record_type"]
-
     restrict_rules = connexion.request.args["restrict_rules"]
 
     metadata_model = initalize_metadata_model(schema_url)
 
     input_token = connexion.request.args["input_token"]
+
+    manifest_id = metadata_model.submit_metadata_manifest(
+            manifest_path=temp_path, dataset_id=dataset_id, validate_component=data_type, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules
+        )
 
     if data_type == 'None':
         manifest_id = metadata_model.submit_metadata_manifest(


### PR DESCRIPTION
This is related to a bug reported by @lakikowolfe After updating the ` submit_metadata_manifest` function, we would also need to update the API /model/submit route. But currently, this is also blocked by the bug here: #703 