### PR TITLE
Check type of 'url' entry when raising errors

### DIFF
--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -602,7 +602,7 @@ class ValidateAttribute(object):
         for i, url in enumerate(manifest_col):
             # Check if a random phrase, string or number was added and
             # log the appropriate error.
-            if not (
+            if not isinstance(url,str) or not (
                 urlparse(url).scheme
                 + urlparse(url).netloc
                 + urlparse(url).params


### PR DESCRIPTION
Errors arose when non-`str` type entries were input for attributes with the `url` validation rule, because numerical type values could not be parsed as strings were. Ex: [#25](https://github.com/ncihtan/HTAN-data-curator/issues/25) in the [HTAN-data-curator](https://github.com/ncihtan/HTAN-data-curator) repo
Updated the error generation criteria to check type of entries when generating errors instead of assuming type `str`.