### PR TITLE
add warning to validate_manifest endpoint

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -170,11 +170,13 @@ def validate_manifest_route(schema_url, data_type):
         inputMModelLocation=jsonld, inputMModelLocationType="local"
     )
 
-    errors = metadata_model.validateModelManifest(
+    errors, warnings = metadata_model.validateModelManifest(
         manifestPath=temp_path, rootNode=data_type
     )
+    
+    res_dict = {"errors": errors, "warnings": warnings}
 
-    return errors
+    return res_dict
 
 
 def submit_manifest_route(schema_url, manifest_record_type=None):


### PR DESCRIPTION
Currently, the `validate_manifest_route` endpoint only returns error messages. I added some small changes so that it also returns warning messages. 

This is requested by @afwillia for the dashboard. 