### PR TITLE
Develop NA string behavior

### DIFF
--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -213,7 +213,8 @@ class MetadataModel(object):
         warnings = []
 
         load_args={
-            "dtype":"string"
+            "dtype":"string",
+            "keep_default_na": False
             }
         # get annotations from manifest (array of json annotations corresponding to manifest rows)
         manifest = load_df(

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -214,7 +214,7 @@ class MetadataModel(object):
 
         load_args={
             "dtype":"string",
-            "keep_default_na": False
+            "keep_default_na": True
             }
         # get annotations from manifest (array of json annotations corresponding to manifest rows)
         manifest = load_df(

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -214,7 +214,6 @@ class MetadataModel(object):
 
         load_args={
             "dtype":"string",
-            "keep_default_na": True
             }
         # get annotations from manifest (array of json annotations corresponding to manifest rows)
         manifest = load_df(

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -802,7 +802,8 @@ class SynapseStorage(BaseStorage):
         # read new manifest csv
         try:
             load_args={
-                "dtype":"string"
+                "dtype":"string",
+                "keep_default_na": False
             }
             manifest = load_df(metadataManifestPath, preserve_raw_input=False, **load_args)
         except FileNotFoundError as err:

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -803,7 +803,6 @@ class SynapseStorage(BaseStorage):
         try:
             load_args={
                 "dtype":"string",
-                "keep_default_na": True
             }
             manifest = load_df(metadataManifestPath, preserve_raw_input=False, **load_args)
         except FileNotFoundError as err:

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -803,7 +803,7 @@ class SynapseStorage(BaseStorage):
         try:
             load_args={
                 "dtype":"string",
-                "keep_default_na": False
+                "keep_default_na": True
             }
             manifest = load_df(metadataManifestPath, preserve_raw_input=False, **load_args)
         except FileNotFoundError as err:

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -18,7 +18,7 @@ def load_df(file_path, preserve_raw_input=True, data_model=False, **load_args):
     Returns: a processed dataframe for manifests or unprocessed df for data models
     """
     #Read CSV to df as type specified in kwargs
-    org_df = pd.read_csv(file_path, keep_default_na = False, encoding='utf8', **load_args)
+    org_df = pd.read_csv(file_path, encoding='utf8', **load_args)
     if preserve_raw_input:
         #only trim if not data model csv
         if not data_model:

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -19,6 +19,7 @@ def load_df(file_path, preserve_raw_input=True, data_model=False, **load_args):
     """
     #Read CSV to df as type specified in kwargs
     org_df = pd.read_csv(file_path, encoding='utf8', **load_args)
+    
     if preserve_raw_input:
         #only trim if not data model csv
         if not data_model:

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -18,7 +18,7 @@ def load_df(file_path, preserve_raw_input=True, data_model=False, **load_args):
     Returns: a processed dataframe for manifests or unprocessed df for data models
     """
     #Read CSV to df as type specified in kwargs
-    org_df = pd.read_csv(file_path, encoding='utf8', **load_args)
+    org_df = pd.read_csv(file_path, keep_default_na = True, encoding='utf8', **load_args)
     
     if preserve_raw_input:
         #only trim if not data model csv

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -18,8 +18,7 @@ def load_df(file_path, preserve_raw_input=True, data_model=False, **load_args):
     Returns: a processed dataframe for manifests or unprocessed df for data models
     """
     #Read CSV to df as type specified in kwargs
-    org_df = pd.read_csv(file_path, encoding='utf8', **load_args)
-    
+    org_df = pd.read_csv(file_path, keep_default_na = False, encoding='utf8', **load_args)
     if preserve_raw_input:
         #only trim if not data model csv
         if not data_model:


### PR DESCRIPTION
Change `pd.read_csv` parameters for manifests to not cast strings to Null values when possible. Fixes string `NA` values from being uploaded to synapse as blanks and type `double`.
Behavior for data models is unchanged