### PR TITLE
add api to get attribute type

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -570,12 +570,12 @@ paths:
           required: true
       responses:
         "200":
-          description: A list of tuples(json). 
+          description: A string
           content:
             application/json:
               schema:
                 type: array
-                example: ['list']
+                example: 'list'
         "500":
           description: Check schematic log. 
       tags:

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -546,3 +546,37 @@ paths:
           description: Check schematic log. 
       tags:
         - Synapse Storage
+  /schema/attribute/type:
+    get:
+      summary: Retrieve validation rules and extract the actual attribute type 
+      description: Retrieve validation rules and extract the actual attribute type 
+      operationId: api.routes.get_class_validation_rules
+      parameters:
+        - in: query
+          name: schema_url
+          schema:
+            type: string
+            nullable: false
+          description: Schema URL
+          example: https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld
+          required: true
+        - in: query
+          name: class_label
+          schema:
+            type: string
+            nullable: false
+          description: class label
+          example: FamilyHistory
+          required: true
+      responses:
+        "200":
+          description: A list of tuples(json). 
+          content:
+            application/json:
+              schema:
+                type: array
+                example: ['list']
+        "500":
+          description: Check schematic log. 
+      tags:
+        - Schema Explorer

--- a/api/routes.py
+++ b/api/routes.py
@@ -329,11 +329,7 @@ def get_class_validation_rules(schema_url, class_label):
     schema_file = get_temp_jsonld(schema_url)
     se.load_schema(schema_file)
 
-    # get all available classes (useful for debugging)
-    #all_class = se.get_nx_schema()
-    #print(all_class.nodes)
+    # get attribute 
+    attribute = se.get_attribute_type(class_label)
 
-    # get rules associated with class
-    rules = se.get_class_validation_rules(class_label)
-
-    return rules
+    return attribute

--- a/api/routes.py
+++ b/api/routes.py
@@ -19,6 +19,8 @@ from schematic.store.synapse import SynapseStorage
 import pandas as pd
 import json
 
+from schematic.schemas.explorer import SchemaExplorer
+
 
 # def before_request(var1, var2):
 #     # Do stuff before your route executes
@@ -318,4 +320,20 @@ def get_project_manifests(input_token, project_id, asset_view):
     lst_manifest = store.getProjectManifests(projectId=project_id)
 
     return lst_manifest
-    
+
+def get_class_validation_rules(schema_url, class_label):
+    # initialize schema exploer 
+    se = SchemaExplorer()
+
+    # load schema
+    schema_file = get_temp_jsonld(schema_url)
+    se.load_schema(schema_file)
+
+    # get all available classes (useful for debugging)
+    #all_class = se.get_nx_schema()
+    #print(all_class.nodes)
+
+    # get rules associated with class
+    rules = se.get_class_validation_rules(class_label)
+
+    return rules

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -435,6 +435,23 @@ class SchemaExplorer:
 
         return rules
 
+    def get_attribute_type(self, class_label):
+        try: 
+            rules = self.get_class_validation_rules(class_label)
+            if len(rules):
+                attribute = rules[0]
+                if attribute in ['num', 'float']:
+                    return "double"
+                elif attribute in ['int', 'list']:
+                    return attribute
+                else:
+                    return 'string'
+            else:
+                return ''
+        except:  
+            raise KeyError('this class does not exist in the data model')
+
+
     def get_property_label_from_display_name(self, display_name):
         """Convert a given display name string into a proper property label string"""
         """


### PR DESCRIPTION
This PR is related to the issue [here](https://github.com/Sage-Bionetworks/schematic/issues/723). But I am not sure what would be the best way to extract attribute types from the validation rules. 

For example, for the example data model [here](https://github.com/Sage-Bionetworks/schematic/blob/develop/tests/data/example.model.csv#:~:text=DataProperty-,protectAges,-Check%20Unique), if I use "FamilyHistory" as an input, the `get_class_validation_rules` function would return `list` which is perfect. But if I use "CheckAges" as an input, the `get_class_validation_rules` function would return a string `protectAges` which doesn't directly tell me the data type. Should I have the API endpoint return `protectAges` as it is? Or should I do more processing and return it as `double` or `integer`? 
