### PR TITLE
update upload_manifest_file function to use manifest basename in config

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -762,7 +762,7 @@ class SynapseStorage(BaseStorage):
         # update file name
         file_name_full = metadataManifestPath.split('/')[-1]
         file_extension = file_name_full.split('.')[-1]
-        file_name_new = CONFIG["synapse"]["manifest_basename"] + component_name + '.' + file_extension
+        file_name_new = os.path.basename(CONFIG["synapse"]["manifest_basename"]) + component_name + '.' + file_extension
 
         manifestSynapseFile = File(
             metadataManifestPath,

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -762,7 +762,7 @@ class SynapseStorage(BaseStorage):
         # update file name
         file_name_full = metadataManifestPath.split('/')[-1]
         file_extension = file_name_full.split('.')[-1]
-        file_name_new = os.path.basename(CONFIG["synapse"]["manifest_basename"]) + component_name + '.' + file_extension
+        file_name_new = os.path.basename(CONFIG["synapse"]["manifest_basename"]) + "_" + component_name + '.' + file_extension
 
         manifestSynapseFile = File(
             metadataManifestPath,

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -669,7 +669,7 @@ class SynapseStorage(BaseStorage):
         # update file name
         file_name_full = metadataManifestPath.split('/')[-1]
         file_extension = file_name_full.split('.')[-1]
-        file_name_new = 'synapse_storage_manifest_' + component_name + '.' + file_extension
+        file_name_new = CONFIG["synapse"]["manifest_basename"] + component_name + '.' + file_extension
 
         manifestSynapseFile = File(
             metadataManifestPath,

--- a/tests/data/test_config.yml
+++ b/tests/data/test_config.yml
@@ -1,13 +1,13 @@
 definitions:
   creds_path: "../../credentials.json"
   token_pickle: "token.pickle"
-  synapse_config: "../../.synapseConfig"
+  #synapse_config: "../../.synapseConfig"
   ### Note: this key is required for people who use Synapse token authentication approach. 
   ### If you run into errors similar to KeyError: 'synpase_config', you might want to consider adding this key. 
 
 synapse:
   master_fileview: "syn23643253"
-  manifest_basename: "synapse_storage_manifest"
+  manifest_basename: "data/manifests/synapse_storage_manifest"
 
 model:
   input:

--- a/tests/data/test_config.yml
+++ b/tests/data/test_config.yml
@@ -7,7 +7,6 @@ definitions:
 
 synapse:
   master_fileview: "syn23643253"
-  #manifest_basename: "data/manifests/synapse_storage_manifest"
   manifest_basename: "synapse_storage_manifest"
 
 model:

--- a/tests/data/test_config.yml
+++ b/tests/data/test_config.yml
@@ -1,13 +1,14 @@
 definitions:
   creds_path: "../../credentials.json"
   token_pickle: "token.pickle"
-  # synapse_config: "../../.synapseConfig"
+  synapse_config: "../../.synapseConfig"
   ### Note: this key is required for people who use Synapse token authentication approach. 
   ### If you run into errors similar to KeyError: 'synpase_config', you might want to consider adding this key. 
 
 synapse:
   master_fileview: "syn23643253"
-  manifest_basename: "data/manifests/synapse_storage_manifest"
+  #manifest_basename: "data/manifests/synapse_storage_manifest"
+  manifest_basename: "synapse_storage_manifest"
 
 model:
   input:


### PR DESCRIPTION
This PR is related to the issue [here](https://github.com/Sage-Bionetworks/schematic/issues/889) and also the PR [here](https://github.com/Sage-Bionetworks/schematic/pull/869/files)

Made the change so that we won't override the base name that users defined in `config.yml`