### PR TITLE
Develop an endpoint to return data types of columns in a manifest 

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -350,6 +350,43 @@ paths:
           description: Check schematic log
       tags:
         - Manifest Operations
+  /get/datatype/manifest:
+    get:
+      summary: Retrieve asset view table as a dataframe.
+      description: Retrieve asset view table as a dataframe.
+      operationId: api.routes.get_manifest_datatype
+      parameters:
+        - in: query
+          name: input_token
+          schema:
+            type: string
+            nullable: false
+          description: Token
+          example: Token
+          required: true
+        - in: query
+          name: asset_view
+          schema:
+            type: string
+            nullable: false
+          description: ID of view listing all project data assets. For example, for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.(i.e. master_fileview in config.yml)
+          example: syn23643253
+          required: true
+        - in: query
+          name: manifest_id
+          schema:
+            type: string
+            nullable: false
+          description: Manifest ID
+          example: syn23643253
+          required: true
+      responses:
+        "200":
+          description: A list of json
+        "500":
+          description: Check schematic log. 
+      tags:
+        - Manifest Operations
   /storage/projects:
     get:
       summary: Get all storage projects the current user has access to

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -378,7 +378,7 @@ paths:
             type: string
             nullable: false
           description: Manifest ID
-          example: syn23643253
+          example: syn27600110
           required: true
       responses:
         "200":

--- a/api/routes.py
+++ b/api/routes.py
@@ -327,7 +327,7 @@ def get_manifest_datatype(input_token, manifest_id, asset_view):
     # use Synapse Storage
     store = SynapseStorage(input_token=input_token)
 
-    # get existing manifest Synapse ID
+    # get existing manifest
     manifest= store.getDataTypeFromManifest(manifest_id)
 
     # convert the DataFrame to use best possible dtypes.

--- a/api/routes.py
+++ b/api/routes.py
@@ -327,18 +327,11 @@ def get_manifest_datatype(input_token, manifest_id, asset_view):
     # use Synapse Storage
     store = SynapseStorage(input_token=input_token)
 
-    # get existing manifest
-    manifest= store.getDataTypeFromManifest(manifest_id)
-
-    # convert the DataFrame to use best possible dtypes.
-    manifest_new = manifest.convert_dtypes()
-
-    # get data types of columns
-    result = manifest_new.dtypes.to_frame('dtypes').reset_index()
-    result_dict = result.set_index('index')['dtypes'].astype(str).to_dict()
+    # get data types of an existing manifest
+    manifest_dtypes_dict= store.getDataTypeFromManifest(manifest_id)
 
 
-    return result_dict
+    return manifest_dtypes_dict
 
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -18,6 +18,7 @@ from schematic.schemas.generator import SchemaGenerator
 from schematic.store.synapse import SynapseStorage
 import pandas as pd
 import json
+from schematic.utils.df_utils import load_df
 
 
 # def before_request(var1, var2):
@@ -318,4 +319,26 @@ def get_project_manifests(input_token, project_id, asset_view):
     lst_manifest = store.getProjectManifests(projectId=project_id)
 
     return lst_manifest
-    
+
+def get_manifest_datatype(input_token, manifest_id, asset_view):
+    # use the default asset view from config
+    config_handler(asset_view=asset_view)
+
+    # use Synapse Storage
+    store = SynapseStorage(input_token=input_token)
+
+    # get existing manifest Synapse ID
+    manifest= store.getDataTypeFromManifest(manifest_id)
+
+    # convert the DataFrame to use best possible dtypes.
+    manifest_new = manifest.convert_dtypes()
+
+    # get data types of columns
+    result = manifest_new.dtypes.to_frame('dtypes').reset_index()
+    result_dict = result.set_index('index')['dtypes'].astype(str).to_dict()
+
+
+    return result_dict
+
+
+

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -392,6 +392,13 @@ class SynapseStorage(BaseStorage):
 
             return manifest_syn_id
 
+    def getDataTypeFromManifest(self, manifestId:str):
+        manifest_filepath = self.syn.get(manifestId).path
+        manifest = load_df(manifest_filepath)
+
+        return manifest
+
+
     def updateDatasetManifestFiles(self, datasetId: str, store:bool = True) -> Union[Tuple[str, pd.DataFrame], None]:
         """Fetch the names and entity IDs of all current files in dataset in store, if any; update dataset's manifest with new files, if any.
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -393,10 +393,27 @@ class SynapseStorage(BaseStorage):
             return manifest_syn_id
 
     def getDataTypeFromManifest(self, manifestId:str):
+        """Fetch a manifest and return data types of all columns
+        Args: 
+            manifestId: synapse ID of a manifest
+        """
+        # get manifest file path 
         manifest_filepath = self.syn.get(manifestId).path
-        manifest = load_df(manifest_filepath)
 
-        return manifest
+        # load manifest dataframe 
+        manifest = load_df(manifest_filepath, preserve_raw_input=False, data_model=False)
+
+        # convert the dataFrame to use best possible dtypes.
+        manifest_new = manifest.convert_dtypes()
+
+        # get data types of columns
+        result = manifest_new.dtypes.to_frame('dtypes').reset_index()
+
+        # return the result as a dictionary 
+        result_dict = result.set_index('index')['dtypes'].astype(str).to_dict()
+
+
+        return result_dict
 
 
     def updateDatasetManifestFiles(self, datasetId: str, store:bool = True) -> Union[Tuple[str, pd.DataFrame], None]:

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -30,6 +30,7 @@ def load_df(file_path, preserve_raw_input=True, data_model=False, **load_args):
     else:
         float_df=deepcopy(org_df)
         #Find integers stored as strings 
+        org_df = org_df.astype(str)
         ints = org_df.applymap(lambda x: np.int64(x) if str.isdigit(x) else False, na_action='ignore').fillna(False)
 
         #convert strings to numerical dtype (float) if possible, preserve non-numerical strings

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -29,8 +29,10 @@ def load_df(file_path, preserve_raw_input=True, data_model=False, **load_args):
 
     else:
         float_df=deepcopy(org_df)
-        #Find integers stored as strings 
-        org_df = org_df.astype(str)
+        #Find integers stored as strings
+        #Cast the columns in dataframe to string while preserving NaN
+        null_cells = org_df.isnull() 
+        org_df = org_df.astype(str).mask(null_cells, np.NaN)
         ints = org_df.applymap(lambda x: np.int64(x) if str.isdigit(x) else False, na_action='ignore').fillna(False)
 
         #convert strings to numerical dtype (float) if possible, preserve non-numerical strings


### PR DESCRIPTION
This PR is related to the issue [here](https://github.com/Sage-Bionetworks/schematic/issues/807). Here are the tests that I did: 
- Test manifest [here](https://www.synapse.org/#!Synapse:syn32602107)
Output: 
```
{
  "Component": "string",
  "File Format": "string",
  "Filename": "string",
  "Genome Build": "string",
  "Genome FASTA": "string",
  "Sample ID": "Int64",
  "Test": "Float64",
  "Test2": "string",
  "Test3": "string",
  "Test4": "object",
  "Test5": "string",
  "entityId": "string"
}
```

- Test manifest [here](https://www.synapse.org/#!Synapse:syn32631266)
Output: 
```
{
  "Check Ages": "Int64",
  "Check Float": "Float64",
  "Check Int": "Float64",
  "Check List": "string",
  "Check Match Exactly": "Int64",
  "Check Match at Least": "Int64",
  "Check Num": "object",
  "Check Range": "Int64",
  "Check Recommended": "string",
  "Check Regex List": "string",
  "Check Regex Single": "string",
  "Check String": "object",
  "Check URL": "string",
  "Check Unique": "string",
  "Component": "string"
}
```

Notes: if two rows under the same column have different data types (i.e. an integer and a string), then it will return as type `object`. Currently, there's also no type `list`. `list` like object (see test 1, column `Test 2` and `Check Regex List` column in test 2)  get returned as "string"