### PR TITLE
change shorthand of output_xlsx

### DIFF
--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -77,7 +77,7 @@ def manifest(ctx, config):  # use as `schematic manifest ...`
     help=query_dict(manifest_commands, ("manifest", "get", "output_csv")),
 )
 @click.option(
-    "-o",
+    "-oxlsx",
     "--output_xlsx",
     help=query_dict(manifest_commands, ("manifest", "get", "output_xlsx")),
 )


### PR DESCRIPTION
This is related to the issue mentioned by @mialy-defelice [here](https://github.com/Sage-Bionetworks/schematic/issues/787). 

This issue happened because a short-hand of flag `--oauth` is supposed to be `oa` instead of `-oauth`. Since `-oauth` was used, the code took `auth` as a file name for an excel document. File name `auth` does not have an extension `.xlsx` so the code breaks. 
> Note: In summary, the code read command `schematic manifest --config config.yml get -s -oauth` as `schematic manifest --config config.yml get -s -o auth`

I also noticed that the short-hand of `--output_csv` and `--output_xlsx` were both `-o`. I have updated them to be something different. In the future, I will also remind myself of testing the short-hand commands when I test CLI. 
