### PR TITLE
Create project table manifests, move entities to new project

### DIFF
--- a/schematic/help.py
+++ b/schematic/help.py
@@ -66,6 +66,10 @@ manifest_commands = {
             "archive_project": (
                 "Specify a single project where legacy manifest entities will be stored after migration to table."
             ),
+            "return_entities": (
+                "This is a boolean flag. If flag is provided when command line utility is executed, "
+                "entities that have been transferred to an archive project will be returned to their original folders."
+            ),
         },
     }
 }

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -70,6 +70,12 @@ manifest_commands = {
                 "This is a boolean flag. If flag is provided when command line utility is executed, "
                 "entities that have been transferred to an archive project will be returned to their original folders."
             ),
+            "dry_run": (
+                "This is a boolean flag. If flag is provided when command line utility is executed, "
+                "a dry run will be performed. No manifests will be re-uploaded and no entities will be migrated, "
+                "but archival folders will still be created. "
+                "Migration information for testing purposes will be logged to the INFO level."
+            ),
         },
     }
 }

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -55,6 +55,18 @@ manifest_commands = {
                 "Optional"
             ),
         },
+        "migrate": {
+            "short_help": (
+                "Specify the path to the `config.yml` using this option. "
+                "This is a required argument."
+            ),
+            "project_scope": (
+                "Specify a comma-separated list of projects where manifest entities will be migrated to tables."
+            ),
+            "archive_project": (
+                "Specify a single project where legacy manifest entities will be stored after migration to table."
+            ),
+        },
     }
 }
 

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -209,15 +209,22 @@ def get_manifest(
     callback=parse_synIDs,
     help=query_dict(manifest_commands, ("manifest", "migrate", "archive_project")),
 )
+@click.option(
+    "-p", "--jsonld", help=query_dict(manifest_commands, ("manifest", "get", "jsonld"))
+)
 @click.pass_obj
 def migrate_manifests(
     ctx,
     project_scope,
     archive_project,
+    jsonld,
 ):
     """
     Running CLI with manifest migration options.
     """
+
     print(project_scope,archive_project)
+    jsonld = fill_in_from_config("jsonld", jsonld, ("model", "input", "location"))
+
 
     return 

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -227,5 +227,14 @@ def migrate_manifests(
     print(project_scope,archive_project)
     jsonld = fill_in_from_config("jsonld", jsonld, ("model", "input", "location"))
 
+    access_token = os.getenv("SYNAPSE_ACCESS_TOKEN")
+    if access_token:
+        synStore = SynapseStorage(access_token=access_token,project_scope=project_scope)
+    else:
+        synStore = SynapseStorage(project_scope=project_scope)  
+
+    for project in project_scope:
+        synStore.upload_annotated_project_manifests_to_synapse(project, jsonld)
+
 
     return 

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -232,12 +232,6 @@ def migrate_manifests(
     Running CLI with manifest migration options.
     """
     print(project_scope,archive_project)
-
-    
-    if return_entities:
-        synStore.return_entities_to_old_project(project, archive_project)
-        return
-
     
     jsonld = fill_in_from_config("jsonld", jsonld, ("model", "input", "location"))
 
@@ -251,7 +245,6 @@ def migrate_manifests(
         synStore.upload_annotated_project_manifests_to_synapse(project, jsonld)
 
         if archive_project:
-            synStore.move_entities_to_new_project(project, archive_project)
+            synStore.move_entities_to_new_project(project, archive_project, return_entities)
         
-
     return 

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -7,7 +7,7 @@ import logging
 import sys
 
 from schematic.manifest.generator import ManifestGenerator
-from schematic.utils.cli_utils import fill_in_from_config, query_dict
+from schematic.utils.cli_utils import fill_in_from_config, query_dict, parse_synIDs
 from schematic.help import manifest_commands
 from schematic import CONFIG
 from schematic.schemas.generator import SchemaGenerator
@@ -189,3 +189,35 @@ def get_manifest(
             result = create_single_manifest(data_type = dt, output_csv=output_csv, output_xlsx=output_xlsx)
 
     return result
+
+@manifest.command(
+    "migrate", short_help=query_dict(manifest_commands, ("manifest", "migrate", "short_help"))
+)
+@click_log.simple_verbosity_option(logger)
+# define the optional arguments
+@click.option(
+    "-ps",
+    "--project_scope",
+    default=None,
+    callback=parse_synIDs,
+    help=query_dict(manifest_commands, ("manifest", "migrate", "project_scope")),
+)
+@click.option(
+    "-ap",
+    "--archive_project",
+    default=None,
+    callback=parse_synIDs,
+    help=query_dict(manifest_commands, ("manifest", "migrate", "archive_project")),
+)
+@click.pass_obj
+def migrate_manifests(
+    ctx,
+    project_scope,
+    archive_project,
+):
+    """
+    Running CLI with manifest migration options.
+    """
+    print(project_scope,archive_project)
+
+    return 

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -220,6 +220,13 @@ def get_manifest(
     default=False,
     help=query_dict(manifest_commands, ("manifest", "migrate", "return_entities")),
 )
+@click.option(
+    "-dr",
+    "--dry_run",
+    is_flag=True,
+    default=False,
+    help=query_dict(manifest_commands, ("manifest", "migrate", "dry_run")),
+)
 @click.pass_obj
 def migrate_manifests(
     ctx,
@@ -227,6 +234,7 @@ def migrate_manifests(
     archive_project: str,
     jsonld: str,
     return_entities: bool,
+    dry_run: bool,
 ):
     """
     Running CLI with manifest migration options.
@@ -243,9 +251,9 @@ def migrate_manifests(
     for project in project_scope:
         if not return_entities:
             logging.info("Re-uploading manifests as tables")
-            synStore.upload_annotated_project_manifests_to_synapse(project, jsonld)
+            synStore.upload_annotated_project_manifests_to_synapse(project, jsonld, dry_run)
         if archive_project:
             logging.info("Migrating entitites")
-            synStore.move_entities_to_new_project(project, archive_project, return_entities)
+            synStore.move_entities_to_new_project(project, archive_project, return_entities, dry_run)
         
     return 

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -231,20 +231,21 @@ def migrate_manifests(
     """
     Running CLI with manifest migration options.
     """
-    print(project_scope,archive_project)
-    
     jsonld = fill_in_from_config("jsonld", jsonld, ("model", "input", "location"))
 
     access_token = os.getenv("SYNAPSE_ACCESS_TOKEN")
+    full_scope = project_scope + [archive_project]
     if access_token:
-        synStore = SynapseStorage(access_token=access_token,project_scope=project_scope)
+        synStore = SynapseStorage(access_token = access_token, project_scope = full_scope)
     else:
-        synStore = SynapseStorage(project_scope=project_scope)  
+        synStore = SynapseStorage(project_scope = full_scope)  
 
     for project in project_scope:
-        synStore.upload_annotated_project_manifests_to_synapse(project, jsonld)
-
+        if not return_entities:
+            logging.info("Re-uploading manifests as tables")
+            synStore.upload_annotated_project_manifests_to_synapse(project, jsonld)
         if archive_project:
+            logging.info("Migrating entitites")
             synStore.move_entities_to_new_project(project, archive_project, return_entities)
         
     return 

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -12,6 +12,7 @@ from schematic.help import manifest_commands
 from schematic import CONFIG
 from schematic.schemas.generator import SchemaGenerator
 from schematic.utils.google_api_utils import export_manifest_csv, export_manifest_excel
+from schematic.store.synapse import SynapseStorage
 
 logger = logging.getLogger(__name__)
 click_log.basic_config(logger)

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -639,7 +639,7 @@ class SynapseStorage(BaseStorage):
         return
 
 
-    def move_entities_to_new_project(self, projectId, newProjectId):
+    def move_entities_to_new_project(self, projectId: str, newProjectId: str, returnEntities: bool = False):
         """
         For each manifest csv in a project, look for all the entitiy ids that are associated.
         Look up the entitiy in the files, move the entity to new project.
@@ -666,34 +666,12 @@ class SynapseStorage(BaseStorage):
                         & (self.storageFileviewTable['type'] == 'folder')
                     ]['id']
 
-                for entityId in annotation_entities:
-                    self.syn.move(entityId, newProjectId)
-
-        return
-
-    def return_entities_to_old_project(self, projectId, newProjectId):
-        """
-        For each manifest csv in a project, look for all the entitiy ids that are associated.
-        Look up the entitiy in the files, move the entity to new project.
-        """
-
-        manifests = []
-        manifest_loaded = []
-        datasets = self.getStorageDatasetsInProject(projectId)
-        for (datasetId, datasetName) in datasets:
-            # encode information about the manifest in a simple list (so that R clients can unpack it)
-            # eventually can serialize differently
-
-            manifest = ((datasetId, datasetName), ("", ""), ("", ""))
-
-            manifest_info = self.getDatasetManifest(datasetId, downloadFile=True)
-            if manifest_info:
-                manifest_id = manifest_info["properties"]["id"]
-                manifest_name = manifest_info["properties"]["name"]
-                manifest_path = manifest_info["path"]
-                manifest_df = load_df(manifest_path)
-                for entityId in manifest_df['entityId']:
-                    self.syn.move(entityId, datasetId)
+                if returnEntities:
+                    for entityId in annotation_entities:
+                        self.syn.move(entityId, datasetId)
+                else:
+                    for entityId in annotation_entities:
+                        self.syn.move(entityId, newProjectId)
 
         return
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -27,6 +27,7 @@ from synapseclient import (
     Column,
     as_table_columns,
 )
+
 from synapseclient.table import CsvFileTable
 from synapseclient.table import build_table
 from synapseclient.annotations import from_synapse_annotations
@@ -597,13 +598,15 @@ class SynapseStorage(BaseStorage):
                 manifest_loaded.append(datasetName)
         return manifest_loaded
 
-    def upload_annotated_project_manifests_to_synapse(self, projectId:str) -> List[str]:
+    def upload_annotated_project_manifests_to_synapse(self, projectId:str, path_to_json_ld: str) -> List[str]:
         '''
         Purpose:
             For all manifests in a project, upload them as a table and add annotations manifest csv.
             Assumes the manifest is already present as a CSV in a dataset in the project.
 
         '''
+
+        sg = SchemaGenerator(path_to_json_ld)
         manifests = []
         manifest_loaded = []
         datasets = self.getStorageDatasetsInProject(projectId)
@@ -621,7 +624,7 @@ class SynapseStorage(BaseStorage):
                 manifest_path = manifest_info["path"]
                 manifest_df = load_df(manifest_path)
                 #manifest_syn_id = self.annotate_upload_manifest_table(manifest_df, datasetId, manifest_path)
-                manifest_syn_id = self.associateMetadataWithFiles(manifest_path, datasetId, manifest_record_type='table')
+                manifest_syn_id = self.associateMetadataWithFiles(sg, manifest_path, datasetId, manifest_record_type='table')
                 manifest_loaded.append(datasetName)
         return
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -625,6 +625,7 @@ class SynapseStorage(BaseStorage):
             # eventually can serialize differently
 
             manifest = ((datasetId, datasetName), ("", ""), ("", ""))
+            manifests.append(manifest)
 
             manifest_info = self.getDatasetManifest(datasetId, downloadFile=True)
 
@@ -632,12 +633,12 @@ class SynapseStorage(BaseStorage):
                 manifest_id = manifest_info["properties"]["id"]
                 manifest_name = manifest_info["properties"]["name"]
                 manifest_path = manifest_info["path"]
-                manifest_df = load_df(manifest_path)
-                #manifest_syn_id = self.annotate_upload_manifest_table(manifest_df, datasetId, manifest_path)
+                manifest = ((datasetId, datasetName), (manifest_id, manifest_name), ("", ""))
                 if not dry_run:
                     manifest_syn_id = self.associateMetadataWithFiles(sg, manifest_path, datasetId, manifest_record_type='table')
-                manifest_loaded.append(datasetName)
-        return
+                manifest_loaded.append(manifest)
+            
+        return manifests, manifest_loaded
 
 
     def move_entities_to_new_project(self, projectId: str, newProjectId: str, returnEntities: bool = False, dry_run: bool = False):
@@ -653,6 +654,9 @@ class SynapseStorage(BaseStorage):
             # encode information about the manifest in a simple list (so that R clients can unpack it)
             # eventually can serialize differently
 
+            manifest = ((datasetId, datasetName), ("", ""), ("", ""))
+            manifests.append(manifest)
+
             manifest_info = self.getDatasetManifest(datasetId, downloadFile=True)
             if manifest_info:
                 manifest_id = manifest_info["properties"]["id"]
@@ -661,7 +665,7 @@ class SynapseStorage(BaseStorage):
                 manifest_df = load_df(manifest_path)
 
                 manifest = ((datasetId, datasetName), (manifest_id, manifest_name), ("", ""))
-                manifests.append(manifest)
+                manifest_loaded.append(manifest)
 
                 annotation_entities = self.storageFileviewTable[
                         (self.storageFileviewTable['id'].isin(manifest_df['entityId']))
@@ -690,7 +694,7 @@ class SynapseStorage(BaseStorage):
                         else:
                             logging.info(f"{entityId} will be moved to folder {dataset_archive_folder.id}.")
                         
-        return manifests
+        return manifests, manifest_loaded
 
     def get_synapse_table(self, synapse_id: str) -> Tuple[pd.DataFrame, CsvFileTable]:
         """Download synapse table as a pd dataframe; return table schema and etags as results too

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -669,9 +669,23 @@ class SynapseStorage(BaseStorage):
                 if returnEntities:
                     for entityId in annotation_entities:
                         self.syn.move(entityId, datasetId)
+                        pass
                 else:
+                    existing_datasets = self.getStorageDatasetsInProject(newProjectId)
+                
+                    # generate project folder
+                    archive_project_folder = Folder(projectId+'_archive', parent = newProjectId)
+                    archive_project_folder = self.syn.store(archive_project_folder)
+    
+                    # generate dataset folder
+                    dataset_archive_folder = Folder("_".join([datasetId,datasetName,'archive']), parent = archive_project_folder.id)
+                    dataset_archive_folder = self.syn.store(dataset_archive_folder)                    
+
+
                     for entityId in annotation_entities:
-                        self.syn.move(entityId, newProjectId)
+                        # move entities to folder
+                        self.syn.move(entityId, dataset_archive_folder.id)
+                        pass
 
         return
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -569,9 +569,64 @@ class SynapseStorage(BaseStorage):
                 manifest_name = manifest_info["properties"]["name"]
                 manifest_path = manifest_info["path"]
                 manifest_df = load_df(manifest_path)
-                manifest_table_id = upload_format_manifest_table(manifest, dataset_id, datasetName)
+                manifest_table_id = upload_format_manifest_table(manifest, datasetId, datasetName)
                 manifest_loaded.append(datasetName)
         return manifest_loaded
+
+    def upload_annotated_project_manifests_to_synapse(self, projectId:str) -> List[str]:
+        '''
+        Purpose:
+            For all manifests in a project, upload them as a table and add annotations manifest csv.
+            Assumes the manifest is already present as a CSV in a dataset in the project.
+
+        '''
+        manifests = []
+        manifest_loaded = []
+        datasets = self.getStorageDatasetsInProject(projectId)
+        for (datasetId, datasetName) in datasets:
+            # encode information about the manifest in a simple list (so that R clients can unpack it)
+            # eventually can serialize differently
+
+            manifest = ((datasetId, datasetName), ("", ""), ("", ""))
+
+            manifest_info = self.getDatasetManifest(datasetId, downloadFile=True)
+
+            if manifest_info:
+                manifest_id = manifest_info["properties"]["id"]
+                manifest_name = manifest_info["properties"]["name"]
+                manifest_path = manifest_info["path"]
+                manifest_df = load_df(manifest_path)
+                #manifest_syn_id = self.annotate_upload_manifest_table(manifest_df, datasetId, manifest_path)
+                manifest_syn_id = self.associateMetadataWithFiles(manifest_path, datasetId, manifest_record_type='table')
+                manifest_loaded.append(datasetName)
+        return
+
+
+    def move_entities_to_new_project(self, projectId, newProjectId):
+        """
+        For each manifest csv in a project, look for all the entitiy ids that are associated.
+        Look up the entitiy in the files, move the entity to new project.
+        """
+
+        manifests = []
+        manifest_loaded = []
+        datasets = self.getStorageDatasetsInProject(projectId)
+        for (datasetId, datasetName) in datasets:
+            # encode information about the manifest in a simple list (so that R clients can unpack it)
+            # eventually can serialize differently
+
+            manifest = ((datasetId, datasetName), ("", ""), ("", ""))
+
+            manifest_info = self.getDatasetManifest(datasetId, downloadFile=True)
+            if manifest_info:
+                manifest_id = manifest_info["properties"]["id"]
+                manifest_name = manifest_info["properties"]["name"]
+                manifest_path = manifest_info["path"]
+                manifest_df = load_df(manifest_path)
+                for entityId in manifest_df['entityId']:
+                    self.syn.move(entityId, newProjectId)
+
+        return
 
     def get_synapse_table(self, synapse_id: str) -> Tuple[pd.DataFrame, CsvFileTable]:
         """Download synapse table as a pd dataframe; return table schema and etags as results too
@@ -731,6 +786,82 @@ class SynapseStorage(BaseStorage):
             annos[annos_k] = annos_v
 
         return annos
+    '''
+    def annotate_upload_manifest_table(self, manifest, datasetId, metadataManifestPath,
+        useSchemaLabel: bool = True, hideBlanks: bool = False, restrict_manifest = False):
+        """
+        Purpose:
+            Works very similarly to associateMetadataWithFiles except takes in the manifest
+            rather than the manifest path
+
+        """
+        
+        # Add uuid for table updates and fill.
+        if not "Uuid" in manifest.columns:
+            manifest["Uuid"] = ''
+
+        for idx,row in manifest.iterrows():
+            if not row["Uuid"]:
+                gen_uuid = uuid.uuid4()
+                row["Uuid"] = gen_uuid
+                manifest.loc[idx, 'Uuid'] = gen_uuid
+
+        # add entityId as a column if not already there or
+        # fill any blanks with an empty string.
+        if not "entityId" in manifest.columns:
+            manifest["entityId"] = ""
+        else:
+            manifest["entityId"].fillna("", inplace=True)
+
+        # get a schema explorer object to ensure schema attribute names used in manifest are translated to schema labels for synapse annotations
+        se = SchemaExplorer()
+
+        # Create table name here.
+        if 'Component' in manifest.columns:
+            table_name = manifest['Component'][0].lower() + '_synapse_storage_manifest_table'
+        else:
+            table_name = 'synapse_storage_manifest_table'
+
+        # Upload manifest as a table and get the SynID and manifest
+        manifest_synapse_table_id, manifest, table_manifest = self.upload_format_manifest_table(
+                                                    se, manifest, datasetId, table_name, restrict = restrict_manifest, useSchemaLabel=useSchemaLabel,)
+            
+        # Iterate over manifest rows, create Synapse entities and store corresponding entity IDs in manifest if needed
+        # also set metadata for each synapse entity as Synapse annotations
+        for idx, row in manifest.iterrows():
+            if not row["entityId"]:
+                # If not using entityIds, fill with manifest_table_id so 
+                row["entityId"] = manifest_synapse_table_id
+                entityId = ''
+            else:
+                # get the entity id corresponding to this row
+                entityId = row["entityId"]
+
+        # Load manifest to synapse as a CSV File
+        manifest_synapse_file_id = self.uplodad_manifest_file(manifest, metadataManifestPath, datasetId, restrict_manifest)
+        
+        # Get annotations for the file manifest.
+        manifest_annotations = self.format_manifest_annotations(manifest, manifest_synapse_file_id)
+        
+        self.syn.set_annotations(manifest_annotations)
+
+        logger.info("Associated manifest file with dataset on Synapse.")
+        
+        # Update manifest Synapse table with new entity id column.
+        self.make_synapse_table(
+            table_to_load = table_manifest,
+            dataset_id = datasetId,
+            existingTableId = manifest_synapse_table_id,
+            table_name = table_name,
+            update_col = 'Uuid',
+            specify_schema = False,
+            )
+        
+        # Get annotations for the table manifest
+        manifest_annotations = self.format_manifest_annotations(manifest, manifest_synapse_table_id)
+        self.syn.set_annotations(manifest_annotations)
+        return manifest_synapse_table_id
+    '''
 
     def associateMetadataWithFiles(
         self, metadataManifestPath: str, datasetId: str, manifest_record_type: str = 'both', 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -660,7 +660,13 @@ class SynapseStorage(BaseStorage):
                 manifest_name = manifest_info["properties"]["name"]
                 manifest_path = manifest_info["path"]
                 manifest_df = load_df(manifest_path)
-                for entityId in manifest_df['entityId']:
+
+                annotation_entities = self.storageFileviewTable[
+                        (self.storageFileviewTable['id'].isin(manifest_df['entityId']))
+                        & (self.storageFileviewTable['type'] == 'folder')
+                    ]['id']
+
+                for entityId in annotation_entities:
                     self.syn.move(entityId, newProjectId)
 
         return


### PR DESCRIPTION
The purpose of this PR is to allow users the ability to recreate all a projects manifests as a `table` and add annotations to the manifest csvs. In addition it provides a function that allows users to move all entities represented in manifests to a new project. This will help with the limits on the number of folders allowed for a single project. 

These functions were created to address a use case by HTAN where they kept hitting file limits. With materialized views we no longer need entities, but want to save previously created ones. 

Holding off on actually pushing to develop till we have moved everything from HTAN just to make sure its working exactly as we want. 

---
From @GiaJordan 
This PR introduces a new command to schematic `schematic manifest migrate` to recreate manifests as `table` type instead of `entity` type, and to  migrate folder entities to a different project for archival. 
PR at merge includes functionality to "recreate all a projects manifests as a `table` and add annotations to the manifest CSVs", and allows users to "move all entities represented in manifests to a new project."
`schematic manifest migrate` takes the commands:

- `--project_scope`: a comma separated list of synIDs for projects on synapse
- `--archive_project`: a single synID for a project on synapse to store the archived folder entities
- `--jsonld`: the path to the user `jsonld` model
- `--return_entities`: a flag to include when it is desired to restore the archived entities to their original locations
- `--dry_run`: perform a dry run without uploading manifests or moving entities, log info about what would be moved

When archiving entities, a folder hierarchy is created in the archival project to avoid encountering Synapse limits on folder number. Entities are sorted first by source project, then by dataset. Logic is also included to only move entities that are present in a manifest and of type `folder`. This logic is stable currently, but will need to be updated if support is added for annotating folders that contain many files, instead of the files themselves.