### PR TITLE
create endpoint to return schema as a pickle file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ tests/data/example.MockComponent.schema.json
 tests/data/mock_manifests/Invalid_Test_Manifest_censored.csv
 tests/data/mock_manifests/valid_test_manifest_censored.csv
 tests/data/mock_manifests/Rule_Combo_Manifest_censored.csv
+
+# Pickle file
+tests/data/schema.gpickle

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -583,3 +583,24 @@ paths:
           description: Check schematic log. 
       tags:
         - Synapse Storage
+  /schemas/get/schema:
+    get:
+      summary: Return schema as a pickle file
+      description: Return schema as a pickle file
+      operationId: api.routes.get_schema_pickle
+      parameters:
+        - in: query
+          name: schema_url
+          schema:
+            type: string
+          description: Data Model URL
+          example: >-
+            https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld
+          required: true
+      responses:
+        "200":
+          description: A pickle file gets downloaded and local file path of the pickle file gets returned.
+          content:
+            text/csv:
+              schema:
+                type: string

--- a/api/routes.py
+++ b/api/routes.py
@@ -14,12 +14,12 @@ from schematic import CONFIG
 from schematic.manifest.generator import ManifestGenerator
 from schematic.models.metadata import MetadataModel
 from schematic.schemas.generator import SchemaGenerator
-
+from schematic.schemas.explorer import SchemaExplorer
 from schematic.store.synapse import SynapseStorage
 import pandas as pd
 import json
 from schematic.utils.df_utils import load_df
-
+import pickle
 
 # def before_request(var1, var2):
 #     # Do stuff before your route executes
@@ -334,6 +334,24 @@ def get_manifest_datatype(input_token, manifest_id, asset_view):
 
 
     return manifest_dtypes_dict
+
+def get_schema_pickle(schema_url):
+    # load schema
+    se = SchemaExplorer()
+
+    se.load_schema(schema_url)
+
+    # get schema
+    schema_graph = se.get_nx_schema()
+
+    # write to local pickle file
+    path = os.getcwd()
+    export_path = os.path.join(path, 'tests/data/schema.gpickle')
+
+    with open(export_path, 'wb') as file:
+        pickle.dump(schema_graph, file)
+    return export_path
+
 
 
 


### PR DESCRIPTION
This endpoint is related to the issue [here](https://github.com/Sage-Bionetworks/schematic/issues/849). For a given schema url, this endpoint would download the schema as a pickle file and return the local file path.

Note: I didn't use `read_gpickle` and `write_gpickle` because of deprecation warning: ```DeprecationWarning: read_gpickle is deprecated and will be removed in 3.0.Use ``pickle.load(path)`` ```