### PR TITLE
do not create dir if located in cwd

### DIFF
--- a/schematic/schemas/generator.py
+++ b/schematic/schemas/generator.py
@@ -708,7 +708,9 @@ class SchemaGenerator(object):
                 "nested key in the configuration: (model > input > log_location)."
             )
         else:
-            os.makedirs(os.path.dirname(json_schema_log_file), exist_ok=True)
+            json_schema_dirname = os.path.dirname(json_schema_log_file)
+            if json_schema_dirname != '':
+                os.makedirs(json_schema_dirname, exist_ok=True)
             with open(json_schema_log_file, "w") as js_f:
                 json.dump(json_schema, js_f, indent=2)
 


### PR DESCRIPTION
Issue #865 arose when a .jsonld file was used from the users current directory. A safeguard in place created the directory specified in the path to the .jsonld, but when it was in the current directory, this field was `''`. 
This PR no longer tries to create the directory containing the .jsonld if it is located in the current directory.