### PR TITLE
HOTFIX: Mixed type column manifest table upload

### DIFF
--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -147,9 +147,9 @@ def submit_manifest(
         logger.error(
             f"Validation errors resulted while validating with '{validate_component}'."
         )
-    except AttributeError:
+    except LookupError:
         logger.error(
-            f"'{dataset_id}' is not in the asset view (or file view for Synapse user)"
+            f"'{dataset_id}' could not be found in the asset view (or file view for Synapse user)"
         )
 
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -994,7 +994,7 @@ class SynapseStorage(BaseStorage):
             load_args={
                 "dtype":"string",
             }
-            manifest = load_df(metadataManifestPath, preserve_raw_input=False, **load_args)
+            manifest = load_df(metadataManifestPath, preserve_raw_input = True, **load_args) #HOTFIX: set preserve_raw_input to true to allow mixed type cols in table uploads schematic#870
         except FileNotFoundError as err:
             raise FileNotFoundError(
                 f"No manifest file was found at this path: {metadataManifestPath}"

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1277,7 +1277,7 @@ class SynapseStorage(BaseStorage):
             )
 
         # If not, then assume dataset not in file view
-        raise AttributeError (
+        raise LookupError (
             f"The given dataset ({datasetId}) doesn't appear in the "
             f"configured file view ({self.storageFileview}). This might "
             "mean that the file view's scope needs to be updated."

--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -12,7 +12,9 @@ def load_df(file_path, preserve_raw_input=True, data_model=False, **load_args):
     Universal function to load CSVs and return DataFrames
     Args:
         file_path: path of csv to open
+        preserve_raw_input: Bool. If false, convert cell datatypes to an inferred type
         data_model: bool, indicates if importing a data model
+        load_args: dict of key value pairs to be passed to the pd.read_csv function
         **kwargs: keyword arguments for pd.read_csv()
 
     Returns: a processed dataframe for manifests or unprocessed df for data models


### PR DESCRIPTION
Patch for #870. The types of manifest entries are not longer inferred when being read in before file annotation. This avoids the error raised in Synapse and pandas when mixed-type columns are incorrectly treated as strings.

This PR also includes a fix for error conflicts. When the `AttributeError` was raised within Pandas, it was caught in `commands.py` and an error message referring to not being able to find the datasetID within the fileview was displayed. The catch statement, and exception it is intended to catch have been changed to avoid the conflation of the two exceptions raised in Pandas and Schematic