### PR TITLE
change manifest name for censored manifest when upload

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -762,8 +762,10 @@ class SynapseStorage(BaseStorage):
         # update file name
         file_name_full = metadataManifestPath.split('/')[-1]
         file_extension = file_name_full.split('.')[-1]
-        if restrict_manifest: 
-            file_name_new = os.path.basename(CONFIG["synapse"]["manifest_basename"]) + "_" + component_name + '_censored' + '.' + file_extension
+
+        # Differentiate "censored" and "uncensored" manifest
+        if "censored" in file_name_full: 
+            file_name_new = os.path.basename(CONFIG["synapse"]["manifest_basename"]) + "_" + component_name + "_censored" + '.' + file_extension
         else: 
             file_name_new = os.path.basename(CONFIG["synapse"]["manifest_basename"]) + "_" + component_name + '.' + file_extension
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -762,7 +762,10 @@ class SynapseStorage(BaseStorage):
         # update file name
         file_name_full = metadataManifestPath.split('/')[-1]
         file_extension = file_name_full.split('.')[-1]
-        file_name_new = 'synapse_storage_manifest_' + component_name + '.' + file_extension
+        if restrict_manifest: 
+            file_name_new = os.path.basename(CONFIG["synapse"]["manifest_basename"]) + "_" + component_name + '_censored' + '.' + file_extension
+        else: 
+            file_name_new = os.path.basename(CONFIG["synapse"]["manifest_basename"]) + "_" + component_name + '.' + file_extension
 
         manifestSynapseFile = File(
             metadataManifestPath,


### PR DESCRIPTION
This PR is related to the issue mentioned [here](https://github.com/Sage-Bionetworks/schematic/issues/922). 

I have tested it out by using `schematic model -c config.yml submit --manifest_path /Users/lpeng/Documents/schematic-git2/schematic/tests/data/mock_manifests/Rule_Combo_Manifest.csv --dataset_id syn27221721` . This would upload both `Rule_Combo_Manifest.csv` and `Rule_Combo_Manifest_censored.csv` to synapse dataset folder. 
These two manifests will be renamed as: `synapse_storage_manifest_mockcomponent_censored.csv` and `synapse_storage_manifest_mockcomponent.csv`