### PR TITLE
Develop Missing Entity Handling

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -619,6 +619,7 @@ class SynapseStorage(BaseStorage):
 
         return df, results
 
+    @missing_entity_handler
     def upload_format_manifest_table(self, se, manifest, datasetId, table_name, restrict, useSchemaLabel,):
         # Rename the manifest columns to display names to match fileview
         blacklist_chars = ['(', ')', '.', ' ']
@@ -723,6 +724,7 @@ class SynapseStorage(BaseStorage):
                 
         return annos
 
+    @missing_entity_handler
     def format_manifest_annotations(self, manifest, manifest_synapse_id):
         '''
         Set annotations for the manifest (as a whole) so they can be applied to the manifest table or csv.

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -133,10 +133,11 @@ class SynapseStorage(BaseStorage):
     def missing_entity_handler(method):
         def wrapper(*args, **kwargs):
             try:
-                method(*args, **kwargs)
+                return method(*args, **kwargs)
             except(SynapseHTTPError) as ex:
                 str_message = str(ex).replace("\n","")
                 logging.warning(str_message)
+                return None
         return wrapper
 
 


### PR DESCRIPTION
Per #587, attempting to annotate entities that have been deleted causes the program to crash. The deletion of these entities is assumed to be intentional, so annotation is simply skipped for the deleted entities.
The methods relating to entity annotation `upload_format_manifest_table`, `format_row_annotations`, and `format_row_annotations` have been decorated so that if a `SynapseHTTPError` is raised, it is caught and displayed so that the rest of the program can continue.