### PR TITLE
add project id parameter for user to submit manifest as a table

### DIFF
--- a/schematic/help.py
+++ b/schematic/help.py
@@ -88,6 +88,10 @@ model_commands = {
                 "This is a boolean flag. If flag is provided when command line utility is executed, annotations with blank values will be hidden from a dataset's annotation list in Synaspe."
                 "If not, annotations with blank values will be displayed."
             ),
+            "project_id":(
+                "Specify the synID of the project folder on Synapse to which you intend to submit. "
+                "This is relevant for submitting manifest as a table"
+            ),            
             "manifest_record_type":(
                 "Specify the way the manifest should be store as on Synapse. Options are 'entity', 'table' and "
                 "'both'. 'entity' will store the manifest as a csv and create Synapse files for each row in the manifest. "

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -80,8 +80,8 @@ def model(ctx, config):  # use as `schematic model ...`
     "--manifest_record_type",
     "-mrt",
     default='both',
-    type=click.Choice(['table', 'entity', 'both'], case_sensitive=True),
-    help=query_dict(model_commands, ("model", "submit", "manifest_record_type")))
+    type=click.Choice(['table', 'entity', 'both'], case_sensitive=True)
+)
 @click.option(
     "-rr",
     "--restrict_rules",
@@ -95,9 +95,15 @@ def model(ctx, config):  # use as `schematic model ...`
     callback=parse_synIDs,
     help=query_dict(model_commands, ("model", "validate", "project_scope")),
 )
+@click.option(
+    "-pj",
+    "--project_id",
+    default=None,
+    help=query_dict(model_commands, ("model", "submit", "project_id")),
+)
 @click.pass_obj
 def submit_manifest(
-    ctx, manifest_path, dataset_id, validate_component, manifest_record_type, use_schema_label, hide_blanks, restrict_rules, project_scope,
+    ctx, manifest_path, dataset_id, validate_component, manifest_record_type, use_schema_label, hide_blanks, restrict_rules, project_scope, project_id
 ):
     """
     Running CLI with manifest validation (optional) and submission options.
@@ -116,6 +122,7 @@ def submit_manifest(
             path_to_json_ld = jsonld,
             manifest_path=manifest_path,
             dataset_id=dataset_id,
+            project_id = project_id, 
             validate_component=validate_component,
             manifest_record_type=manifest_record_type,
             restrict_rules=restrict_rules,
@@ -142,6 +149,10 @@ def submit_manifest(
     except ValueError:
         logger.error(
             f"Component '{validate_component}' is not present in '{jsonld}', or is invalid."
+        )
+    except TypeError: 
+        logger.error(
+            f"{project_id} is not a valid project folder. Please provide a valid project ID when submitting your manifest as a table"
         )
     except ValidationError:
         logger.error(

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -80,7 +80,8 @@ def model(ctx, config):  # use as `schematic model ...`
     "--manifest_record_type",
     "-mrt",
     default='both',
-    type=click.Choice(['table', 'entity', 'both'], case_sensitive=True)
+    type=click.Choice(['table', 'entity', 'both'], case_sensitive=True),
+     help=query_dict(model_commands, ("model", "submit", "manifest_record_type")),
 )
 @click.option(
     "-rr",

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -283,6 +283,7 @@ class MetadataModel(object):
         dataset_id: str,
         manifest_record_type: str,
         restrict_rules: bool,
+        project_id: str = None,
         validate_component: str = None,
         use_schema_label: bool = True,
         hide_blanks: bool = False,
@@ -294,6 +295,7 @@ class MetadataModel(object):
         Args:
             manifest_path: Path to the manifest file, which contains the metadata.
             dataset_id: Synapse ID of the dataset on Synapse containing the metadata manifest file.
+            project_id: Synapse ID of the project on Synapse. Only relevant when submitting manifest as a table. 
             validate_component: Component from the schema.org schema based on which the manifest template has been generated.
         Returns:
             Manifest ID: If both validation and association were successful.
@@ -312,7 +314,6 @@ class MetadataModel(object):
         censored_manifest_path=manifest_path.replace('.csv','_censored.csv')
         # check if user wants to perform validation or not
         if validate_component is not None:
-
             try:
                 # check if the component ("class" in schema) passed as argument is valid (present in schema) or not
                 self.sg.se.is_class_in_schema(validate_component)
@@ -348,6 +349,7 @@ class MetadataModel(object):
                     schemaGenerator = self.sg,
                     metadataManifestPath = manifest_path, 
                     datasetId = dataset_id, 
+                    projectId = project_id,
                     manifest_record_type = manifest_record_type,
                     useSchemaLabel = use_schema_label, 
                     hideBlanks = hide_blanks,
@@ -362,7 +364,6 @@ class MetadataModel(object):
                     "Manifest could not be validated under provided data model. "
                     f"Validation failed with the following errors: {val_errors}"
                 )
-
         # no need to perform validation, just submit/associate the metadata manifest file
         if exists(censored_manifest_path):
             censored_manifest_id = syn_store.associateMetadataWithFiles(
@@ -372,6 +373,7 @@ class MetadataModel(object):
                 manifest_record_type=manifest_record_type,
                 useSchemaLabel=use_schema_label,
                 hideBlanks=hide_blanks,
+                projectId=project_id
             )
             restrict_maniest = True
         
@@ -383,6 +385,7 @@ class MetadataModel(object):
             useSchemaLabel=use_schema_label,
             hideBlanks=hide_blanks,
             restrict_manifest=restrict_maniest,
+            projectId=project_id
         )
 
         logger.debug(


### PR DESCRIPTION
This PR is related to the issue [here](https://github.com/Sage-Bionetworks/schematic/issues/874). I added a parameter called `Project id`. When submitting manifest as a table, users would need to specify that to successfully upload a manifest. 