### PR TITLE
Develop fix manifest generator

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -955,15 +955,16 @@ class ManifestGenerator(object):
             validation_body = self._get_column_data_validation_values(
                 spreadsheet_id, req_vals, i, strict=None, validation_type="ONE_OF_RANGE"
             )
-        elif ("list strict" in validation_rules) or ("list like" in validation_rules )and valid_values:
+        elif ("list strict" in validation_rules) or ("list like" in validation_rules) and valid_values:
             # if list is in validation rule attempt to create a multi-value
             # selection UI, which requires explicit valid values range in
             # the spreadsheet
+            # set "strict" parameter to false to allow users enter multiple values on google sheet
             validation_body = self._get_column_data_validation_values(
                 spreadsheet_id,
                 req_vals,
                 i,
-                strict=None,
+                strict=False,
                 custom_ui=False,
                 input_message="",
                 validation_type="ONE_OF_RANGE",

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -22,7 +22,10 @@ from schematic.store.synapse import SynapseStorage
 
 from schematic import CONFIG
 
+from schematic.utils.validate_utils import rule_in_rule_list
+
 logger = logging.getLogger(__name__)
+
 
 
 class ManifestGenerator(object):
@@ -834,7 +837,7 @@ class ManifestGenerator(object):
                 This notes body will be added to a request.
         """            
        
-        if ("list strict" in validation_rules) or ("list like" in validation_rules) and valid_values:
+        if rule_in_rule_list("list", validation_rules) and valid_values:
             note = "From 'Selection options' menu above, go to 'Select multiple values', check all items that apply, and click 'Save selected values'"
             notes_body = {
                 "requests": [
@@ -852,7 +855,7 @@ class ManifestGenerator(object):
                 ]
             }
             return notes_body["requests"]
-        elif ("list strict" in validation_rules) or ("list like" in validation_rules) and not valid_values:
+        elif rule_in_rule_list("list", validation_rules) and not valid_values:
             note = "Please enter values as a comma separated list. For example: XX, YY, ZZ"
             notes_body = {
                 "requests": [
@@ -946,7 +949,7 @@ class ManifestGenerator(object):
         Returns:
             validation_body: dict
         """
-        if len(req_vals) > 0 and not ("list strict" in validation_rules) and not ("list like" in validation_rules):
+        if len(req_vals) > 0 and not rule_in_rule_list("list", validation_rules):
             # if more than 0 values in dropdown use ONE_OF_RANGE type of validation
             # since excel and openoffice
             # do not support other kinds of data validation for
@@ -955,7 +958,7 @@ class ManifestGenerator(object):
             validation_body = self._get_column_data_validation_values(
                 spreadsheet_id, req_vals, i, strict=None, validation_type="ONE_OF_RANGE"
             )
-        elif ("list strict" in validation_rules) or ("list like" in validation_rules) and valid_values:
+        elif rule_in_rule_list("list", validation_rules) and valid_values:
             # if list is in validation rule attempt to create a multi-value
             # selection UI, which requires explicit valid values range in
             # the spreadsheet

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -23,8 +23,6 @@ from schematic.store.synapse import SynapseStorage
 
 from schematic import CONFIG
 
-from schematic.utils.validate_utils import rule_in_rule_list
-
 logger = logging.getLogger(__name__)
 
 

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -834,7 +834,8 @@ class ManifestGenerator(object):
                 This notes body will be added to a request.
         """            
        
-        if "list" in validation_rules and valid_values:
+        #if "list" in validation_rules and valid_values:
+        if validation_rules.find("list") and valid_values:
             note = "From 'Selection options' menu above, go to 'Select multiple values', check all items that apply, and click 'Save selected values'"
             notes_body = {
                 "requests": [

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -834,8 +834,7 @@ class ManifestGenerator(object):
                 This notes body will be added to a request.
         """            
        
-        #if "list" in validation_rules and valid_values:
-        if validation_rules.find("list") and valid_values:
+        if ("list strict" in validation_rules) or ("list like" in validation_rules) and valid_values:
             note = "From 'Selection options' menu above, go to 'Select multiple values', check all items that apply, and click 'Save selected values'"
             notes_body = {
                 "requests": [
@@ -853,7 +852,7 @@ class ManifestGenerator(object):
                 ]
             }
             return notes_body["requests"]
-        elif "list" in validation_rules and not valid_values:
+        elif ("list strict" in validation_rules) or ("list like" in validation_rules) and not valid_values:
             note = "Please enter values as a comma separated list. For example: XX, YY, ZZ"
             notes_body = {
                 "requests": [
@@ -947,7 +946,7 @@ class ManifestGenerator(object):
         Returns:
             validation_body: dict
         """
-        if len(req_vals) > 0 and not "list" in validation_rules:
+        if len(req_vals) > 0 and not ("list strict" in validation_rules) and not ("list like" in validation_rules):
             # if more than 0 values in dropdown use ONE_OF_RANGE type of validation
             # since excel and openoffice
             # do not support other kinds of data validation for
@@ -956,7 +955,7 @@ class ManifestGenerator(object):
             validation_body = self._get_column_data_validation_values(
                 spreadsheet_id, req_vals, i, strict=None, validation_type="ONE_OF_RANGE"
             )
-        elif "list" in validation_rules and valid_values:
+        elif ("list strict" in validation_rules) or ("list like" in validation_rules )and valid_values:
             # if list is in validation rule attempt to create a multi-value
             # selection UI, which requires explicit valid values range in
             # the spreadsheet

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -20,8 +20,9 @@ Genome Build,,"GRCh37, GRCh38, GRCm38, GRCm39",,,TRUE,DataProperty,,,
 Genome FASTA,,,,,TRUE,DataProperty,,,
 MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range",,FALSE,DataType,,,
 Check List,,"ab, cd, ef, gh",,,FALSE,DataProperty,,,list strict
-Check Regex List,,,,,FALSE,DataProperty,,,list::regex match [a-f]
+Check Regex List,,,,,FALSE,DataProperty,,,list strict::regex match [a-f]
 Check Regex Single,,,,,FALSE,DataProperty,,,regex search [a-f]
+Check Regex Format,,,,,FALSE,DataProperty,,,regex match [a-f]
 Check Num,,,,,FALSE,DataProperty,,,num
 Check Float,,,,,FALSE,DataProperty,,,float
 Check Int,,,,,FALSE,DataProperty,,,int

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -19,7 +19,7 @@ CSV/TSV,,,Genome Build,,FALSE,ValidValue,,,
 Genome Build,,"GRCh37, GRCh38, GRCm38, GRCm39",,,TRUE,DataProperty,,,
 Genome FASTA,,,,,TRUE,DataProperty,,,
 MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range",,FALSE,DataType,,,
-Check List,,,,,FALSE,DataProperty,,,list
+Check List,,"ab, cd, ef, gh",,,FALSE,DataProperty,,,list strict
 Check Regex List,,,,,FALSE,DataProperty,,,list::regex match [a-f]
 Check Regex Single,,,,,FALSE,DataProperty,,,regex search [a-f]
 Check Num,,,,,FALSE,DataProperty,,,num

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -1,4 +1,4 @@
-﻿Attribute,Description,Valid Values,DependsOn,Properties,Required,Parent,DependsOn Component,Source,Validation Rules
+Attribute,Description,Valid Values,DependsOn,Properties,Required,Parent,DependsOn Component,Source,Validation Rules
 Patient,,,"Patient ID, Sex, Year of Birth, Diagnosis, Component",,FALSE,DataType,,,
 Patient ID,,,,,TRUE,DataProperty,,,
 Sex,,"Female, Male, Other",,,TRUE,DataProperty,,,

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -18,7 +18,7 @@ CRAM,,,"Genome Build, Genome FASTA",,FALSE,ValidValue,,,
 CSV/TSV,,,Genome Build,,FALSE,ValidValue,,,
 Genome Build,,"GRCh37, GRCh38, GRCm38, GRCm39",,,TRUE,DataProperty,,,
 Genome FASTA,,,,,TRUE,DataProperty,,,
-MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range",,FALSE,DataType,,,
+MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range",,FALSE,DataType,,,
 Check List,,"ab, cd, ef, gh",,,FALSE,DataProperty,,,list strict
 Check Regex List,,,,,FALSE,DataProperty,,,list strict::regex match [a-f]
 Check Regex Single,,,,,FALSE,DataProperty,,,regex search [a-f]

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2586,7 +2586,7 @@
             "sms:displayName": "Check Regex List",
             "sms:required": "sms:false",
             "sms:validationRules": [
-                "list",
+                "list strict",
                 "regex match [a-f]"
             ]
         },
@@ -2607,6 +2607,25 @@
             "sms:required": "sms:false",
             "sms:validationRules": [
                 "regex search [a-f]"
+            ]
+        },
+        {
+            "@id": "bts:CheckRegexFormat",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckRegexFormat",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Regex Format",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "regex match [a-f]"
             ]
         },
         {

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2550,6 +2550,20 @@
             "schema:isPartOf": {
                 "@id": "http://schema.biothings.io"
             },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:Ab"
+                },
+                {
+                    "@id": "bts:Cd"
+                },
+                {
+                    "@id": "bts:Ef"
+                },
+                {
+                    "@id": "bts:Gh"
+                }
+            ],
             "sms:displayName": "Check List",
             "sms:required": "sms:false",
             "sms:validationRules": [
@@ -2572,7 +2586,7 @@
             "sms:displayName": "Check Regex List",
             "sms:required": "sms:false",
             "sms:validationRules": [
-                "list strict",
+                "list",
                 "regex match [a-f]"
             ]
         },
@@ -3111,6 +3125,74 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "GRCm39",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Ab",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Ab",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CheckList"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "ab",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Cd",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Cd",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CheckList"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "cd",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Ef",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Ef",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CheckList"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "ef",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Gh",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Gh",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CheckList"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "gh",
             "sms:required": "sms:false",
             "sms:validationRules": []
         }

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2496,6 +2496,9 @@
                     "@id": "bts:CheckRegexSingle"
                 },
                 {
+                    "@id": "bts:CheckRegexFormat"
+                },
+                {
                     "@id": "bts:CheckNum"
                 },
                 {

--- a/tests/data/mock_manifests/Invalid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Invalid_Test_Manifest.csv
@@ -1,4 +1,4 @@
-Component,Check List,Check Regex List,Check Regex Single,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range
-MockComponent,"valid,list,values","ab,cd,ef",a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,,6549,str1,70
-MockComponent,invalid list values,ab cd ef,q,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,,32851,str1,30
-MockComponent,"valid,list,values","ab,cd,ef",b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,210065,,6550,str1,90
+Component,Check List,Check Regex List,Check Regex Format,Check Regex Single,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range
+MockComponent,"ab,cd","ab,cd,ef",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,,6549,str1,70
+MockComponent,invalid list values,ab cd ef,m,q,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,,32851,str1,30
+MockComponent,"ab,cd","ab,cd,ef",b,b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,210065,,6550,str1,90

--- a/tests/data/mock_manifests/Valid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Valid_Test_Manifest.csv
@@ -1,5 +1,5 @@
-Component,Check List,Check Regex List,Check Regex Single,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range
-MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,,6571,str1,75
-MockComponent,"valid,list,values","a,c,f",e,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80
-MockComponent,"valid,list,values","b,d,f",b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,1738,present,32849,str3,95
-MockComponent,"valid,list,values","b,d,f",b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,79,79,7,7,,32849,str4,55
+Component,Check List,Check Regex List,Check Regex Single,Check Regex Format, Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range
+MockComponent,"ab,cd","a,c,f",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,,6571,str1,75
+MockComponent,"ab,cd","a,c,f",e,b,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80
+MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,present,32849,str3,95
+MockComponent,"ab,cd","b,d,f",b,f,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,32849,str4,55

--- a/tests/data/mock_manifests/Valid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Valid_Test_Manifest.csv
@@ -2,4 +2,4 @@ Component,Check List,Check Regex List,Check Regex Single,Check Regex Format, Che
 MockComponent,"ab,cd","a,c,f",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,,6571,str1,75
 MockComponent,"ab,cd","a,c,f",e,b,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80
 MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,present,32849,str3,95
-MockComponent,"ab,cd","b,d,f",b,f,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,32849,str4,55
+MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,32849,str4,55

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -250,7 +250,16 @@ class TestManifestValidation:
             attribute_name = 'Check Regex Single',
             module_to_call = 'search',
             invalid_entry = 'q'
-            ) in errors   
+            ) in errors 
+
+        assert GenerateError.generate_regex_error(
+            val_rule = 'regex',
+            reg_expression = '[a-f]',
+            row_num = '3',
+            attribute_name = 'Check Regex Format',
+            module_to_call = 'match',
+            invalid_entry = 'm'
+            ) in errors     
 
         assert GenerateError.generate_url_error(
             url = 'http://googlef.com/',

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -104,6 +104,15 @@ class TestManifestValidation:
             val_rule = 'regex',
             reg_expression = '[a-f]',
             row_num = '3',
+            attribute_name = 'Check Regex Format',
+            module_to_call = 'match',
+            invalid_entry = 'm'
+            ) in errors   
+
+        assert GenerateError.generate_regex_error(
+            val_rule = 'regex',
+            reg_expression = '[a-f]',
+            row_num = '3',
             attribute_name = 'Check Regex Single',
             module_to_call = 'search',
             invalid_entry = 'q'


### PR DESCRIPTION
I updated the following: 
* For "Check List", changed it from "list" to "list strict" 
* "check list" now takes the following valid values: `ab, cd, ef, gh`
* For attribute "Check Regex List", change "list::regex match [a-f]" to "list strict::regex match [a-f]" 
* Add an additional attribute in data model: Check Regex Format
* Update invalid_test_manifest.csv and valid_test_manifest.csv
* Update example.model.jsonld
 
In addition, I also updated the ManifestGenerator class so that something like `elif "list" in validation_rules and values` gets changed to `elif ("list strict" in validation_rules) or ("list like" in validation_rules) and valid_values`

When I created the manifest based on the example data model and opened it in Firefox (see an example here: https://docs.google.com/spreadsheets/d/1Ax_fb-TdQK67i9B60rncjAffVYJ8_hNKpguXBuIEH3k/edit#gid=0), I could now see a list of valid values for "Check List" in sheet 2. 


> But when I tried to enter a comma separated list under column "Check List" in sheet 1, I still got an error message related to the data validation rules. Should we update the "Data validation" rule as "On invalid data: show warning" instead of "Reject input" so that a comma separate list could show up?



^^ Note: In my code, for list in validation rule that allows multi-selection, I set "strict" to "False" so that users could enter multiple values. See here: https://github.com/Sage-Bionetworks/schematic/pull/847/files#:~:text=%3DNone%2C-,strict%3DFalse%2C,-custom_ui%3DFalse


> If we can't change all the "list" to "list like"/"list strict" in all existing data models, should we still maintain the logic related to "list"?

^^ Note: all the old logic related to "list" in schemaGenerator was handled by branch `develop-listlike-behavior`. After merging that branch with this branch here, there seems to be no more test errors. 