### PR TITLE
update documentation for /manifest/download endpoint

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -92,7 +92,7 @@ paths:
   /manifest/download:
     get:
       summary: Endpoint to download an existing manifest
-      description: Endpoint to download an existing manifest
+      description: Endpoint to download an existing manifest. For synapse user, please update config.yml. For example, if you want to download "data_flow_status_manifest.csv", change default the value of key "manifest_basename" from "synapse_storage_manifest" to "data_flow_status_manifest"
       parameters:
         - in: query
           name: input_token


### PR DESCRIPTION
add documentation related to how to use /manifest/download endpoint in swagger UI. 

The current (new) behavior requires users to also update `manifest_basename` key in `config.yml` with the name of the manifest that users want to download. 

Question for discussion: what if user want to download different manifests with different names? Should we also allow users to enter multiple names of manifest? 