### PR TITLE
allow users to upload csv or json file when validating manifest using API endpoints

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -175,6 +175,23 @@ paths:
           description: Data Model Component
           example: Patient
           required: true
+        - in: query
+          name: json_str
+          required: false
+          schema:
+            type: string
+            nullable: false
+          description: A JSON object
+          example: '[{
+          "Patient ID": 123,
+          "Sex": "Female",
+          "Year of Birth": "",
+          "Diagnosis": "Healthy",
+          "Component": "Patient",
+          "Cancer Type": "Breast",
+          "Family History": "Breast, Lung",
+          }]'
+
       operationId: api.routes.validate_manifest_route
       responses:
         "200":

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -152,9 +152,10 @@ paths:
             schema:
               type: object
               properties:
-                # csv_file will be the field name in
+                # file_name will be the field name in
                 # this multipart request
-                csv_file:
+                file_name:
+                  description: Upload a json or a csv file. 
                   type: string
                   format: binary
       parameters:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import tempfile
 import shutil
-from urllib.parse import non_hierarchical
 import urllib.request
 
 import connexion

--- a/api/routes.py
+++ b/api/routes.py
@@ -192,8 +192,9 @@ def validate_manifest_route(schema_url, data_type):
     # call config_handler()
     config_handler()
 
-    #Get path to temp file where manifest file contents will be saved
-    temp_path = file_path_handler()
+    # convert Json file to CSV if applicable
+    # get temporary CSV file path
+    temp_path = convert_json_to_csv()
 
     # get path to temporary JSON-LD file
     jsonld = get_temp_jsonld(schema_url)


### PR DESCRIPTION
This PR is related to the issue mentioned [here](https://github.com/Sage-Bionetworks/schematic/issues/899)