### PR TITLE
df_parser: Replace calls for pd.isnull to look for empty string

### DIFF
--- a/schematic/schemas/df_parser.py
+++ b/schematic/schemas/df_parser.py
@@ -89,6 +89,9 @@ def get_class(
     # determine parent class of element and add subclass relationship to schema - required by biothings
     # if no subclass is provided, set a default to schema.org Thing
     if subclass_of:
+        if type(subclass_of[0]) == float:
+            if np.isnan(subclass_of[0]):
+                subclass_of[0] = ""
         if len(subclass_of) == 1 and subclass_of[0] == "":
             parent = {"rdfs:subClassOf": [{"@id": "schema:Thing"}]}
         else:
@@ -313,6 +316,9 @@ def create_nx_schema_objects(
     # property to class map
     prop_2_class = {}
     for record in properties:
+        if type(record["Properties"]) == float:
+            if np.isnan(record["Properties"]):
+                record["Properties"] = ""
         if not record["Properties"] == "":
             props = record["Properties"].strip().split(",")
             for p in props:
@@ -322,6 +328,9 @@ def create_nx_schema_objects(
     for attribute in attributes:
 
         required = None
+        if type(attribute["Required"]) == float:
+            if np.isnan(attribute["Required"]):
+                attribute["Required"] = ""
         if not attribute["Required"] == "":
             required = attribute["Required"]
 
@@ -329,6 +338,9 @@ def create_nx_schema_objects(
             display_name = attribute["Attribute"]
 
             subclass_of = None
+            if type(attribute["Parent"]) == float:
+                if np.isnan(attribute["Parent"]):
+                    attribute["Parent"] = ""
             if not attribute["Parent"] == "":
                 subclass_of = [
                     parent for parent in attribute["Parent"].strip().split(",")
@@ -375,6 +387,9 @@ def create_nx_schema_objects(
     logger.debug("Adding and editing properties")
 
     for prop in properties:
+        if type(prop["Properties"]) == float:
+            if np.isnan(prop["Properties"]):
+                prop["Properties"] = ""
         if not prop["Properties"] == "":  # a class may have or not have properties
             for p in (
                 prop["Properties"].strip().split(",")
@@ -435,6 +450,9 @@ def create_nx_schema_objects(
 
         # get values in range for this attribute, if any are specified
         range_values = attribute["Valid Values"]
+        if type(range_values) == float:
+            if np.isnan(range_values):
+                range_values = ""
         if not range_values == "":
             # prepare the range values list and split based on appropriate delimiter
             # if the string "range_values" starts with double quotes, then extract all "valid values" within double quotes
@@ -514,6 +532,9 @@ def create_nx_schema_objects(
         # get validation rules for this attribute, if any are specified
         validation_rules = attribute["Validation Rules"]
 
+        if type(validation_rules) == float:
+            if np.isnan(validation_rules):
+                validation_rules = ""
         if not validation_rules == "":
             
             # TODO: make validation rules delimiter configurable parameter
@@ -570,6 +591,9 @@ def create_nx_schema_objects(
 
         # get dependencies for this attribute, if any are specified
         requires_dependencies = attribute["DependsOn"]
+        if type(requires_dependencies) == float:
+            if np.isnan(requires_dependencies):
+                requires_dependencies = ""
         if not requires_dependencies == "":
 
             for dep in requires_dependencies.strip().split(","):
@@ -670,6 +694,9 @@ def create_nx_schema_objects(
             # TODO check for cycles in attribute dependencies schema subgraph
 
         # check if the attribute requires any components
+        if type(attribute["DependsOn Component"]) == float:
+            if np.isnan(attribute["DependsOn Component"]):
+                attribute["DependsOn Component"] = ""
         if not attribute["DependsOn Component"] == "":
             component_dependencies = attribute["DependsOn Component"]
         else:

--- a/schematic/schemas/df_parser.py
+++ b/schematic/schemas/df_parser.py
@@ -80,7 +80,7 @@ def get_class(
         "@id": "bts:" + class_name,
         "@type": "rdfs:Class",
         "rdfs:comment": description
-        if description and not pd.isnull(description)
+        if description and not description == ""
         else "TBD",
         "rdfs:label": class_name,
         "schema:isPartOf": {"@id": "http://schema.biothings.io"},
@@ -89,7 +89,7 @@ def get_class(
     # determine parent class of element and add subclass relationship to schema - required by biothings
     # if no subclass is provided, set a default to schema.org Thing
     if subclass_of:
-        if len(subclass_of) == 1 and pd.isnull(subclass_of[0]):
+        if len(subclass_of) == 1 and subclass_of[0] == "":
             parent = {"rdfs:subClassOf": [{"@id": "schema:Thing"}]}
         else:
             parent = {
@@ -179,7 +179,7 @@ def get_property(
         "@id": "bts:" + property_name,
         "@type": "rdf:Property",
         "rdfs:comment": description
-        if description and not pd.isnull(description)
+        if description and not description == ""
         else "TBD",
         "rdfs:label": property_name,
         "sms:displayName": property_display_name,
@@ -313,7 +313,7 @@ def create_nx_schema_objects(
     # property to class map
     prop_2_class = {}
     for record in properties:
-        if not pd.isnull(record["Properties"]):
+        if not record["Properties"] == "":
             props = record["Properties"].strip().split(",")
             for p in props:
                 prop_2_class[p.strip()] = record["Attribute"]
@@ -322,14 +322,14 @@ def create_nx_schema_objects(
     for attribute in attributes:
 
         required = None
-        if not pd.isnull(attribute["Required"]):
+        if not attribute["Required"] == "":
             required = attribute["Required"]
 
         if not attribute["Attribute"] in all_properties:
             display_name = attribute["Attribute"]
 
             subclass_of = None
-            if not pd.isnull(attribute["Parent"]):
+            if not attribute["Parent"] == "":
                 subclass_of = [
                     parent for parent in attribute["Parent"].strip().split(",")
                 ]
@@ -375,7 +375,7 @@ def create_nx_schema_objects(
     logger.debug("Adding and editing properties")
 
     for prop in properties:
-        if not pd.isnull(prop["Properties"]):  # a class may have or not have properties
+        if not prop["Properties"] == "":  # a class may have or not have properties
             for p in (
                 prop["Properties"].strip().split(",")
             ):  # a class may have multiple properties
@@ -435,7 +435,7 @@ def create_nx_schema_objects(
 
         # get values in range for this attribute, if any are specified
         range_values = attribute["Valid Values"]
-        if not pd.isnull(range_values):
+        if not range_values == "":
             # prepare the range values list and split based on appropriate delimiter
             # if the string "range_values" starts with double quotes, then extract all "valid values" within double quotes
             range_values_list = []
@@ -514,7 +514,7 @@ def create_nx_schema_objects(
         # get validation rules for this attribute, if any are specified
         validation_rules = attribute["Validation Rules"]
 
-        if not pd.isnull(validation_rules):
+        if not validation_rules == "":
             
             # TODO: make validation rules delimiter configurable parameter
            
@@ -570,7 +570,7 @@ def create_nx_schema_objects(
 
         # get dependencies for this attribute, if any are specified
         requires_dependencies = attribute["DependsOn"]
-        if not pd.isnull(requires_dependencies):
+        if not requires_dependencies == "":
 
             for dep in requires_dependencies.strip().split(","):
                 # check if dependency is a property or not
@@ -670,7 +670,7 @@ def create_nx_schema_objects(
             # TODO check for cycles in attribute dependencies schema subgraph
 
         # check if the attribute requires any components
-        if not pd.isnull(attribute["DependsOn Component"]):
+        if not attribute["DependsOn Component"] == "":
             component_dependencies = attribute["DependsOn Component"]
         else:
             continue


### PR DESCRIPTION
This PR corrects the bug reported by @allaway in issue  #734.

The reason why this bug was being hit was the df_parser was relying on `pd.isnull()` to determine if a string was empty. Instead `pd.isnull('')` was returning `False`. This did not present as an error in our test cases because our examples were never passing an empty string into these fields. But for another issue I was trying to debug, and for Robert they ran into this test case. Normally this error would be bypassed silently for other fields that are not passed by the user but in the case of `Properties` the property name string was attempted to be accessed later. Since there was no value, an error was being thrown.

In the fix, I updated _all_ calls to `pd.isnull(string)` to `string == ""` to more explicitly catch empty strings.