### PR TITLE
Develop manifest submission error handle

### DIFF
--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -147,6 +147,10 @@ def submit_manifest(
         logger.error(
             f"Validation errors resulted while validating with '{validate_component}'."
         )
+    except AttributeError:
+        logger.error(
+            f"'{dataset_id}' is not in the asset view (or file view for Synapse user)"
+        )
 
 
 # prototype based on validateModelManifest()

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -321,8 +321,8 @@ class MetadataModel(object):
                 # here, we are suppressing the KeyError exception and replacing it with a more
                 # descriptive ValueError exception
                 raise ValueError(
-                    "The component {} could not be found "
-                    "in the schema.".format(validate_component)
+                    f"The component '{validate_component}' could not be found "
+                    f"in the schema here '{path_to_json_ld}'"
                 )
 
             # automatic JSON schema generation and validation with that JSON schema

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1077,13 +1077,13 @@ class SynapseStorage(BaseStorage):
             if syn_object.properties["concreteType"].endswith("Project"):
                 return datasetId
         except SynapseHTTPError:
-            raise ValueError(
+            raise PermissionError(
                 f"The given dataset ({datasetId}) isn't accessible with this "
                 "user. This might be caused by a typo in the dataset Synapse ID."
             )
 
         # If not, then assume dataset not in file view
-        raise AssertionError (
+        raise AttributeError (
             f"The given dataset ({datasetId}) doesn't appear in the "
             f"configured file view ({self.storageFileview}). This might "
             "mean that the file view's scope needs to be updated."

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -46,7 +46,6 @@ from schematic import CONFIG
 
 logger = logging.getLogger(__name__)
 
-
 class SynapseStorage(BaseStorage):
     """Implementation of Storage interface for datasets/files stored on Synapse.
     Provides utilities to list files in a specific project; update files annotations, create fileviews, etc.
@@ -1084,11 +1083,11 @@ class SynapseStorage(BaseStorage):
             )
 
         # If not, then assume dataset not in file view
-        raise ValueError(
+        raise AssertionError (
             f"The given dataset ({datasetId}) doesn't appear in the "
             f"configured file view ({self.storageFileview}). This might "
             "mean that the file view's scope needs to be updated."
-        )
+        )     
 
     def getDatasetAnnotationsBatch(
         self, datasetId: str, dataset_file_ids: Sequence[str] = None

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -124,7 +124,7 @@ class TestSynapseStorage:
         assert synapse_store.getDatasetProject("syn24992812") == "syn24992754"
         assert synapse_store.getDatasetProject("syn24992754") == "syn24992754"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(PermissionError):
             synapse_store.getDatasetProject("syn12345678")
 
 


### PR DESCRIPTION
This issue is related to the issue #874  . Here are the few changes: 

* When a dataset ID is not present in the master file view, I changed it to raise `AttributeError` instead of `ValueError`. 
* If user has no permission to upload it to a given folder, I changed the error type from "ValueError" to "PermissionError"
* I also updated `command.py` to catch AttributeError being raised 
* In addition, I added "asset view" parameter to swagger UI. Users could update their asset view/file view when using the submit endpoint as well. 

