### PR TITLE
Output errors generated from jsonSchema (when submitting manifest) to the console

### DIFF
--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -34,11 +34,15 @@ class GenerateError:
             - attribute_name: the attribute the error occurred on.
             - error_msg: Error message
         '''
+        error_col = attribute_name  # Attribute name
+        error_row = row_num  # index row of the manifest where the error presented.
+        error_message = error_msg
+
         arg_error_string = (
-                f"For the attribute '{attribute_name}', on row {row_num}, {error_msg}."
-            )
+                f"For the attribute '{error_col}', on row {error_row}, {error_message}."
+        )
         logging.error(arg_error_string)
-        return [row_num, attribute_name, arg_error_string]
+        return [error_row, error_col, error_message]
 
     def generate_list_error(
         list_string: str, row_num: str, attribute_name: str, list_error: str,

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -26,6 +26,20 @@ from schematic.utils.validate_utils import parse_str_series_to_list
 logger = logging.getLogger(__name__)
 
 class GenerateError:
+    def generate_schema_error(row_num: str, attribute_name: str, error_msg: str)-> List[str]:
+        '''
+        Purpose: Process error messages generated from schema
+        Input:
+            - row_num: the row the error occurred on.
+            - attribute_name: the attribute the error occurred on.
+            - error_msg: Error message
+        '''
+        arg_error_string = (
+                f"For the attribute '{attribute_name}', on row {row_num}, {error_msg}."
+            )
+        logging.error(arg_error_string)
+        return [row_num, attribute_name, arg_error_string]
+
     def generate_list_error(
         list_string: str, row_num: str, attribute_name: str, list_error: str,
         invalid_entry:str,

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -255,10 +255,7 @@ class ValidateManifest(object):
                 attribute_name = error[1]
                 row_num = error[0]
                 errorMsg = error[3]
-                arg_error_string = (
-                f"For the attribute '{attribute_name}', on row {row_num}, {errorMsg}."
-            )
-                logging.error(arg_error_string)
+                GenerateError.generate_schema_error(row_num = row_num, attribute_name = attribute_name, error_msg = errorMsg)
 
         return errors, warnings
 

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -232,6 +232,7 @@ class ValidateManifest(object):
         
         errors = []
         warnings = []
+        col_attr = {} # save the mapping between column index and attribute name
         
         # numerical values need to be type string for the jsonValidator
         for col in manifest.select_dtypes(include=[int, np.int64, float, np.float64]).columns:
@@ -248,14 +249,15 @@ class ValidateManifest(object):
                 errorMsg = error.message[0:500]
                 errorVal = error.instance if len(error.path) > 0 else "Wrong schema"
 
-                errors.append([errorRow, errorColName, errorCol, errorMsg, errorVal])
-            
+                errors.append([errorRow, errorCol, errorMsg, errorVal])
+                col_attr[errorCol] = errorColName
         if errors: 
             for error in errors: 
-                attribute_name = error[1]
                 row_num = error[0]
-                errorMsg = error[3]
-                GenerateError.generate_schema_error(row_num = row_num, attribute_name = attribute_name, error_msg = errorMsg)
+                col_index = error[1]
+                attr_name = col_attr[col_index]
+                errorMsg = error[2]
+                GenerateError.generate_schema_error(row_num = row_num, attribute_name = attr_name, error_msg = errorMsg)
 
         return errors, warnings
 

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -244,10 +244,22 @@ class ValidateManifest(object):
             for error in sorted(v.iter_errors(annotation), key=exceptions.relevance):
                 errorRow = i + 2
                 errorCol = error.path[-1] if len(error.path) > 0 else "Wrong schema"
+                errorColName = error.path[0] if len(error.path) > 0 else "Wrong schema"
                 errorMsg = error.message[0:500]
                 errorVal = error.instance if len(error.path) > 0 else "Wrong schema"
 
-                errors.append([errorRow, errorCol, errorMsg, errorVal])
+                errors.append([errorRow, errorColName, errorCol, errorMsg, errorVal])
+            
+        if errors: 
+            for error in errors: 
+                attribute_name = error[1]
+                row_num = error[0]
+                errorMsg = error[3]
+                arg_error_string = (
+                f"For the attribute '{attribute_name}', on row {row_num}, {errorMsg}."
+            )
+                logging.error(arg_error_string)
+
         return errors, warnings
 
 


### PR DESCRIPTION
This PR is related to the issue mentioned [here](https://github.com/Sage-Bionetworks/schematic/issues/867)

Currently, when using CLI to submit manifest, if there's an error in the manifest that is related to JSON Schema, the error won't get posted in the console. 

Here's the new behavior by using `schematic model -c config.yml submit -mp /Users/lpeng/Documents/test-schematic/CA184897.csv -d syn33691763 -vc DatasetView -mrt table`: 

```
error: For the attribute 'Dataset Tissue', on row 2, '' is not one of ['Omentum', 'Bile Duct', 'Bone Marrow', 'Adipose Tissue', 'Small Intestine', 'Lymphoid Tissue', 'Trachea', 'Testis', 'Foreskin', 'Tendon', 'Embryo', 'Nervous System', 'Skin', 'Frontal Lobe', 'Cervix Uteri', 'Adrenal Gland', 'Bladder', 'Embryonic Heart', 'Fallopian Tube', 'Sclera', 'Main Bronchus', 'Abdominal Esophagus', 'Vagina', 'Tongue', 'Gastrointestinal Tract', 'Pending Annotation', 'Spinal Cord', 'Meninges', 'Pleura', 'Nasal Cavity', 'Esophagus', 'Salivary Gland', 'Ascendin.
error: For the attribute 'Dataset Tissue', on row 3, '' is not one of ['Omentum', 'Bile Duct', 'Bone Marrow', 'Adipose Tissue', 'Small Intestine', 'Lymphoid Tissue', 'Trachea', 'Testis', 'Foreskin', 'Tendon', 'Embryo', 'Nervous System', 'Skin', 'Frontal Lobe', 'Cervix Uteri', 'Adrenal Gland', 'Bladder', 'Embryonic Heart', 'Fallopian Tube', 'Sclera', 'Main Bronchus', 'Abdominal Esophagus', 'Vagina', 'Tongue', 'Gastrointestinal Tract', 'Pending Annotation', 'Spinal Cord', 'Meninges', 'Pleura', 'Nasal Cavity', 'Esophagus', 'Salivary Gland', 'Ascendin.
error: Validation errors resulted while validating with 'DatasetView'.
```