### PR TITLE
Download manifest with custom name

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -63,11 +63,14 @@ paths:
           required: false
         - in: query
           name: dataset_id
+          style: form
           schema:
-            type: string
+            type: array
+            items: 
+              type: string
             nullable: true
           description: >
-            Dataset ID. If you want to get an existing manifest, this dataset_id should be the parent ID of the manifest.
+            Dataset ID. If you want to get an existing manifest, this dataset_id should be the parent ID of the manifest. Can enter multiple dataset_ids, corresponding to order of multiple data_types entered above. Do not enter multiple if calling 'all manifests' for data_type.
           required: false
         - in: query
           name: asset_view

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -100,7 +100,7 @@ paths:
             type: string
             nullable: false
           description: Token
-          example: Token
+          example: Paste Token Here.
           required: true
         - in: query
           name: asset_view
@@ -118,6 +118,13 @@ paths:
           description: this dataset_id should be the parent ID of the manifest.
           example: syn28268700
           required: true
+        - in: query
+          name: new_manifest_name
+          schema:
+            type: string
+            nullable: true
+          description: Fill in if you want to change the filename of the downloaded manifest.
+          required: false
       operationId: api.routes.download_manifest
       responses:
         "200":

--- a/api/routes.py
+++ b/api/routes.py
@@ -78,7 +78,11 @@ def get_manifest_route(schema_url, title, oauth, use_annotations, dataset_ids=No
     all_args = connexion.request.args
     args_dict = dict(all_args.lists())
     data_type = args_dict['data_type']
-    dataset_ids = args_dict['dataset_id']
+    
+    try:
+        dataset_ids = args_dict['dataset_id']
+    except:
+        pass
     
     if dataset_ids:
         # Check that the number of submitted data_types matches

--- a/api/routes.py
+++ b/api/routes.py
@@ -140,7 +140,7 @@ def get_manifest_route(schema_url, title, oauth, use_annotations, dataset_ids=No
                 t = f'{title}.{dt}.manifest'
             else:
                 t = title
-            breakpoint()
+
             if dataset_ids:
                 result = create_single_manifest(data_type = dt, dataset_id = dataset_ids[i])
             else:

--- a/api/routes.py
+++ b/api/routes.py
@@ -49,6 +49,7 @@ def csv_path_handler():
     manifest_file.save(temp_path)
 
     return temp_path
+
 def initalize_metadata_model(schema_url):
     jsonld = get_temp_jsonld(schema_url)
     metadata_model = MetadataModel(
@@ -65,9 +66,8 @@ def get_temp_jsonld(schema_url):
     # get path to temporary JSON-LD file
     return tmp_file.name
 
-
 # @before_request
-def get_manifest_route(schema_url, title, oauth, use_annotations, dataset_id=None, asset_view = None):
+def get_manifest_route(schema_url, title, oauth, use_annotations, dataset_ids=None, asset_view = None):
     # call config_handler()
     config_handler(asset_view = asset_view)
 
@@ -78,9 +78,32 @@ def get_manifest_route(schema_url, title, oauth, use_annotations, dataset_id=Non
     all_args = connexion.request.args
     args_dict = dict(all_args.lists())
     data_type = args_dict['data_type']
+    dataset_ids = args_dict['dataset_id']
+    
+    if dataset_ids:
+        # Check that the number of submitted data_types matches
+        # the number of dataset_ids (if applicable)
+        len_data_types = len(data_type)
+        len_dataset_ids = len(dataset_ids)
+        
+        try:
+            len_data_types == len_dataset_ids
+        except:
+            raise ValueError(
+                    f"There is a mismatch in the number of data_types and dataset_id's that "
+                    f"submitted. Please check your submission and try again."
+                )
+        
+        try:
+            data_type[0] != 'all manifests'
+        except:
+            raise ValueError(
+                    f"When submitting 'all manifests' as the data_type cannot also submit dataset_id. "
+                    f"Please check your submission and try again."
+                )
 
 
-    def create_single_manifest(data_type):
+    def create_single_manifest(data_type, dataset_id=None):
         # create object of type ManifestGenerator
         manifest_generator = ManifestGenerator(
             path_to_json_ld=jsonld,
@@ -107,12 +130,16 @@ def get_manifest_route(schema_url, title, oauth, use_annotations, dataset_id=Non
             result = create_single_manifest(data_type = component)
             all_results.append(result)
     else:
-        for dt in data_type:
+        for i, dt in enumerate(data_type):
             if len(data_type) > 1:
                 t = f'{title}.{dt}.manifest'
             else:
                 t = title
-            result = create_single_manifest(data_type = dt)
+            breakpoint()
+            if dataset_ids:
+                result = create_single_manifest(data_type = dt, dataset_id = dataset_ids[i])
+            else:
+                result = create_single_manifest(data_type = dt)
             all_results.append(result)
 
     return all_results

--- a/api/routes.py
+++ b/api/routes.py
@@ -263,7 +263,7 @@ def get_component_requirements(schema_url, source_component, as_graph):
 
     return req_components
 
-def download_manifest(input_token, dataset_id, asset_view):
+def download_manifest(input_token, dataset_id, asset_view, new_manifest_name=''):
     # call config handler
     config_handler(asset_view=asset_view)
 
@@ -271,7 +271,7 @@ def download_manifest(input_token, dataset_id, asset_view):
     store = SynapseStorage(input_token=input_token)
 
     # download existing file
-    manifest_data = store.getDatasetManifest(datasetId=dataset_id, downloadFile=True)
+    manifest_data = store.getDatasetManifest(datasetId=dataset_id, downloadFile=True, newManifestName=new_manifest_name)
 
     #return local file path
     manifest_local_file_path = manifest_data['path']

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1432,7 +1432,8 @@ class ManifestGenerator(object):
         Returns:
             Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
         """
-
+        breakpoint()
+        
         # Handle case when no dataset ID is provided
         if not dataset_id:
             return self.get_empty_manifest(json_schema_filepath=json_schema)

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1238,7 +1238,7 @@ class ManifestGenerator(object):
         Returns:
             manifest_url (str): url of the google sheet manifest.
         """
-
+        breakpoint()
         spreadsheet_id = self._create_empty_manifest_spreadsheet(self.title)
         json_schema = self._get_json_schema(json_schema_filepath)
 
@@ -1432,7 +1432,6 @@ class ManifestGenerator(object):
         Returns:
             Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
         """
-        breakpoint()
         
         # Handle case when no dataset ID is provided
         if not dataset_id:

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1238,7 +1238,6 @@ class ManifestGenerator(object):
         Returns:
             manifest_url (str): url of the google sheet manifest.
         """
-        breakpoint()
         spreadsheet_id = self._create_empty_manifest_spreadsheet(self.title)
         json_schema = self._get_json_schema(json_schema_filepath)
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -354,6 +354,8 @@ class SynapseStorage(BaseStorage):
         # get existing manifest Synapse ID
         manifest_id = self.getDatasetManifest(datasetId)
 
+        breakpoint()
+
         # if there is no manifest return None
         if not manifest_id:
             return None

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -354,8 +354,6 @@ class SynapseStorage(BaseStorage):
         # get existing manifest Synapse ID
         manifest_id = self.getDatasetManifest(datasetId)
 
-        breakpoint()
-
         # if there is no manifest return None
         if not manifest_id:
             return None


### PR DESCRIPTION
Allows users to provide an alternative name to download the manifest as.

Includes an addition to the existing API manifest/download endpoint.