### PR TITLE
Add support for Schematic API to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,12 @@ RUN apt-get update -qqy \
 
 RUN pip install --no-cache-dir "poetry==$POETRY_VERSION"
 
+COPY pyproject.toml poetry.lock ./
+
+RUN poetry config virtualenvs.create false
+
+RUN poetry install --no-interaction --no-ansi --no-root
+
 COPY . ./
 
-RUN poetry config virtualenvs.create false \
-  && poetry install --no-interaction --no-ansi
-
-ENTRYPOINT [ "schematic" ]
+RUN poetry install --no-interaction --no-ansi --only-root

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -13,9 +13,9 @@ def create_app():
     app = connexionapp.app
 
     # path to config.yml file saved as a Flask config variable
-    app.config["SCHEMATIC_CONFIG"] = os.path.abspath(
-        os.path.join(__file__, "../../config.yml")
-    )
+    default_config = os.path.abspath(os.path.join(__file__, "../../config.yml"))
+    schematic_config = os.environ.get("SCHEMATIC_CONFIG", default_config)
+    app.config["SCHEMATIC_CONFIG"] = schematic_config
 
     # Configure flask app
     # app.config[] = schematic[]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,14 @@ services:
   schematic:
     build: .
     container_name: schematic
-    entrypoint: python run_api.py
+    entrypoint: python /usr/src/app/run_api.py
     ports:
       - "3001:3001"
     volumes:
-      - .:/work
-    working_dir: /work
+      - .:/schematic
+    working_dir: /schematic
     environment:
       APP_HOST: "0.0.0.0"
       APP_PORT: "3001"
-      SCHEMATIC_CONFIG: /work/config.yml
+      SCHEMATIC_CONFIG: /schematic/config.yml
+      GE_HOME: /usr/src/app/great_expectations/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  schematic:
+    build: .
+    container_name: schematic
+    entrypoint: python run_api.py
+    ports:
+      - "3001:3001"
+    volumes:
+      - .:/work
+    working_dir: /work
+    environment:
+      APP_HOST: "0.0.0.0"
+      APP_PORT: "3001"
+      SCHEMATIC_CONFIG: /work/config.yml

--- a/run_api.py
+++ b/run_api.py
@@ -1,7 +1,16 @@
+#!/usr/bin/env python3
+
 # import our application
 # Run our application
 from api import create_app
+import os
 
 if __name__ == "__main__":
+    # Get app configuration
+    host = os.environ.get("APP_HOST", "0.0.0.0")
+    port = os.environ.get("APP_PORT", "3001")
+    port = int(port)
+
+    # Launch app
     app = create_app()
-    app.run(port=3001, debug=True)
+    app.run(host=host, port=port, debug=True)


### PR DESCRIPTION
Since Schematic has a REST API, it makes sense to make that accessible via the container. In this PR, I tweak the container's entrypoint to allow the `run_api.py` script to be run. I had to tweak the file paths and host address to make this work. I also make a change to the dependency installation of the Dockerfile that will speed things up significantly by leveraging cached layers. Lastly, I added a docker-compose YAML file so it's easy to launch Schematic using the current configuration in your repository (including your credentials). You just need to run the following command and visit http://127.0.0.1:3001/v1/ui/. 

```console
docker compose up
```

The above command is equivalent to (although, I still omitted some unimportant bits for brevity):

```console
docker build -t schematic .
docker run --rm -p 3001:3001 -v $(pwd):/work -w /work --name schematic -e SCHEMATIC_CONFIG=/work/config.yml schematic python /usr/src/app/run_api.py
```