### PR TITLE
Develop blank annotation behavior

### DIFF
--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -761,7 +761,7 @@ class ValidateAttribute(object):
                         val_rule = val_rule,
                         row_num = str(list(invalid_rows)), 
                         attribute_name = source_attribute, 
-                        invalid_entry = str(invalid_values.squeeze().values.tolist()) 
+                        invalid_entry = str(pd.Series(invalid_values.squeeze()).values.tolist()) 
                     )
                 )
             

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -698,17 +698,19 @@ class SynapseStorage(BaseStorage):
         annos = self.syn.get_annotations(entityId)
         csv_list_regex=comma_separated_list_regex()
         for anno_k, anno_v in metadataSyn.items():
-            #Do not save blank annotations as NaNs,
-            #remove keys with nan/blank values from dict of annotations to be uploaded if present on current data annotation
-            if isinstance(anno_v,float) and np.isnan(anno_v):
-                if hideBlanks:
-                    annos.pop(anno_k) if anno_k in annos.keys() else annos
-                else:
-                    annos[anno_k] = ""
-            elif isinstance(anno_v,str) and re.fullmatch(csv_list_regex, anno_v) and rule_in_rule_list('list', sg.get_node_validation_rules(anno_k)):
-                annos[anno_k] = anno_v.split(",")
+            
+            # Remove keys with nan or empty string values from dict of annotations to be uploaded
+            # if present on current data annotation
+            if hideBlanks and (anno_v == '' or (isinstance(anno_v,float) and np.isnan(anno_v))):
+                annos.pop(anno_k) if anno_k in annos.keys() else annos
+            # Otherwise save annotation as approrpriate
             else:
-                annos[anno_k] = anno_v
+                if isinstance(anno_v,float) and np.isnan(anno_v):
+                        annos[anno_k] = ""
+                elif isinstance(anno_v,str) and re.fullmatch(csv_list_regex, anno_v) and rule_in_rule_list('list', sg.get_node_validation_rules(anno_k)):
+                    annos[anno_k] = anno_v.split(",")
+                else:
+                    annos[anno_k] = anno_v
                 
         return annos
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import platform
 
 import pytest
 import pandas as pd
@@ -62,6 +63,9 @@ class Helpers:
         se.load_schema(fullpath)
         return se
 
+    @staticmethod
+    def get_python_verion():
+        return platform.python_version()
 
 @pytest.fixture
 def helpers():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 import os
 import logging
 import platform
@@ -65,12 +66,32 @@ class Helpers:
         return se
 
     @staticmethod
-    def duplicate_unique_manifest(self, path):
+    def duplicate_version_specific_manifest(self, path):
         version=platform.python_version()
         manifest_path = self.get_data_path(path)
         temp_manifest_path = manifest_path.replace('.csv',version+'.csv')
         shutil.copyfile(manifest_path,temp_manifest_path)
         return temp_manifest_path
+
+    @staticmethod
+    def get_version_specific_syn_dataset():
+        version=platform.python_version()
+
+        synId = None
+
+        if version.startswith('3.7'):
+            synId = 'syn34999062'
+        elif version.startswith('3.8'):
+            synId = 'syn34999080'
+        elif version.startswith('3.9'):
+            synId = 'syn34999096'
+
+        if not synId:
+            raise OSError(
+                "Unsupported Version of Python"
+            )
+        else:
+            return synId
 
 @pytest.fixture
 def helpers():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import logging
 import platform
 
+import shutil
 import pytest
 import pandas as pd
 from dotenv import load_dotenv, find_dotenv
@@ -64,8 +65,12 @@ class Helpers:
         return se
 
     @staticmethod
-    def get_python_verion():
-        return platform.python_version()
+    def duplicate_unique_manifest(self, path):
+        version=platform.python_version()
+        manifest_path = self.get_data_path(path)
+        temp_manifest_path = manifest_path.replace('.csv',version+'.csv')
+        shutil.copyfile(manifest_path,temp_manifest_path)
+        return temp_manifest_path
 
 @pytest.fixture
 def helpers():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,11 +66,10 @@ class Helpers:
         return se
 
     @staticmethod
-    def duplicate_version_specific_manifest(self, path):
+    def get_version_specific_manifest_path(self, path):
         version=platform.python_version()
         manifest_path = self.get_data_path(path)
-        temp_manifest_path = manifest_path.replace('.csv',version+'.csv')
-        shutil.copyfile(manifest_path,temp_manifest_path)
+        temp_manifest_path = manifest_path.replace('.csv',version[0:3]+'.csv')
         return temp_manifest_path
 
     @staticmethod

--- a/tests/data/mock_manifests/annotations_test_manifest.csv
+++ b/tests/data/mock_manifests/annotations_test_manifest.csv
@@ -1,2 +1,2 @@
-Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique,Uuid,entityId
-MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,d20871ee-bf7c-42f1-bef0-aff91ede5c50,syn34298753
+,Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique
+0,MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1

--- a/tests/data/mock_manifests/annotations_test_manifest.csv
+++ b/tests/data/mock_manifests/annotations_test_manifest.csv
@@ -1,3 +1,3 @@
-,Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique
-0,MockComponent,"valid,list,values","a,c,f",a,6,99.65,7.0,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1
-1,MockComponent,"valid,list,values","a,c,f",a,6,99.65,7.52,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1
+Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique,Uuid,entityId
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,f1c82885-e0eb-45e2-9796-2679a5daf628,syn34528414
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,8.52,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,4eebef0b-02c1-41c3-9a53-5643dc699794,syn34528415

--- a/tests/data/mock_manifests/annotations_test_manifest.csv
+++ b/tests/data/mock_manifests/annotations_test_manifest.csv
@@ -1,0 +1,2 @@
+Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique,Uuid,entityId
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,d20871ee-bf7c-42f1-bef0-aff91ede5c50,syn34298753

--- a/tests/data/mock_manifests/annotations_test_manifest.csv
+++ b/tests/data/mock_manifests/annotations_test_manifest.csv
@@ -1,3 +1,3 @@
-Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique,Uuid,entityId
-MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,f1c82885-e0eb-45e2-9796-2679a5daf628,syn34528414
-MockComponent,"valid,list,values","a,c,f",a,6,99.65,8.52,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,4eebef0b-02c1-41c3-9a53-5643dc699794,syn34528415
+Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,8.52,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1

--- a/tests/data/mock_manifests/annotations_test_manifest.csv
+++ b/tests/data/mock_manifests/annotations_test_manifest.csv
@@ -1,2 +1,3 @@
 ,Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique
-0,MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1
+0,MockComponent,"valid,list,values","a,c,f",a,6,99.65,7.0,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1
+1,MockComponent,"valid,list,values","a,c,f",a,6,99.65,7.52,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1

--- a/tests/data/mock_manifests/annotations_test_manifest3.7.csv
+++ b/tests/data/mock_manifests/annotations_test_manifest3.7.csv
@@ -1,0 +1,3 @@
+Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique,Uuid,entityId
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,c1effded-549d-4a9a-9436-d8c1709e5695,syn35005002
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,8.52,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,cdd85e6d-347f-489e-be81-ebc711f5db7d,syn35005007

--- a/tests/data/mock_manifests/annotations_test_manifest3.8.csv
+++ b/tests/data/mock_manifests/annotations_test_manifest3.8.csv
@@ -1,0 +1,3 @@
+Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique,Uuid,entityId
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,205bacf2-de39-4444-8ae7-d4a692524636,syn35005129
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,8.52,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,8f57de31-870c-4f79-84da-b35ed266c902,syn35005133

--- a/tests/data/mock_manifests/annotations_test_manifest3.9.csv
+++ b/tests/data/mock_manifests/annotations_test_manifest3.9.csv
@@ -1,0 +1,3 @@
+Component,CheckList,CheckRegexList,CheckRegexSingle,CheckNum,CheckFloat,CheckInt,CheckString,CheckURL,CheckMatchatLeast,CheckMatchatLeastvalues,CheckMatchExactly,CheckMatchExactlyvalues,CheckRecommended,CheckAges,CheckUnique,Uuid,entityId
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,ab6c9164-7ffc-4603-81db-7c96351e19c2,syn35005820
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,8.52,valid,https://www.google.com/,1985,4891,23487492,24323472834,,6571,str1,533fe875-b95a-4a63-9990-bc243cf7bb0d,syn35005823

--- a/tests/data/test_config.yml
+++ b/tests/data/test_config.yml
@@ -9,6 +9,11 @@ synapse:
   master_fileview: "syn23643253"
   manifest_basename: "data/manifests/synapse_storage_manifest"
 
+model:
+  input:
+    location: 'example.model.jsonld'
+    file_type: 'local'
+
 style:
   google_manifest:
     master_template_id: '1LYS5qE4nV9jzcYw5sXwCza25slDfRA1CIg3cs-hCdpU'

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -83,7 +83,7 @@ class TestSynapseStorage:
     def test_annotation_submission(self, synapse_store, helpers, config):
         # Duplicate base file to avoid conflicts
         manifest_path = "mock_manifests/annotations_test_manifest.csv"
-        temp_manifest_path = helpers.duplicate_unique_manifest(helpers, manifest_path)
+        temp_manifest_path = helpers.duplicate_version_specific_manifest(helpers, manifest_path)
 
         # Upload dataset annotations
         inputModelLocaiton = helpers.get_data_path(get_from_config(config.DATA, ("model", "input", "location")))
@@ -92,7 +92,7 @@ class TestSynapseStorage:
         manifest_id = synapse_store.associateMetadataWithFiles(
             schemaGenerator=sg,
             metadataManifestPath=temp_manifest_path,
-            datasetId='syn34295552',
+            datasetId=helpers.get_version_specific_syn_dataset(),
             manifest_record_type = 'entity',
             useSchemaLabel = True,
             hideBlanks = True,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -113,7 +113,7 @@ class TestSynapseStorage:
                 restrict_manifest = False,
             )
 
-        entity_id = helpers.get_data_frame(manifest_path)["entityId"][0]
+        entity_id, entity_id_spare = helpers.get_data_frame(manifest_path)["entityId"][0:2]
         annotations = synapse_store.getFileAnnotations(entity_id)
 
         assert annotations['CheckInt'] == '7'
@@ -128,6 +128,7 @@ class TestSynapseStorage:
         manifest.to_csv(manifest_path)
         # Remove manifest and entity from synapse to avoid file conflicts
         synapse_store.syn.delete(entity_id)
+        synapse_store.syn.delete(entity_id_spare)
         synapse_store.syn.delete(manifest_id)
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -83,12 +83,13 @@ class TestSynapseStorage:
     def test_annotation_submission(self, synapse_store, helpers, config):
         # Duplicate base file to avoid conflicts
         manifest_path = "mock_manifests/annotations_test_manifest.csv"
-        temp_manifest_path = helpers.duplicate_version_specific_manifest(helpers, manifest_path)
+        temp_manifest_path = helpers.get_version_specific_manifest_path(helpers, manifest_path)
 
         # Upload dataset annotations
         inputModelLocaiton = helpers.get_data_path(get_from_config(config.DATA, ("model", "input", "location")))
         sg = SchemaGenerator(inputModelLocaiton)
 
+        
         manifest_id = synapse_store.associateMetadataWithFiles(
             schemaGenerator=sg,
             metadataManifestPath=temp_manifest_path,
@@ -98,17 +99,11 @@ class TestSynapseStorage:
             hideBlanks = True,
             restrict_manifest = False,
         )
+        
 
         # Retrive annotations
         entity_id, entity_id_spare = helpers.get_data_frame(temp_manifest_path)["entityId"][0:2]
         annotations = synapse_store.getFileAnnotations(entity_id)
-
-        ## Clean up
-        os.remove(temp_manifest_path)
-        # Remove manifest and entities from synapse to avoid file conflicts
-        synapse_store.syn.delete(entity_id)
-        synapse_store.syn.delete(entity_id_spare)
-        synapse_store.syn.delete(manifest_id)
 
         # Check annotations of interest
         assert annotations['CheckInt'] == '7'

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -45,24 +45,6 @@ def dataset_fileview_table_tidy(dataset_fileview, dataset_fileview_table):
     table = dataset_fileview.tidy_table()
     yield table
 
-@pytest.fixture
-def manfifest_and_path(helpers):
-    manifest_path = helpers.get_data_path("mock_manifests/annotations_test_manifest.csv")
-
-    manifest = helpers.get_data_frame(manifest_path)
-    if 'Uuid' in manifest.columns:
-        manifest = manifest.drop(['Uuid','entityId'], axis=1)
-        manifest.to_csv(manifest_path)
-
-    yield manifest, manifest_path
-
-@pytest.fixture
-def schemagenerator(helpers):
-    inputModelLocaiton = helpers.get_data_path(get_from_config(config.DATA, ("model", "input", "location")))
-    sg = SchemaGenerator(inputModelLocaiton)
-
-    yield sg
-
 
 class TestBaseStorage:
     def test_init(self):
@@ -99,8 +81,17 @@ class TestSynapseStorage:
 
 
     @pytest.mark.parametrize("hide_blanks",[True, False],ids=["hide_blanks","show_blanks"])
-    def test_annotation_submission(self, synapse_store, helpers, config, manifest, manifest_path, sg, hide_blanks):
+    def test_annotation_submission(self, synapse_store, helpers, config, hide_blanks):
 
+        manifest_path = helpers.get_data_path("mock_manifests/annotations_test_manifest.csv")
+        inputModelLocaiton = helpers.get_data_path(get_from_config(config.DATA, ("model", "input", "location")))
+
+        sg = SchemaGenerator(inputModelLocaiton)
+
+        manifest = helpers.get_data_frame(manifest_path)
+        if 'Uuid' in manifest.columns:
+            manifest = manifest.drop(['Uuid','entityId'], axis=1)
+            manifest.to_csv(manifest_path)
 
         manifest_id = synapse_store.associateMetadataWithFiles(
             schemaGenerator=sg,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -79,7 +79,7 @@ class TestSynapseStorage:
 
         assert expected_dict == actual_dict
 
-    def test_annotation_submission(self, synapse_store, helpers, config, hide_blanks):
+    def test_annotation_submission(self, synapse_store, helpers, config):
 
         manifest_path = helpers.get_data_path("mock_manifests/annotations_test_manifest.csv")
         inputModelLocaiton = helpers.get_data_path(get_from_config(config.DATA, ("model", "input", "location")))
@@ -93,7 +93,7 @@ class TestSynapseStorage:
                 datasetId='syn34295552',
                 manifest_record_type = 'entity',
                 useSchemaLabel = True,
-                hideBlanks = hide_blanks,
+                hideBlanks = True,
                 restrict_manifest = False,
             )
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3,6 +3,7 @@ import os
 import math
 import logging
 import pytest
+import time
 
 import pandas as pd
 from synapseclient import EntityViewSchema
@@ -89,16 +90,28 @@ class TestSynapseStorage:
         inputModelLocaiton = helpers.get_data_path(get_from_config(config.DATA, ("model", "input", "location")))
         sg = SchemaGenerator(inputModelLocaiton)
 
-        
-        manifest_id = synapse_store.associateMetadataWithFiles(
-            schemaGenerator=sg,
-            metadataManifestPath=temp_manifest_path,
-            datasetId=helpers.get_version_specific_syn_dataset(),
-            manifest_record_type = 'entity',
-            useSchemaLabel = True,
-            hideBlanks = True,
-            restrict_manifest = False,
-        )
+        try:        
+            manifest_id = synapse_store.associateMetadataWithFiles(
+                schemaGenerator=sg,
+                metadataManifestPath=temp_manifest_path,
+                datasetId=helpers.get_version_specific_syn_dataset(),
+                manifest_record_type = 'entity',
+                useSchemaLabel = True,
+                hideBlanks = True,
+                restrict_manifest = False,
+            )
+        except(SynapseHTTPError):
+            time.sleep(30)
+            
+            manifest_id = synapse_store.associateMetadataWithFiles(
+                schemaGenerator=sg,
+                metadataManifestPath=temp_manifest_path,
+                datasetId=helpers.get_version_specific_syn_dataset(),
+                manifest_record_type = 'entity',
+                useSchemaLabel = True,
+                hideBlanks = True,
+                restrict_manifest = False,
+            )
         
 
         # Retrive annotations

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -88,6 +88,11 @@ class TestSynapseStorage:
 
         sg = SchemaGenerator(inputModelLocaiton)
 
+        manifest = helpers.get_data_frame(manifest_path)
+        if 'Uuid' in manifest.columns:
+            manifest = manifest.drop(['Uuid','entityId'], axis=1)
+            manifest.to_csv(manifest_path)
+
         manifest_id = synapse_store.associateMetadataWithFiles(
             schemaGenerator=sg,
             metadataManifestPath=manifest_path,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -118,10 +118,7 @@ class TestSynapseStorage:
 
         assert annotations['CheckInt'] == '7'
         assert annotations['CheckList'] == 'valid, list, values'
-        if hide_blanks:
-            assert 'CheckRecommended' not in annotations.keys()
-        elif not hide_blanks:
-            assert annotations['CheckRecommended'] == ''
+        assert 'CheckRecommended' not in annotations.keys()
 
         ## Clean up
         # Remove uuid and entityId from manifest and save, 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -79,8 +79,6 @@ class TestSynapseStorage:
 
         assert expected_dict == actual_dict
 
-
-    @pytest.mark.parametrize("hide_blanks",[True, False],ids=["hide_blanks","show_blanks"])
     def test_annotation_submission(self, synapse_store, helpers, config, hide_blanks):
 
         manifest_path = helpers.get_data_path("mock_manifests/annotations_test_manifest.csv")
@@ -111,7 +109,7 @@ class TestSynapseStorage:
                 datasetId='syn34295552',
                 manifest_record_type = 'entity',
                 useSchemaLabel = True,
-                hideBlanks = hide_blanks,
+                hideBlanks = True,
                 restrict_manifest = False,
             )
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -13,7 +13,6 @@ from schematic.store.synapse import SynapseStorage, DatasetFileView
 from schematic.utils.cli_utils import get_from_config
 from schematic.schemas.generator import SchemaGenerator
 from synapseclient.core.exceptions import SynapseHTTPError
-from csv import QUOTE_NONNUMERIC
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3,8 +3,6 @@ import os
 import math
 import logging
 import pytest
-import platform
-import shutil
 
 import pandas as pd
 from synapseclient import EntityViewSchema
@@ -84,10 +82,8 @@ class TestSynapseStorage:
 
     def test_annotation_submission(self, synapse_store, helpers, config):
         # Duplicate base file to avoid conflicts
-        version=helpers.get_python_verion()
-        manifest_path = helpers.get_data_path("mock_manifests/annotations_test_manifest.csv")
-        temp_manifest_path = manifest_path.replace('.csv',version+'.csv')
-        shutil.copyfile(manifest_path,temp_manifest_path)
+        manifest_path = "mock_manifests/annotations_test_manifest.csv"
+        temp_manifest_path = helpers.duplicate_unique_manifest(helpers, manifest_path)
 
         # Upload dataset annotations
         inputModelLocaiton = helpers.get_data_path(get_from_config(config.DATA, ("model", "input", "location")))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -45,6 +45,24 @@ def dataset_fileview_table_tidy(dataset_fileview, dataset_fileview_table):
     table = dataset_fileview.tidy_table()
     yield table
 
+@pytest.fixture
+def manfifest_and_path(helpers):
+    manifest_path = helpers.get_data_path("mock_manifests/annotations_test_manifest.csv")
+
+    manifest = helpers.get_data_frame(manifest_path)
+    if 'Uuid' in manifest.columns:
+        manifest = manifest.drop(['Uuid','entityId'], axis=1)
+        manifest.to_csv(manifest_path)
+
+    yield manifest, manifest_path
+
+@pytest.fixture
+def schemagenerator(helpers):
+    inputModelLocaiton = helpers.get_data_path(get_from_config(config.DATA, ("model", "input", "location")))
+    sg = SchemaGenerator(inputModelLocaiton)
+
+    yield sg
+
 
 class TestBaseStorage:
     def test_init(self):
@@ -81,17 +99,8 @@ class TestSynapseStorage:
 
 
     @pytest.mark.parametrize("hide_blanks",[True, False],ids=["hide_blanks","show_blanks"])
-    def test_annotation_submission(self, synapse_store, helpers, config, hide_blanks):
+    def test_annotation_submission(self, synapse_store, helpers, config, manifest, manifest_path, sg, hide_blanks):
 
-        manifest_path = helpers.get_data_path("mock_manifests/annotations_test_manifest.csv")
-        inputModelLocaiton = helpers.get_data_path(get_from_config(config.DATA, ("model", "input", "location")))
-
-        sg = SchemaGenerator(inputModelLocaiton)
-
-        manifest = helpers.get_data_frame(manifest_path)
-        if 'Uuid' in manifest.columns:
-            manifest = manifest.drop(['Uuid','entityId'], axis=1)
-            manifest.to_csv(manifest_path)
 
         manifest_id = synapse_store.associateMetadataWithFiles(
             schemaGenerator=sg,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -84,7 +84,7 @@ class TestSynapseStorage:
 
     def test_annotation_submission(self, synapse_store, helpers, config):
         # Duplicate base file to avoid conflicts
-        version=platform.python_version()
+        version=helpers.get_python_verion()
         manifest_path = helpers.get_data_path("mock_manifests/annotations_test_manifest.csv")
         temp_manifest_path = manifest_path.replace('.csv',version+'.csv')
         shutil.copyfile(manifest_path,temp_manifest_path)


### PR DESCRIPTION
Addresses #733, which is related to #402 that was previously addressed by #579. 
This PR extends the functionality of #579, which was previously contained to the handling of `NA` or `NULL` values.
Now, `hide_blanks` will prevent both empty string values and `NULL` values from being uploaded as annotations.

Also, out of necessity and in response to [#173](https://github.com/nf-osi/nf-metadata-dictionary/issues/173), an additional test was added that submits a manifest to annotate a dataset and verifies that the annotations for the matching entity on synapse are correct. Currently the test assertions are written to cover issues raised with `int` annotations (#664), `list` annotations (#710), and empty string / `NULL` annotations (#733 / #402)

Also fixes a bug with cross manifest validation when trying to join a manifest with only one element.