### PR TITLE
allow users to upload csv or json file when submitting manifest using API endpoints

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -259,6 +259,15 @@ paths:
             type: string
             nullable: false
           description: A JSON object
+          example: '[{
+          "Patient ID": 123,
+          "Sex": "Female",
+          "Year of Birth": "",
+          "Diagnosis": "Healthy",
+          "Component": "Patient",
+          "Cancer Type": "Breast",
+          "Family History": "Breast, Lung",
+          }]'
       operationId: api.routes.submit_manifest_route
       responses:
         "200":

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -252,6 +252,13 @@ paths:
             nullable: false
           description: Token
           required: true
+        - in: query
+          name: json_str
+          required: false
+          schema:
+            type: string
+            nullable: false
+          description: A JSON object
       operationId: api.routes.submit_manifest_route
       responses:
         "200":

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -253,6 +253,14 @@ paths:
           description: Token
           required: true
         - in: query
+          name: asset_view
+          schema:
+            type: string
+            nullable: false
+          description: ID of view listing all project data assets. For example, for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.(i.e. master_fileview in config.yml)
+          example: syn28559058
+          required: true
+        - in: query
           name: json_str
           required: false
           schema:

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -203,7 +203,8 @@ paths:
             schema:
               type: object
               properties:
-                csv_file:
+                file_name:
+                  description: Upload a json or a csv file. 
                   type: string
                   format: binary
       parameters:

--- a/api/routes.py
+++ b/api/routes.py
@@ -295,9 +295,9 @@ def validate_manifest_route(schema_url, data_type):
     return res_dict
 
 
-def submit_manifest_route(schema_url, manifest_record_type=None, json_str=None):
+def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None, json_str=None):
     # call config_handler()
-    config_handler()
+    config_handler(asset_view = asset_view)
 
     # convert Json file to CSV if applicable
     jsc = JsonConverter()

--- a/api/routes.py
+++ b/api/routes.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import tempfile
 import shutil
-from urllib.parse import non_hierarchical
 import urllib.request
 
 import connexion

--- a/api/routes.py
+++ b/api/routes.py
@@ -43,6 +43,15 @@ def config_handler(asset_view=None):
             f"No configuration file was found at this path: {path_to_config}"
         )
 
+def convert_json_str(json_str):
+    # read json str as dataframe
+    df = pd.read_json(json_str)
+    # convert dataframe to a temporary csv file
+    temp_dir = tempfile.gettempdir()
+    temp_path = os.path.join(temp_dir, "example_json")
+    df.to_csv(temp_path, encoding = 'utf-8', index=False)
+    return temp_path
+
 def convert_json_to_csv(file_key="file_name"):
     '''
     convert an incoming json file to a csv
@@ -218,8 +227,11 @@ def submit_manifest_route(schema_url, manifest_record_type=None, json_str=None):
 
     # convert Json file to CSV if applicable
     # get temporary CSV file path
-    temp_path = convert_json_to_csv()
-
+    if json_str:
+        temp_path = convert_json_str(json_str)
+    else:
+        temp_path = convert_json_to_csv()
+    
     dataset_id = connexion.request.args["dataset_id"]
 
     data_type = connexion.request.args["data_type"]

--- a/api/routes.py
+++ b/api/routes.py
@@ -302,10 +302,9 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
     # convert Json file to CSV if applicable
     jsc = JsonConverter()
     if json_str:
-        temp_path = jsc.convert_json_str_to_csv(json_str = json_str, file_name = "example_json")
+        temp_path = jsc.convert_json_str_to_csv(json_str = json_str, file_name = "example_json.csv")
     else: 
         temp_path = jsc.convert_json_file_to_csv("file_name")
-
 
     dataset_id = connexion.request.args["dataset_id"]
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -300,11 +300,6 @@ def submit_manifest_route(schema_url, manifest_record_type=None, json_str=None):
     config_handler()
 
     # convert Json file to CSV if applicable
-    # get temporary CSV file path
-    # if json_str:
-    #     temp_path = convert_json_str(json_str)
-    # else:
-    #     temp_path = convert_json_to_csv()
     jsc = JsonConverter()
     if json_str:
         temp_path = jsc.convert_json_str_to_csv(json_str = json_str, file_name = "example_json")

--- a/api/routes.py
+++ b/api/routes.py
@@ -42,12 +42,14 @@ def config_handler(asset_view=None):
             f"No configuration file was found at this path: {path_to_config}"
         )
 
-def convert_json_to_csv():
+def convert_json_to_csv(file_key="file_name"):
     '''
     convert an incoming json file to a csv
+    input: 
+        file_key: Defined in api.yaml. This key refers to the files uploaded. By default, set to "file_name"
     Return: a temporary CSV file path
     '''
-    manifest_file = connexion.request.files["file_name"]
+    manifest_file = connexion.request.files[file_key]
     file_type = manifest_file.content_type
 
     if file_type == 'application/json':
@@ -63,16 +65,16 @@ def convert_json_to_csv():
         # convert to csv
         df.to_csv(temp_path, encoding = 'utf-8', index=False)
     else: 
-        temp_path = file_path_handler(request_file_key='file_name')
+        temp_path = file_path_handler(file_key='file_name')
     return temp_path
         
-def file_path_handler(request_file_key="csv_file"):
+def file_path_handler(file_key="csv_file"):
     '''
     input: 
-        request_file_key: Defined in api.yaml. This key refers to the files uploaded. By default, set to "csv_file"
+        file_key: Defined in api.yaml. This key refers to the files uploaded. By default, set to "csv_file"
     Return a temporary file path for the uploaded a given file
     '''
-    manifest_file = connexion.request.files[request_file_key]
+    manifest_file = connexion.request.files[file_key]
 
     # save contents of incoming manifest CSV file to temp file
     temp_dir = tempfile.gettempdir()

--- a/api/routes.py
+++ b/api/routes.py
@@ -47,7 +47,6 @@ def convert_json_to_csv():
     convert an incoming json file to a csv
     Return: a temporary CSV file path
     '''
-
     manifest_file = connexion.request.files["file_name"]
     file_type = manifest_file.content_type
 
@@ -64,13 +63,13 @@ def convert_json_to_csv():
         # convert to csv
         df.to_csv(temp_path, encoding = 'utf-8', index=False)
     else: 
-        temp_path = file_path_handler('file_name')
+        temp_path = file_path_handler(request_file_key='file_name')
     return temp_path
         
-def file_path_handler(request_file_key):
+def file_path_handler(request_file_key="csv_file"):
     '''
     input: 
-        request_file_key: Defined in api.yaml. This key refers to the files uploaded 
+        request_file_key: Defined in api.yaml. This key refers to the files uploaded. By default, set to "csv_file"
     Return a temporary file path for the uploaded a given file
     '''
     manifest_file = connexion.request.files[request_file_key]
@@ -192,7 +191,7 @@ def validate_manifest_route(schema_url, data_type):
     config_handler()
 
     #Get path to temp file where manifest file contents will be saved
-    temp_path = file_path_handler("csv_file")
+    temp_path = file_path_handler()
 
     # get path to temporary JSON-LD file
     jsonld = get_temp_jsonld(schema_url)
@@ -245,7 +244,7 @@ def populate_manifest_route(schema_url, title=None, data_type=None):
     jsonld = get_temp_jsonld(schema_url)
 
     # Get path to temp file where manifest file contents will be saved
-    temp_path = file_path_handler("csv_file")
+    temp_path = file_path_handler()
    
     #Initalize MetadataModel
     metadata_model = MetadataModel(inputMModelLocation=jsonld, inputMModelLocationType='local')

--- a/api/routes.py
+++ b/api/routes.py
@@ -43,42 +43,116 @@ def config_handler(asset_view=None):
             f"No configuration file was found at this path: {path_to_config}"
         )
 
-def convert_json_str(json_str):
-    # read json str as dataframe
-    df = pd.read_json(json_str)
-    # convert dataframe to a temporary csv file
-    temp_dir = tempfile.gettempdir()
-    temp_path = os.path.join(temp_dir, "example_json")
-    df.to_csv(temp_path, encoding = 'utf-8', index=False)
-    return temp_path
-
-def convert_json_to_csv(file_key="file_name"):
+class JsonConverter:
     '''
-    convert an incoming json file to a csv
-    input: 
-        file_key: Defined in api.yaml. This key refers to the files uploaded. By default, set to "file_name"
-    Return: a temporary CSV file path
+    Mainly handle converting json str or json file to csv
     '''
-    manifest_file = connexion.request.files[file_key]
-    file_type = manifest_file.content_type
+    def readJson(self, json_str=None, manifest_file=None):
+        '''
+        The purpose of this function is to read either json str or json file
+        input: 
+            json_str: json object
+            manifest_file: manifest file object 
+        output: 
+            return a dataframe
+        '''
+        if json_str:
+            df = pd.read_json(json_str)
+        elif manifest_file: 
+            df = pd.read_json(manifest_file.read())
+        return df
+    
+    def get_file(self, file_key):
+        '''
+        The purpose of this function is to get the file uploaded by user
+        input: 
+            file_key: Defined in api.yaml. This key refers to the files uploaded. 
+            manifest_file: manifest file object 
+        output: 
+            return file object
+        '''
 
-    if file_type == 'application/json':
-        # convert json file to a dataframe
-        df = pd.read_json(manifest_file.read())
-        # get base file name
-        base = os.path.splitext(manifest_file.filename)[0]
-        # name the new csv file 
-        new_file_name = base + '.csv'
+        manifest_file = connexion.request.files[file_key]
+        return manifest_file
+
+    def IsJsonFile(self, manifest_file):
+        '''
+        The purpose of this function is check if the manifest file that gets uploaded is a json or not
+        input: 
+            manifest_file: manifest file object 
+        output: 
+            return True if it is json
+        '''
+
+        file_type = manifest_file.content_type
+        if file_type == 'application/json':
+            return True
+        else: 
+            return False
+
+    def convert_df_to_csv(self, df, file_name):
+        '''
+        The purpose of this function is to convert dataframe to a temporary CSV file
+        input: 
+            df: dataframe
+            file_name: file name of the output csv
+        output: 
+            return temporary file path of the output csv
+        '''
+
         # convert dataframe to a temporary csv file
         temp_dir = tempfile.gettempdir()
-        temp_path = os.path.join(temp_dir, new_file_name)
-        # convert to csv
+        temp_path = os.path.join(temp_dir, file_name)
         df.to_csv(temp_path, encoding = 'utf-8', index=False)
-    else: 
-        temp_path = file_path_handler(file_key='file_name')
-    return temp_path
+        return temp_path
+
+    def convert_json_str_to_csv(self, json_str, file_name):
+        '''
+        The purpose of this function is to convert json str to a temporary csv file
+        input: 
+            json_str: json object
+            file_name: file name of the output csv
+        output: 
+            return temporary file path of the output csv
+        '''
+
+        # convert json to df
+        df = self.readJson(json_str = json_str)
+
+        # convert dataframe to a temporary csv file
+        temp_path = self.convert_df_to_csv(df, file_name)
+
+        return temp_path
+
+    def convert_json_file_to_csv(self, file_key):
+        '''
+        The purpose of this function is to convert json str to a temporary csv file
+        input: 
+            file_key: Defined in api.yaml. This key refers to the files uploaded. 
+        output: 
+            return temporary file path of the output csv
+        '''
+
+        # get manifest file
+        manifest_file = self.get_file(file_key)
+
+        if self.IsJsonFile(manifest_file):
+            # read json as dataframe
+            df = self.readJson(manifest_file = manifest_file)
+            # get base file name
+            base = os.path.splitext(manifest_file.filename)[0]
+            # name the new csv file 
+            new_file_name = base + '.csv'
+            # convert to csv
+            temp_path = self.convert_df_to_csv(df, new_file_name)
+            return temp_path
+        else: 
+            temp_path = save_file(file_key='file_name')
+            return temp_path
         
-def file_path_handler(file_key="csv_file"):
+
+        
+def save_file(file_key="csv_file"):
     '''
     input: 
         file_key: Defined in api.yaml. This key refers to the files uploaded. By default, set to "csv_file"
@@ -203,7 +277,7 @@ def validate_manifest_route(schema_url, data_type):
     config_handler()
 
     #Get path to temp file where manifest file contents will be saved
-    temp_path = file_path_handler()
+    temp_path = save_file()
 
     # get path to temporary JSON-LD file
     jsonld = get_temp_jsonld(schema_url)
@@ -227,11 +301,17 @@ def submit_manifest_route(schema_url, manifest_record_type=None, json_str=None):
 
     # convert Json file to CSV if applicable
     # get temporary CSV file path
+    # if json_str:
+    #     temp_path = convert_json_str(json_str)
+    # else:
+    #     temp_path = convert_json_to_csv()
+    jsc = JsonConverter()
     if json_str:
-        temp_path = convert_json_str(json_str)
-    else:
-        temp_path = convert_json_to_csv()
-    
+        temp_path = jsc.convert_json_str_to_csv(json_str = json_str, file_name = "example_json")
+    else: 
+        temp_path = jsc.convert_json_file_to_csv("file_name")
+
+
     dataset_id = connexion.request.args["dataset_id"]
 
     data_type = connexion.request.args["data_type"]
@@ -260,7 +340,7 @@ def populate_manifest_route(schema_url, title=None, data_type=None):
     jsonld = get_temp_jsonld(schema_url)
 
     # Get path to temp file where manifest file contents will be saved
-    temp_path = file_path_handler()
+    temp_path = save_file()
    
     #Initalize MetadataModel
     metadata_model = MetadataModel(inputMModelLocation=jsonld, inputMModelLocationType='local')

--- a/api/routes.py
+++ b/api/routes.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import shutil
+from urllib.parse import non_hierarchical
 import urllib.request
 
 import connexion
@@ -211,7 +212,7 @@ def validate_manifest_route(schema_url, data_type):
     return res_dict
 
 
-def submit_manifest_route(schema_url, manifest_record_type=None):
+def submit_manifest_route(schema_url, manifest_record_type=None, json_str=None):
     # call config_handler()
     config_handler()
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -216,6 +216,7 @@ def submit_manifest_route(schema_url, manifest_record_type=None):
     config_handler()
 
     # convert Json file to CSV if applicable
+    # get temporary CSV file path
     temp_path = convert_json_to_csv()
 
     dataset_id = connexion.request.args["dataset_id"]


### PR DESCRIPTION
This PR is related to the issue mentioned [here](https://github.com/Sage-Bionetworks/schematic/issues/900). Users could now upload json file when submitting a manifest using the API endpoint