### PR TITLE
Flag loading data model in df_utils.load_df

### DIFF
--- a/schematic/schemas/df_parser.py
+++ b/schematic/schemas/df_parser.py
@@ -746,7 +746,7 @@ def _convert_csv_to_data_model(
                  (base_se.schema and base_se.schema_nx).
     """
     # create data model from provided RFC
-    rfc_df = load_df(schema_csv)
+    rfc_df = load_df(schema_csv, data_model=True)
 
     # instantiate schema explorer
     base_se = SchemaExplorer()

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -7,11 +7,12 @@ from copy import deepcopy
 logger = logging.getLogger(__name__)
 
 
-def load_df(file_path, preserve_raw_input=True, **kwargs):
+def load_df(file_path, preserve_raw_input=True, data_model=False, **kwargs):
     """
     Universal function to load CSVs and return DataFrames
     Args:
         file_path: path of csv to open
+        data_model: bool, indicates if importing a data model
         **kwargs: keyword arguments for pd.read_csv()
 
     Returns: a processed dataframe for manifests or unprocessed df for data models
@@ -22,7 +23,7 @@ def load_df(file_path, preserve_raw_input=True, **kwargs):
         org_df = pd.read_csv(file_path, encoding='utf8', **kwargs)
 
         #only trim if not data model csv
-        if 'model' not in file_path:
+        if not data_model:
             org_df=trim_commas_df(org_df)
 
         return org_df


### PR DESCRIPTION
Adding a flag to `df_utils.load_df` that a data model is being loaded, so that it is processed correctly. Remove portion that looks for `model` in the file path as an indicator that it is a model.

This will fix a bug reported by @allaway in #734. The bug was happening when a model was being used that did not contain `model` in the name. This caused the model to be imported in a way that caused breaks in `df_parser`.