### PR TITLE
Develop optional rule args

### DIFF
--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -404,7 +404,7 @@ class GreatExpectationsHelpers(object):
                         values.append(item) if isinstance(item,type_dict[observed_type]) else values
 
                 #call functions to generate error messages and add to error list
-                if validation_types[rule.split(" ")[0]]=='type_validation':
+                if validation_types[rule.split(" ")[0]]['type']=='type_validation':
                     for row, value in zip(indices,values):
                         errors.append(
                             GenerateError.generate_type_error(
@@ -414,7 +414,7 @@ class GreatExpectationsHelpers(object):
                                 invalid_entry = value,
                             )
                         )          
-                elif validation_types[rule.split(" ")[0]]=='regex_validation':
+                elif validation_types[rule.split(" ")[0]]['type']=='regex_validation':
                     expression=result_dict['expectation_config']['kwargs']['regex']
 
                     for row, value in zip(indices,values):   
@@ -428,7 +428,7 @@ class GreatExpectationsHelpers(object):
                                 invalid_entry = value,
                             )
                         )    
-                elif validation_types[rule.split(" ")[0]]=='content_validation':     
+                elif validation_types[rule.split(" ")[0]]['type']=='content_validation':     
                     content_errors, content_warnings = GenerateError.generate_content_error(
                                                             val_rule = rule, 
                                                             attribute_name = errColumn,

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -21,6 +21,7 @@ from schematic.models.validate_attribute import ValidateAttribute, GenerateError
 from schematic.schemas.generator import SchemaGenerator
 from schematic.store.synapse import SynapseStorage
 from schematic.models.GE_Helpers import GreatExpectationsHelpers
+from schematic.utils.validate_rules_utils import validation_type_dict
 
 from ruamel import yaml
 
@@ -97,21 +98,8 @@ class ValidateManifest(object):
 
         # for each type of rule that can be spefified (key) point
         # to the type of validation that will be run.
-        validation_types = {
-            "int": "type_validation",
-            "float": "type_validation",
-            "num": "type_validation",
-            "str": "type_validation",
-            "regex": "regex_validation",
-            "url": "url_validation",
-            "list": "list_validation",
-            "matchAtLeastOne": "cross_validation",
-            "matchExactlyOne": "cross_validation",
-            "recommended": "content_validation",
-            "protectAges": "content_validation",
-            "unique": "content_validation",
-            "inRange": "content_validation",
-        }
+
+        validation_types = validation_type_dict()
 
         type_dict={
             "float64": float,
@@ -213,7 +201,7 @@ class ValidateManifest(object):
 
                     #Validate for each individual validation rule.
                     validation_method = getattr(
-                            ValidateAttribute, validation_types[validation_type]
+                            ValidateAttribute, validation_types[validation_type]['type']
                         )
 
                     if validation_type == "list":

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -21,7 +21,7 @@ from schematic.models.validate_attribute import ValidateAttribute, GenerateError
 from schematic.schemas.generator import SchemaGenerator
 from schematic.store.synapse import SynapseStorage
 from schematic.models.GE_Helpers import GreatExpectationsHelpers
-from schematic.utils.validate_rules_utils import validation_type_dict
+from schematic.utils.validate_rules_utils import validation_rule_info
 
 from ruamel import yaml
 
@@ -99,7 +99,7 @@ class ValidateManifest(object):
         # for each type of rule that can be spefified (key) point
         # to the type of validation that will be run.
 
-        validation_types = validation_type_dict()
+        validation_types = validation_rule_info()
 
         type_dict={
             "float64": float,

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -13,9 +13,10 @@ def validation_rule_info():
     Will be pulled into validate_single_rule and validate_manifest_rules
     Structure:    
         Rule:{
-            'arguments':(<are arguments allowed>, <no arguments allowed>, <no arguments required>),
+            'arguments':(<num arguments allowed>, <num arguments required>),
             'type': <rule type>,
             'complementary_rules': <rules available for pairing>}
+            'complementary_rules': [<rules available for pairing>]}
         }
     '''
     rule_dict = {

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -192,20 +192,6 @@ def validate_single_rule(validation_rule, attribute, input_filetype):
                 error_type = 'delimiter', input_filetype=input_filetype))
     return errors
 
-def valid_rule_combinations():
-    complementary_rules = {
-        "int": ['inRange',],
-        "float": ['inRange'],
-        "num": ['inRange'],
-        "protectAges": ['inRange'],
-        "inRange": ['int','float','num','protectAges'],
-        "list": ['regex'],
-        "regex": ['list'],
-    }
-
-    return complementary_rules
-
-
 def validate_schema_rules(validation_rules, attribute, input_filetype):
     '''
     validation_rules: list
@@ -223,7 +209,7 @@ def validate_schema_rules(validation_rules, attribute, input_filetype):
     # a set number of arguments required.
 
     errors = []
-    complementary_rules = validation_rule_info()
+    rule_info = validation_rule_info()
     num_validation_rules = len(validation_rules)
 
     
@@ -239,7 +225,7 @@ def validate_schema_rules(validation_rules, attribute, input_filetype):
         second_type = second_rule.split(" ")[0]  
 
         # validate rule combination
-        if second_type not in complementary_rules[first_type]['complementary_rules']:
+        if second_type not in rule_info[first_type]['complementary_rules']:
             errors.append(get_error(validation_rules, attribute, 
                 error_type = 'invalid_rule_combination', input_filetype=input_filetype))
         

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -15,7 +15,6 @@ def validation_rule_info():
         Rule:{
             'arguments':(<num arguments allowed>, <num arguments required>),
             'type': <rule type>,
-            'complementary_rules': <rules available for pairing>}
             'complementary_rules': [<rules available for pairing>]}
         }
     '''
@@ -223,7 +222,7 @@ def validate_schema_rules(validation_rules, attribute, input_filetype):
     # a set number of arguments required.
 
     errors = []
-    complementary_rules = valid_rule_combinations()
+    complementary_rules = validation_rule_info()
     num_validation_rules = len(validation_rules)
 
     
@@ -239,7 +238,7 @@ def validate_schema_rules(validation_rules, attribute, input_filetype):
         second_type = second_rule.split(" ")[0]  
 
         # validate rule combination
-        if second_type not in complementary_rules[first_type]:
+        if second_type not in complementary_rules[first_type]['complementary_rules']:
             errors.append(get_error(validation_rules, attribute, 
                 error_type = 'invalid_rule_combination', input_filetype=input_filetype))
         

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -127,9 +127,16 @@ def get_error(validation_rules: list,
         error_message = error_str
         error_val = f"Args not allowed."
     if error_type == 'incorrect_num_args':
+        rule_type=validation_rules.split(" ")[0]
+        
+        if rule_type in validation_rule_info():
+            no_allowed, no_required = validation_rule_info()[rule_type]['arguments']
+        else:
+            no_allowed, no_required = ('', '')
+
         error_str = (f"The {input_filetype}, has an error in the validation rule "
             f"for the attribute: {attribute_name}, the provided validation rules ({validation_rules}) is not "
-            f"formatted properly. The number of provided arguments does not match the number required/allowed.")
+            f"formatted properly. The number of provided arguments does not match the number allowed({no_allowed}) or required({no_required}).")
         logging.error(error_str)
         error_message = error_str
         error_val = f"Incorrect num arguments."

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -6,6 +6,63 @@ from typing import Any, Dict, Optional, Text, List
 
 logger = logging.getLogger(__name__)
 
+def validation_type_dict():
+    type_dict = {
+            "int": {
+                'arguments':(False, None, None),
+                'type': "type_validation"},
+
+            "float": {
+                'arguments':(False, None, None), 
+                'type': "type_validation"},
+
+            "num": {
+                'arguments':(False, None, None), 
+                'type': "type_validation"},
+
+            "str": {
+                'arguments':(False, None, None), 
+                'type': "type_validation"},
+
+            "regex": {
+                'arguments':(True, 2, 2), 
+                'fixed_arg': ['strict'], 
+                'type': "regex_validation"},
+
+            "url" : {
+                'arguments':(True, None, None), 
+                'type': "url_validation"},
+
+            "list": {
+                'arguments':(True, 1, 0), 
+                'type': "list_validation"},
+                
+            "matchAtLeastOne": {
+                'arguments':(True, 2, 2), 
+                'type': "cross_validation"},
+
+            "matchExactlyOne": {
+                'arguments':(True, 2, 2), 
+                'type': "cross_validation"},
+                
+            "recommended": {
+                'arguments':(False, None, None), 
+                'type': "content_validation"},
+
+            "protectAges": {
+                'arguments':(True, 1, 0), 
+                'type': "content_validation"},
+
+            "unique": {
+                'arguments':(True, 1, 0), 
+                'type': "content_validation"},
+                
+            "inRange": {
+                'arguments':(True, 3, 2), 
+                'type': "content_validation"},
+            }
+
+    return type_dict
 
 def get_error(validation_rules: list, 
         attribute_name: str, error_type: str, input_filetype:str,) -> List[str]:

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -136,7 +136,7 @@ def get_error(validation_rules: list,
 
     if error_type == 'invalid_rule_combination':
         first_type=validation_rules[0].split(' ')[0]
-        second_type=valid_rule_combinations()[first_type]
+        second_type=validation_rule_info()[first_type]['complementary_rules']
 
         error_str = (f"The {input_filetype}, has an error in the validation rule "
             f"for the attribute: {attribute_name}, the provided validation rules ({'::'.join(validation_rules)}) are not "
@@ -166,25 +166,26 @@ def validate_single_rule(validation_rule, attribute, input_filetype):
 
     else:
         arguments_allowed, arguments_required = validation_types[rule_type]['arguments']
+        # Remove any fixed args from our calc.
         if 'fixed_arg' in validation_types[rule_type].keys():
             fixed_args = validation_types[rule_type]['fixed_arg']
             num_args = len([vr for vr in validation_rule_with_args if vr not in fixed_args])-1 
         else:
             num_args = len(validation_rule_with_args) - 1
             
+        # If arguments are provided but not allowed, raise an error.
+        if num_args and not arguments_allowed:
+            errors.append(get_error(validation_rule, attribute,
+                error_type = 'args_not_allowed', input_filetype=input_filetype))
+        
         # If arguments are allowed, check that the correct amount have been passed.
-        if num_args and arguments_allowed:
-            # Remove any fixed args from our calc.
-            
-            # Are limits placed on the number of arguments.
-            if num_args != arguments_allowed and num_args != arguments_required:
+        # There must be at least the number of args required,
+        # and not more than allowed
+        elif arguments_allowed:
+            if (num_args < arguments_required) or (num_args > arguments_allowed):
                 errors.append(get_error(validation_rule, attribute,
                     error_type = 'incorrect_num_args', input_filetype=input_filetype))
 
-            # If arguments are provided but not allowed raise an error.
-        elif num_args and not arguments_allowed:
-            errors.append(get_error(validation_rule, attribute,
-                error_type = 'args_not_allowed', input_filetype=input_filetype))
 
         if ':' in validation_rule:
             errors.append(get_error(validation_rule, attribute,

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 def validation_rule_info():
     '''
     Function to return dict that holds information about each rule
-    Will be pulled into validate_single_rule and validate_manifest_rules
+    Will be pulled into validate_single_rule, validate_manifest_rules, validate_schema_rules
     Structure:    
         Rule:{
             'arguments':(<num arguments allowed>, <num arguments required>),

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -7,6 +7,15 @@ from typing import Any, Dict, Optional, Text, List
 logger = logging.getLogger(__name__)
 
 def validation_type_dict():
+    '''
+    Function to return dict that holds information about each rule
+    Will be pulled into validate_single_rule and validate_manifest_rules
+    Structure:    
+        Rule:{
+            'arguments':(<are arguments allowed>, <no arguments allowed>, <no arguments required>),
+            'type': <rule type>}
+        }
+    '''
     type_dict = {
             "int": {
                 'arguments':(False, None, None),

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -7,72 +7,86 @@ from typing import Any, Dict, Optional, Text, List
 
 logger = logging.getLogger(__name__)
 
-def validation_type_dict():
+def validation_rule_info():
     '''
     Function to return dict that holds information about each rule
     Will be pulled into validate_single_rule and validate_manifest_rules
     Structure:    
         Rule:{
             'arguments':(<are arguments allowed>, <no arguments allowed>, <no arguments required>),
-            'type': <rule type>}
+            'type': <rule type>,
+            'complementary_rules': <rules available for pairing>}
         }
     '''
-    type_dict = {
+    rule_dict = {
             "int": {
                 'arguments':(None, None),
-                'type': "type_validation"},
+                'type': "type_validation",
+                'complementary_rules': ['inRange',]},
 
             "float": {
                 'arguments':(None, None), 
-                'type': "type_validation"},
+                'type': "type_validation",
+                'complementary_rules': ['inRange',]},
 
             "num": {
                 'arguments':(None, None), 
-                'type': "type_validation"},
+                'type': "type_validation",
+                'complementary_rules': ['inRange',]},
 
             "str": {
                 'arguments':(None, None), 
-                'type': "type_validation"},
+                'type': "type_validation",
+                'complementary_rules': None},
 
             "regex": {
                 'arguments':(2, 2), 
                 'fixed_arg': ['strict'], 
-                'type': "regex_validation"},
+                'type': "regex_validation",
+                'complementary_rules': ['list']},
 
             "url" : {
                 'arguments':(None, None), 
-                'type': "url_validation"},
+                'type': "url_validation",
+                'complementary_rules': None},
 
             "list": {
                 'arguments':(1, 0), 
-                'type': "list_validation"},
+                'type': "list_validation",
+                'complementary_rules': ['regex']},
                 
             "matchAtLeastOne": {
                 'arguments':(2, 2), 
-                'type': "cross_validation"},
+                'type': "cross_validation",
+                'complementary_rules': None},
 
             "matchExactlyOne": {
                 'arguments':(2, 2), 
-                'type': "cross_validation"},
+                'type': "cross_validation",
+                'complementary_rules': None},
                 
             "recommended": {
                 'arguments':(None, None), 
-                'type': "content_validation"},
+                'type': "content_validation",
+                'complementary_rules': None},
 
             "protectAges": {
                 'arguments':(1, 0), 
-                'type': "content_validation"},
+                'type': "content_validation",
+                'complementary_rules': ['inRange',]},
 
             "unique": {
                 'arguments':(1, 0), 
-                'type': "content_validation"},
+                'type': "content_validation",
+                'complementary_rules': None},
                 
             "inRange": {
                 'arguments':(3, 2), 
-                'type': "content_validation"},
+                'type': "content_validation",
+                'complementary_rules': ['int','float','num','protectAges']},
             }
 
-    return type_dict
+    return rule_dict
 
 def get_error(validation_rules: list, 
         attribute_name: str, error_type: str, input_filetype:str,) -> List[str]:
@@ -139,7 +153,7 @@ def validate_single_rule(validation_rule, attribute, input_filetype):
     arguments allowed. Keep in that location and pull into this function.
     '''
     errors = []
-    validation_types = validation_type_dict()
+    validation_types = validation_rule_info()
     validation_rule_with_args = [
                 val_rule.strip() for val_rule in validation_rule.strip().split(" ")]
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -11,8 +11,7 @@ from schematic.models.validate_manifest import ValidateManifest
 from schematic.models.metadata import MetadataModel
 from schematic.store.synapse import SynapseStorage
 from schematic.schemas.generator import SchemaGenerator
-from schematic.utils.validate_rules_utils import valid_rule_combinations
-
+from schematic.utils.validate_rules_utils import validation_rule_info
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
@@ -34,10 +33,14 @@ def metadataModel(helpers):
     yield metadataModel
 
 def get_rule_combinations():
-    complementary_rules = valid_rule_combinations()
-    for base_rule, allowable_rules in complementary_rules.items():
-        for second_rule in allowable_rules:            
-            yield base_rule, second_rule
+    rule_info = validation_rule_info()
+    for base_rule, indiv_info in rule_info.items():
+        complementary_rules = indiv_info['complementary_rules']
+        if complementary_rules:
+            for second_rule in complementary_rules:
+                yield base_rule, second_rule
+        else:
+            continue
     
 class TestManifestValidation:
     def test_valid_manifest(self,helpers,metadataModel):


### PR DESCRIPTION
With the introduction of rules: `list`, `protectAges`, `unique`, and `inRange`, there are now multiple rules that allow arguments but do not require all of them to be specified every time because default behavior is defined. 

The process of declaring novel rules available to the suite has been simplified. The three dictionaries `valid_rule_combinations`, `validation_types` ( in the `validate_rules_utils.py`), and the separate `validation_types` ( in the `validate_manifest.py`) have been combined into the `validation_rule_info` dict that holds a dict of information for each rule containing arguments, type, and complementary rules available for use. New rules can now be declared in a single place, and rule spec updates are contained to one function in one file.

This PR also closes the bug in #675 where rules that required 1 argument and were missing it were not flagged as invalid.