### PR TITLE
populate manifest as an excel spreadsheet without sending data to Google api

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -79,6 +79,13 @@ paths:
             nullable: true
           description: ID of view listing all project data assets. E.g. for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.(i.e. master_fileview in config.yml)
           required: false
+        - in: query
+          name: return_excel
+          schema:
+            type: boolean
+            nullable: true
+          description: If true, this would return an Excel spreadsheet.(This approach would avoid sending metadata to Google sheet APIs)
+          required: false
       operationId: api.routes.get_manifest_route
       responses:
         "201":

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -80,11 +80,11 @@ paths:
           description: ID of view listing all project data assets. E.g. for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.(i.e. master_fileview in config.yml)
           required: false
         - in: query
-          name: return_excel
+          name: output_form
           schema:
-            type: boolean
-            nullable: true
-          description: If true, this would return an Excel spreadsheet.(This approach would avoid sending metadata to Google sheet APIs)
+            type: string
+            enum: ["excel", "google_sheet", "dataframe (only if getting existing manifests)"]
+          description: If "excel" gets selected, this approach would avoid sending metadata to Google sheet APIs; if "google_sheet" gets selected, this would return a Google sheet URL. This parameter could potentially override sheet_url parameter. 
           required: false
       operationId: api.routes.get_manifest_route
       responses:

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -338,6 +338,13 @@ paths:
           description: Title of Manifest
           example: Example
           required: false
+        - in: query
+          name: return_excel
+          schema:
+            type: boolean
+            nullable: false
+          description: If true, this would return an Excel spreadsheet.(This approach would avoid sending metadata to Google sheet APIs)
+          required: true
       operationId: api.routes.populate_manifest_route
       responses:
         "200":

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -80,7 +80,7 @@ paths:
           description: ID of view listing all project data assets. E.g. for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.(i.e. master_fileview in config.yml)
           required: false
         - in: query
-          name: output_form
+          name: output_format
           schema:
             type: string
             enum: ["excel", "google_sheet", "dataframe (only if getting existing manifests)"]

--- a/api/routes.py
+++ b/api/routes.py
@@ -72,7 +72,24 @@ def get_temp_jsonld(schema_url):
     return tmp_file.name
 
 # @before_request
-def get_manifest_route(schema_url, title, oauth, use_annotations, dataset_ids=None, asset_view = None):
+def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations: bool, dataset_ids=None, asset_view = None, return_excel=False):
+    """Get the immediate dependencies that are related to a given source node.
+
+    Args:
+        '''Gets manifest for a given dataset on Synapse.
+        Args:
+            schema_url: link to data model in json ld format
+            title: title of a given manifest. 
+            oauth: if user wants to use OAuth for Google authentication
+            dataset_id: Synapse ID of the "dataset" entity on Synapse (for a given center/project).
+            return_excel: if true, return an Excel spreadsheet; else, return a google sheet url.
+            use_annotations: Whether to use existing annotations during manifest generation
+
+        Returns:
+            Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
+        '''
+    """
+
     # call config_handler()
     config_handler(asset_view = asset_view)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -208,7 +208,7 @@ def submit_manifest_route(schema_url, manifest_record_type=None):
 
     return manifest_id
 
-def populate_manifest_route(schema_url, title=None, data_type=None):
+def populate_manifest_route(schema_url, title=None, data_type=None, return_excel=None):
     # call config_handler()
     config_handler()
 
@@ -222,7 +222,7 @@ def populate_manifest_route(schema_url, title=None, data_type=None):
     metadata_model = MetadataModel(inputMModelLocation=jsonld, inputMModelLocationType='local')
 
     #Call populateModelManifest class
-    populated_manifest_link = metadata_model.populateModelManifest(title=title, manifestPath=temp_path, rootNode=data_type)
+    populated_manifest_link = metadata_model.populateModelManifest(title=title, manifestPath=temp_path, rootNode=data_type, return_excel=return_excel)
 
     return populated_manifest_link
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -72,7 +72,7 @@ def get_temp_jsonld(schema_url):
     return tmp_file.name
 
 # @before_request
-def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations: bool, dataset_ids=None, asset_view = None, output_form=None):
+def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations: bool, dataset_ids=None, asset_view = None, output_format=None):
     """Get the immediate dependencies that are related to a given source node.
         Args:
             schema_url: link to data model in json ld format
@@ -127,7 +127,7 @@ def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations
                 )
 
 
-    def create_single_manifest(data_type, dataset_id=None, output_form = None):
+    def create_single_manifest(data_type, dataset_id=None, output_format = None):
         # create object of type ManifestGenerator
         manifest_generator = ManifestGenerator(
             path_to_json_ld=jsonld,
@@ -139,12 +139,12 @@ def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations
         )
 
         # if returning a dataframe
-        if output_form:
-            if "dataframe" in output_form:
-                output_form = "dataframe"
+        if output_format:
+            if "dataframe" in output_format:
+                output_format = "dataframe"
 
         result = manifest_generator.get_manifest(
-            dataset_id=dataset_id, sheet_url=True, output_form = output_form
+            dataset_id=dataset_id, sheet_url=True, output_format = output_format
         )
                
         return result
@@ -157,7 +157,7 @@ def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations
         components = component_digraph.nodes()
         for component in components:
             t = f'{title}.{component}.manifest'
-            result = create_single_manifest(data_type = component, output_form = output_form)
+            result = create_single_manifest(data_type = component, output_format = output_format)
             all_results.append(result)
     else:
         for i, dt in enumerate(data_type):
@@ -168,9 +168,9 @@ def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations
 
             if dataset_ids:
                 # if a dataset_id is provided add this to the function call.
-                result = create_single_manifest(data_type = dt, dataset_id = dataset_ids[i], output_form = output_form)
+                result = create_single_manifest(data_type = dt, dataset_id = dataset_ids[i], output_format = output_format)
             else:
-                result = create_single_manifest(data_type = dt, output_form = output_form)
+                result = create_single_manifest(data_type = dt, output_format = output_format)
             all_results.append(result)
 
     return all_results

--- a/api/routes.py
+++ b/api/routes.py
@@ -72,7 +72,7 @@ def get_temp_jsonld(schema_url):
     return tmp_file.name
 
 # @before_request
-def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations: bool, dataset_ids=None, asset_view = None, return_excel=False):
+def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations: bool, dataset_ids=None, asset_view = None, output_form=None):
     """Get the immediate dependencies that are related to a given source node.
         Args:
             schema_url: link to data model in json ld format
@@ -127,7 +127,7 @@ def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations
                 )
 
 
-    def create_single_manifest(data_type, dataset_id=None, return_excel=False):
+    def create_single_manifest(data_type, dataset_id=None, output_form = None):
         # create object of type ManifestGenerator
         manifest_generator = ManifestGenerator(
             path_to_json_ld=jsonld,
@@ -138,14 +138,13 @@ def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations
             alphabetize_valid_values = 'ascending',
         )
 
-        # if returning an excel spreadsheet
-        if return_excel: 
-            sheet_url = False
-        else: 
-            sheet_url = True
+        # if returning a dataframe
+        if output_form:
+            if "dataframe" in output_form:
+                output_form = "dataframe"
 
         result = manifest_generator.get_manifest(
-            dataset_id=dataset_id, sheet_url=sheet_url, return_excel = return_excel
+            dataset_id=dataset_id, sheet_url=True, output_form = output_form
         )
                
         return result
@@ -158,7 +157,7 @@ def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations
         components = component_digraph.nodes()
         for component in components:
             t = f'{title}.{component}.manifest'
-            result = create_single_manifest(data_type = component, return_excel=return_excel)
+            result = create_single_manifest(data_type = component, output_form = output_form)
             all_results.append(result)
     else:
         for i, dt in enumerate(data_type):
@@ -169,9 +168,9 @@ def get_manifest_route(schema_url: str, title: str, oauth: bool, use_annotations
 
             if dataset_ids:
                 # if a dataset_id is provided add this to the function call.
-                result = create_single_manifest(data_type = dt, dataset_id = dataset_ids[i], return_excel=return_excel)
+                result = create_single_manifest(data_type = dt, dataset_id = dataset_ids[i], output_form = output_form)
             else:
-                result = create_single_manifest(data_type = dt, return_excel=return_excel)
+                result = create_single_manifest(data_type = dt, output_form = output_form)
             all_results.append(result)
 
     return all_results

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -147,9 +147,9 @@ def get_manifest(
         )
 
         # call get_manifest() on manifest_generator
-        # if output_xlsx gets specified, output_form = "excel"
+        # if output_xlsx gets specified, output_format = "excel"
         if output_xlsx: 
-            output_form = "excel"
+            output_format = "excel"
 
             # if file name is in the path, and that file does not exist
             if not os.path.exists(output_xlsx):
@@ -162,11 +162,11 @@ def get_manifest(
             else: 
                 output_path = output_xlsx
         else: 
-            output_form = None
+            output_format = None
             output_path = None
 
         result = manifest_generator.get_manifest(
-            dataset_id=dataset_id, sheet_url=sheet_url, json_schema=json_schema, output_form = output_form, output_path = output_path
+            dataset_id=dataset_id, sheet_url=sheet_url, json_schema=json_schema, output_format = output_format, output_path = output_path
         )
 
         if sheet_url:

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -161,18 +161,9 @@ def get_manifest(
 
             else: 
                 output_path = output_xlsx
-
-
-        #     if ".xlsx" or ".xls" in output_xlsx:
-        #         # get the location of file location 
-        #         #output_path = os.path.abspath(os.path.join(output_xlsx, os.pardir))
-        #         path = Path(output_xlsx)
-        #         output_path = path.parent.absolute()
-        #         #print(path.parent.absolute())
-        #     else: 
-        #         output_path = output_xlsx
-        # else: 
-        #     output_form = None
+        else: 
+            output_form = None
+            output_path = None
 
         result = manifest_generator.get_manifest(
             dataset_id=dataset_id, sheet_url=sheet_url, json_schema=json_schema, output_form = output_form, output_path = output_path

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -1,6 +1,6 @@
 import os
 import logging
-
+from pathlib import Path
 import click
 import click_log
 import logging
@@ -12,7 +12,7 @@ from schematic.utils.cli_utils import fill_in_from_config, query_dict, parse_syn
 from schematic.help import manifest_commands
 from schematic import CONFIG
 from schematic.schemas.generator import SchemaGenerator
-from schematic.utils.google_api_utils import export_manifest_csv, export_manifest_excel
+from schematic.utils.google_api_utils import export_manifest_csv, export_manifest_excel, export_manifest_drive_service
 from schematic.store.synapse import SynapseStorage
 
 logger = logging.getLogger(__name__)
@@ -147,8 +147,35 @@ def get_manifest(
         )
 
         # call get_manifest() on manifest_generator
+        # if output_xlsx gets specified, output_form = "excel"
+        if output_xlsx: 
+            output_form = "excel"
+
+            # if file name is in the path, and that file does not exist
+            if not os.path.exists(output_xlsx):
+                if ".xlsx" or ".xls" in output_xlsx:
+                    path = Path(output_xlsx)
+                    output_path = path.parent.absolute()
+                else: 
+                    logger.error(f"{output_xlsx} does not exists. Please try a valid file path")
+
+            else: 
+                output_path = output_xlsx
+
+
+        #     if ".xlsx" or ".xls" in output_xlsx:
+        #         # get the location of file location 
+        #         #output_path = os.path.abspath(os.path.join(output_xlsx, os.pardir))
+        #         path = Path(output_xlsx)
+        #         output_path = path.parent.absolute()
+        #         #print(path.parent.absolute())
+        #     else: 
+        #         output_path = output_xlsx
+        # else: 
+        #     output_form = None
+
         result = manifest_generator.get_manifest(
-            dataset_id=dataset_id, sheet_url=sheet_url, json_schema=json_schema,
+            dataset_id=dataset_id, sheet_url=sheet_url, json_schema=json_schema, output_form = output_form, output_path = output_path
         )
 
         if sheet_url:
@@ -160,13 +187,13 @@ def get_manifest(
             if prefix_ext == ".model":
                 prefix = prefix_root
             output_csv = f"{prefix}.{data_type}.manifest.csv"
+
         elif output_xlsx:
-            export_manifest_excel(output_excel=output_xlsx, manifest=result)
             logger.info(
                 f"Find the manifest template using this Excel file path: {output_xlsx}"
             )
             return result
-        export_manifest_csv(file_name=output_csv, manifest=result)
+        export_manifest_csv(file_path=output_csv, manifest=result)
         logger.info(
                 f"Find the manifest template using this CSV file path: {output_csv}"
             )
@@ -184,8 +211,12 @@ def get_manifest(
             result = create_single_manifest(data_type = component)
     else:
         for dt in data_type:
-            if len(data_type) > 1:
+            if len(data_type) > 1 and not output_xlsx:
                 t = f'{title}.{dt}.manifest'
+            elif output_xlsx: 
+                if ".xlsx" or ".xls" in output_xlsx:
+                    title_with_extension = os.path.basename(output_xlsx)
+                    t = title_with_extension.split('.')[0]
             else:
                 t = title
             result = create_single_manifest(data_type = dt, output_csv=output_csv, output_xlsx=output_xlsx)

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1469,11 +1469,11 @@ class ManifestGenerator(object):
         
         return output_excel_file_path
 
-    def handle_output_format_logic(self, output_form: str = None, output_path: str = None, sheet_url: bool = None, manifest_url: str = None, empty_manifest_url: str = None, dataframe: pd.DataFrame = None):
+    def _handle_output_format_logic(self, output_format: str = None, output_path: str = None, sheet_url: bool = None, manifest_url: str = None, empty_manifest_url: str = None, dataframe: pd.DataFrame = None):
         """
-        handle the logic between sheet_url parameter and output_form parameter to determine the type of output to return
+        handle the logic between sheet_url parameter and output_format parameter to determine the type of output to return
         Args: 
-            output_form: Determines if Google sheet URL, pandas dataframe, or Excel spreadsheet gets returned.
+            output_format: Determines if Google sheet URL, pandas dataframe, or Excel spreadsheet gets returned.
             sheet_url (Will be deprecated): a boolean ; determine if a pandas dataframe or a google sheet url gets return
             manifest_url: Google sheet URL populated with metadata
             empty_manifest_url: Google sheet URL that leads to an empty manifest 
@@ -1482,8 +1482,8 @@ class ManifestGenerator(object):
         return: a pandas dataframe, file path of an excel spreadsheet, or a google sheet URL 
         """
 
-        # check if output_form parameter gets set. If not, check the sheet_url parameter
-        if not output_form: 
+        # check if output_format parameter gets set. If not, check the sheet_url parameter
+        if not output_format: 
             # if the sheet_url parameter gets set to True, return a google sheet url 
             if sheet_url: 
                 return manifest_url
@@ -1492,10 +1492,10 @@ class ManifestGenerator(object):
                 return dataframe
         else:
             # if the output type gets set to "dataframe", return a data frame 
-            if output_form == "dataframe":
+            if output_format == "dataframe":
                 return dataframe
             # if the output type gets set to "excel", return an excel spreadsheet
-            elif output_form == "excel":                 
+            elif output_format == "excel":                 
                 # export the manifest url to excel
                 output_file_path = self.export_sheet_to_excel(title = self.title, manifest_url = empty_manifest_url, output_location = output_path)
 
@@ -1511,7 +1511,7 @@ class ManifestGenerator(object):
                 return manifest_url  
 
     def get_manifest(
-        self, dataset_id: str = None, sheet_url: bool = None, json_schema: str = None, output_form: str = None, output_path: str = None
+        self, dataset_id: str = None, sheet_url: bool = None, json_schema: str = None, output_format: str = None, output_path: str = None
     ) -> Union[str, pd.DataFrame]:
         """Gets manifest for a given dataset on Synapse.
            TODO: move this function to class MetadatModel (after MetadataModel is refactored)
@@ -1519,11 +1519,11 @@ class ManifestGenerator(object):
         Args:
             dataset_id: Synapse ID of the "dataset" entity on Synapse (for a given center/project).
             sheet_url: Determines if googlesheet URL or pandas dataframe should be returned.
-            output_form: Determines if Google sheet URL, pandas dataframe, or Excel spreadsheet gets returned.
+            output_format: Determines if Google sheet URL, pandas dataframe, or Excel spreadsheet gets returned.
             output_path: Determines the output path of the exported manifest
 
         Returns:
-            Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
+            Googlesheet URL, pandas dataframe, or an Excel spreadsheet 
         """
 
         # Handle case when no dataset ID is provided
@@ -1531,7 +1531,7 @@ class ManifestGenerator(object):
             manifest_url = self.get_empty_manifest(json_schema_filepath=json_schema)
 
             # if output_form parameter is set to "excel", return an excel spreadsheet
-            if output_form == "excel": 
+            if output_format == "excel": 
                 output_file_path = self.export_sheet_to_excel(title = self.title, manifest_url = manifest_url, output_location = output_path)
                 return output_file_path
             # since we are not going to return an empty dataframe for an empty manifest, here we will just return a google sheet url for all other cases
@@ -1562,7 +1562,7 @@ class ManifestGenerator(object):
             manifest_sh = self.set_dataframe_by_url(empty_manifest_url, manifest_record[1])
 
             # determine the format of manifest
-            result = self.handle_output_format_logic(output_form = output_form, output_path = output_path, sheet_url = sheet_url, manifest_url = manifest_sh.url, empty_manifest_url=empty_manifest_url, dataframe = manifest_record[1])
+            result = self._handle_output_format_logic(output_format = output_format, output_path = output_path, sheet_url = sheet_url, manifest_url = manifest_sh.url, empty_manifest_url=empty_manifest_url, dataframe = manifest_record[1])
             return result
 
         # Generate empty template and optionally fill in with annotations
@@ -1586,10 +1586,10 @@ class ManifestGenerator(object):
                 manifest_url, manifest_df = self.get_manifest_with_annotations(annotations)
             
             # determine the format of manifest that gets return 
-            result = self.handle_output_format_logic(output_form = output_form, output_path = output_path, sheet_url = sheet_url, manifest_url = manifest_url, empty_manifest_url=empty_manifest_url, dataframe = manifest_df)
+            result = self._handle_output_format_logic(output_format = output_format, output_path = output_path, sheet_url = sheet_url, manifest_url = manifest_url, empty_manifest_url=empty_manifest_url, dataframe = manifest_df)
             return result
 
-    def populate_existing_excel_spreadsheet(self, existing_excel_path, additional_df):
+    def populate_existing_excel_spreadsheet(self, existing_excel_path: str = None, additional_df: pd.DataFrame = None):
         '''Populate an existing excel spreadsheet by using an additional dataframe (to avoid sending metadata directly to Google APIs)
         Args:
             existing_excel_path: path of an existing excel spreadsheet

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1278,6 +1278,7 @@ class ManifestGenerator(object):
         Args:
             manifest_url (str): Google Sheets URL.
             manifest_df (pd.DataFrame): Data frame to "upload".
+            populate_df: if true, populate google sheet with dataframe.
 
         Returns:
             ps.Spreadsheet: A Google Sheet object.

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1524,7 +1524,7 @@ class ManifestGenerator(object):
 
         #get missing columns and sort manifest 
         #get existing headers
-        existing_df = pd.read_excel(existing_excel_path)
+        existing_df = pd.read_excel(existing_excel_path, sheet_name="Sheet1")
         workbook_headers = existing_df.columns
 
         # get new column headers
@@ -1545,13 +1545,13 @@ class ManifestGenerator(object):
             for i, col_name in enumerate(out_of_schema_columns_lst):
                 col_index = len(workbook_headers) + 1 + i
                 worksheet.cell(row=1, column=col_index).value = col_name
-
+        
+        # save and close
         writer.save()
         writer.close()
 
     def populate_manifest_spreadsheet(self, existing_manifest_path: str = None, empty_manifest_url: str = None, return_excel: bool = False, title: str = None):
         """Creates a google sheet manifest based on existing manifest.
-
         Args:
             existing_manifest_path: the location of the manifest containing metadata presently stored
             empty_manifest_url: the path to a manifest template to be prepopulated with existing's manifest metadata

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1308,12 +1308,12 @@ class ManifestGenerator(object):
         # find missing columns in existing manifest
         new_columns = set(wb_header) - set(manifest_df.columns)
 
-        # # clean empty columns if any are present (there should be none)
-        # # TODO: Remove this line once we start preventing empty column names
+        # clean empty columns if any are present (there should be none)
+        # TODO: Remove this line once we start preventing empty column names
         if '' in new_columns:
             new_columns = new_columns.remove('')
 
-        # # update existing manifest w/ missing columns, if any
+        # update existing manifest w/ missing columns, if any
         if new_columns:
             manifest_df = manifest_df.assign(
                 **dict(zip(new_columns, len(new_columns) * [""]))

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1566,11 +1566,13 @@ class ManifestGenerator(object):
             '''if we are returning an Excel spreadsheet, do not populate dataframe to google'''
             manifest_sh = self.set_dataframe_by_url(empty_manifest_url, manifest, populate_df = False)
             # construct output excel file path 
-            output_excel_file = os.path.basename("tests/data/" + title + ".xlsx")
+            file_name = title + ".xlsx"
+            output_excel_file_path = os.path.join("tests/data/", file_name)
             # export the manifest to excel
-            export_manifest_drive_service(manifest_url = manifest_sh.url, file_name=output_excel_file, mimeType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+            export_manifest_drive_service(manifest_url = manifest_sh.url, file_name=output_excel_file_path, mimeType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
             # populate exported sheet 
-            self.populate_existing_excel_spreadsheet(output_excel_file, manifest)
+            self.populate_existing_excel_spreadsheet(output_excel_file_path, manifest)
+            return output_excel_file_path
         else: 
             manifest_sh = self.set_dataframe_by_url(empty_manifest_url, manifest, populate_df = True)
             return manifest_sh.url

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1466,6 +1466,7 @@ class ManifestGenerator(object):
         Args:
             dataset_id: Synapse ID of the "dataset" entity on Synapse (for a given center/project).
             sheet_url: Determines if googlesheet URL or pandas dataframe should be returned.
+            return_excel: Determines if returning an Excel spreadsheet 
 
         Returns:
             Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
@@ -1474,12 +1475,13 @@ class ManifestGenerator(object):
         # Handle case when no dataset ID is provided
         if not dataset_id:
             manifest_url = self.get_empty_manifest(json_schema_filepath=json_schema)
-            if sheet_url:
+            if sheet_url or sheet_url == None:
                 return manifest_url
             else: 
                 # return an excel spreadsheet
-                output_file_path = self.export_sheet_to_excel(title = self.title, manifest_url = manifest_url)
-                return output_file_path
+                if return_excel: 
+                    output_file_path = self.export_sheet_to_excel(title = self.title, manifest_url = manifest_url)
+                    return output_file_path
 
         # Otherwise, create manifest using the given dataset
         #TODO: avoid explicitly exposing Synapse store functionality
@@ -1509,7 +1511,7 @@ class ManifestGenerator(object):
                 # if returning an excel spreadsheet
                 if return_excel:                    
                     # export to excel
-                    output_file_path = self.export_sheet_to_excel(title = self.title, manifest_url = manifest_url)
+                    output_file_path = self.export_sheet_to_excel(title = self.title, manifest_url = empty_manifest_url)
 
                     # populate existing excel spreadsheet
                     self.populate_existing_excel_spreadsheet(output_file_path, manifest_record[1])

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -254,7 +254,7 @@ class MetadataModel(object):
         errors, warnings, manifest = validate_all(self, errors, warnings, manifest, manifestPath, self.sg, jsonSchema, restrict_rules, project_scope)
         return errors, warnings
 
-    def populateModelManifest(self, title, manifestPath: str, rootNode: str) -> str:
+    def populateModelManifest(self, title, manifestPath: str, rootNode: str, return_excel = False) -> str:
         """Populate an existing annotations manifest based on a dataframe.
             TODO: Remove this method; always use getModelManifest instead
 
@@ -274,7 +274,7 @@ class MetadataModel(object):
 
         emptyManifestURL = mg.get_manifest()
 
-        return mg.populate_manifest_spreadsheet(manifestPath, emptyManifestURL)
+        return mg.populate_manifest_spreadsheet(manifestPath, emptyManifestURL, return_excel = return_excel, title=title)
 
     def submit_metadata_manifest(
         self,

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -157,7 +157,7 @@ def execute_google_api_requests(service, requests_body, **kwargs):
 
 def export_manifest_drive_service(manifest_url, file_name, mimeType):
     '''
-    Export manifest by using google drive api. 
+    Export manifest by using google drive api. If export as an Excel spreadsheet, the exported spreasheet would also include a hidden sheet 
     Args:
         manifest_url: google sheet manifest url
         file_name: name of the exported manifest

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -175,7 +175,21 @@ def export_manifest_csv(file_name, manifest):
         with open(file_name, 'wb') as f:
             f.write(data)
         f.close
-    
+
+def export_excel_sheet(manifest_url, output_excel, ):
+    # intialize drive service 
+    services_creds = build_service_account_creds()
+    drive_service = services_creds["drive_service"]
+
+    # get spreadsheet id from url 
+    spreadsheet_id = manifest_url.split('/')[-1]
+    data = drive_service.files().export(fileId=spreadsheet_id, mimeType='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet').execute()
+
+    # open file and write data
+    with open(output_excel, 'wb') as f:
+        f.write(data)
+    f.close
+
 def export_manifest_excel(manifest, output_excel=None):
     # intialize drive service 
     services_creds = build_service_account_creds()

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -178,8 +178,12 @@ def export_manifest_drive_service(manifest_url, file_path, mimeType):
     data = drive_service.files().export(fileId=spreadsheet_id, mimeType=mimeType).execute()
 
     # open file and write data
-    with open(file_path, 'wb') as f:
-        f.write(data)
+    with open(os.path.abspath(file_path), 'wb') as f:
+        try: 
+            f.write(data)
+        except FileNotFoundError as not_found: 
+            logger.error(f"{not_found.filename} could not be found")
+
     f.close
    
 

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -155,17 +155,18 @@ def execute_google_api_requests(service, requests_body, **kwargs):
 
         return response
 
-def export_manifest_drive_service(manifest_url, file_name, mimeType):
+def export_manifest_drive_service(manifest_url, file_path, mimeType):
     '''
     Export manifest by using google drive api. If export as an Excel spreadsheet, the exported spreasheet would also include a hidden sheet 
     Args:
         manifest_url: google sheet manifest url
-        file_name: name of the exported manifest
+        file_path: file path of the exported manifest
         mimeType: exporting mimetype
 
     result: Google sheet gets exported in desired format
 
     '''
+
     # intialize drive service 
     services_creds = build_service_account_creds()
     drive_service = services_creds["drive_service"]
@@ -177,26 +178,27 @@ def export_manifest_drive_service(manifest_url, file_name, mimeType):
     data = drive_service.files().export(fileId=spreadsheet_id, mimeType=mimeType).execute()
 
     # open file and write data
-    with open(file_name, 'wb') as f:
+    with open(file_path, 'wb') as f:
         f.write(data)
     f.close
    
 
-def export_manifest_csv(file_name, manifest):
+def export_manifest_csv(file_path, manifest):
     '''
     Export manifest as a CSV by using google drive api
     Args:
         manifest: could be a dataframe or a manifest url
-        file_name: name of the exported manifest
+        file_path: file path of the exported manifest
         mimeType: exporting mimetype
 
     result: Google sheet gets exported as a CSV
     '''
 
     if isinstance(manifest, pd.DataFrame):
-        manifest.to_csv(file_name, index=False)
+        manifest.to_csv(file_path, index=False)
     else: 
-        export_manifest_drive_service(manifest, file_name, mimeType = 'text/csv')
+        export_manifest_drive_service(manifest, file_path, mimeType = 'text/csv')
+
 
 
 def export_manifest_excel(manifest, output_excel=None):

--- a/tests/data/test_config.yml
+++ b/tests/data/test_config.yml
@@ -1,9 +1,8 @@
 definitions:
   creds_path: "../../credentials.json"
   token_pickle: "token.pickle"
-  # synapse_config: "../../.synapseConfig"
-  ### Note: this key is required for people who use Synapse token authentication approach. 
-  ### If you run into errors similar to KeyError: 'synpase_config', you might want to consider adding this key. 
+  synapse_config: "../../.synapseConfig" ### Note: this key is required for people who use Synapse token authentication approach. 
+  service_acct_creds: "../../schematic_service_account_creds.json" ## Note: this key is required for google drive services 
 
 synapse:
   master_fileview: "syn23643253"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -136,13 +136,13 @@ class TestManifestGenerator:
         if use_annotations:
             assert output["File Format"].tolist() == ["txt", "csv", "fastq"]
       
-    @pytest.mark.parametrize("output_form", [None, "dataframe", "excel", "google_sheet"])
+    @pytest.mark.parametrize("output_format", [None, "dataframe", "excel", "google_sheet"])
     @pytest.mark.parametrize("sheet_url", [None, True, False])
     @pytest.mark.parametrize("dataset_id", [None, "syn27600056"])
     @pytest.mark.google_credentials_needed
-    def test_get_manifest_excel(self, helpers, sheet_url, output_form, dataset_id):
+    def test_get_manifest_excel(self, helpers, sheet_url, output_format, dataset_id):
         '''
-        Purpose: the goal of this test is to make sure that output_form parameter and sheet_url parameter could function well; 
+        Purpose: the goal of this test is to make sure that output_format parameter and sheet_url parameter could function well; 
         In addition, this test also makes sure that getting a manifest with an existing dataset_id is working
         "use_annotations" and "data_type" are hard-coded to fixed values to avoid long run time
         '''
@@ -156,15 +156,15 @@ class TestManifestGenerator:
         )
 
 
-        manifest= generator.get_manifest(dataset_id=dataset_id, sheet_url = sheet_url, output_form = output_form)
+        manifest= generator.get_manifest(dataset_id=dataset_id, sheet_url = sheet_url, output_format = output_format)
 
         # if dataset id exists, it could return pandas dataframe, google spreadsheet, or an excel spreadsheet
         if dataset_id: 
-            if output_form: 
+            if output_format: 
 
-                if output_form == "dataframe":
+                if output_format == "dataframe":
                     assert isinstance(manifest, pd.DataFrame)
-                elif output_form == "excel":
+                elif output_format == "excel":
                     assert os.path.exists(manifest) == True
                 else: 
                     assert type(manifest) is str
@@ -178,8 +178,8 @@ class TestManifestGenerator:
         
         # if dataset id does not exist, it could return an empty google sheet or an empty excel spreadsheet exported from google
         else:
-            if output_form: 
-                if output_form == "excel":
+            if output_format: 
+                if output_format == "excel":
                     assert os.path.exists(manifest) == True
                 else: 
                     assert type(manifest) is str

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -186,10 +186,9 @@ class TestManifestGenerator:
                     assert manifest.startswith("https://docs.google.com/spreadsheets/")
         
         # Clean-up
-        try:
-            os.remove(helpers.get_data_path(f"example.{data_type}.schema.json"))
-        except FileNotFoundError:
-            pass
+    
+        if type(manifest) is str and os.path.exists(manifest): 
+            os.remove(manifest)
 
 
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -4,6 +4,7 @@ import pytest
 
 from schematic.manifest.generator import ManifestGenerator
 from schematic.schemas.generator import SchemaGenerator
+import pandas as pd
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -51,7 +52,6 @@ def manifest_generator(helpers, request):
         os.remove(helpers.get_data_path(f"example.{data_type}.schema.json"))
     except FileNotFoundError:
         pass
-
 
 @pytest.fixture(params=[True, False], ids=["sheet_url", "data_frame"])
 def manifest(dataset_id, manifest_generator, request):
@@ -135,3 +135,62 @@ class TestManifestGenerator:
         # An annotation merged with an attribute from the data model
         if use_annotations:
             assert output["File Format"].tolist() == ["txt", "csv", "fastq"]
+      
+    @pytest.mark.parametrize("return_excel", [None, True, False])
+    @pytest.mark.parametrize("sheet_url", [None, True, False])
+    @pytest.mark.parametrize("dataset_id", [None, "syn27600056"])
+    @pytest.mark.google_credentials_needed
+    def test_get_manifest_excel(self, helpers, sheet_url, return_excel, dataset_id):
+        '''
+        Purpose: the goal of this test is to make sure that return_excel parameter and sheet_url parameter could function well; 
+        In addition, this test also makes sure that getting a manifest with an existing dataset_id is working
+        "use_annotations" and "data_type" are hard-coded to fixed values to avoid long run time
+        '''
+
+        data_type = "Patient"
+
+        generator = ManifestGenerator(
+        path_to_json_ld=helpers.get_data_path("example.model.jsonld"),
+        root=data_type,
+        use_annotations=False,
+        )
+
+
+        manifest= generator.get_manifest(dataset_id=dataset_id, sheet_url = sheet_url, return_excel= return_excel)
+
+        # if dataset id exists, it could return pandas dataframe, google spreadsheet, or an excel spreadsheet
+        if dataset_id: 
+            if sheet_url: 
+                assert type(manifest) is str
+                assert manifest.startswith("https://docs.google.com/spreadsheets/")
+
+            else: 
+                if return_excel: 
+                    assert os.path.exists(manifest) == True                
+                else: 
+                    assert isinstance(manifest, pd.DataFrame)
+                    assert "Male" in manifest["Sex"].to_list()
+                    assert "Healthy" in manifest["Diagnosis"].to_list()
+
+                    if data_type == "Patient":
+                        assert "Patient" in manifest["Component"].to_list()
+                        assert "Patient ID" in manifest.columns
+        
+        # if dataset id does not exist, it could return an empty google sheet or an empty excel spreadsheet exported from google
+        else:
+            if sheet_url or sheet_url == None: 
+                assert type(manifest) is str
+                assert manifest.startswith("https://docs.google.com/spreadsheets/")
+            else:
+                if return_excel:
+                    assert os.path.exists(manifest) == True 
+        
+        # Clean-up
+        try:
+            os.remove(helpers.get_data_path(f"example.{data_type}.schema.json"))
+        except FileNotFoundError:
+            pass
+
+
+
+

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -8,7 +8,6 @@ from schematic.models.metadata import MetadataModel
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-
 @pytest.fixture
 def metadata_model(helpers):
 
@@ -19,6 +18,30 @@ def metadata_model(helpers):
 
     yield metadata_model
 
+
+class TestPopulateManifest:
+    @pytest.mark.parametrize("return_excel", [True, False])
+    @pytest.mark.google_credentials_needed
+    def test_populate_manifest(self, metadata_model, helpers, return_excel):
+        #Get path of manifest 
+        manifestPath = helpers.get_data_path("mock_manifests/Valid_Test_Manifest.csv")
+    
+        #Call populateModelManifest class
+        populated_manifest_route= metadata_model.populateModelManifest(title="mock_title", manifestPath=manifestPath, rootNode="MockComponent", return_excel=return_excel)
+
+        if not return_excel:
+            # return a url
+            assert type(populated_manifest_route) is str
+            assert populated_manifest_route.startswith("https://docs.google.com/spreadsheets/")
+        else: 
+            # return a valid file path
+            assert os.path.exists(populated_manifest_route) == True
+
+        # clean up 
+        try:
+            os.remove(helpers.get_data_path(f"mock_manifests/mock_title.xlsx"))
+        except FileNotFoundError:
+            pass
 
 class TestMetadataModel:
     @pytest.mark.parametrize("as_graph", [True, False], ids=["as_graph", "as_list"])
@@ -39,3 +62,26 @@ class TestMetadataModel:
             assert "Biospecimen" in output
             assert "Patient" in output
             assert "BulkRNA-seqAssay" in output
+
+    @pytest.mark.parametrize("return_excel", [True, False])
+    @pytest.mark.google_credentials_needed
+    def test_populate_manifest(self, metadata_model, helpers, return_excel):
+        #Get path of manifest 
+        manifestPath = helpers.get_data_path("mock_manifests/Valid_Test_Manifest.csv")
+    
+        #Call populateModelManifest class
+        populated_manifest_route= metadata_model.populateModelManifest(title="mock_title", manifestPath=manifestPath, rootNode="MockComponent", return_excel=return_excel)
+
+        if not return_excel:
+            # return a url
+            assert type(populated_manifest_route) is str
+            assert populated_manifest_route.startswith("https://docs.google.com/spreadsheets/")
+        else: 
+            # return a valid file path
+            assert os.path.exists(populated_manifest_route) == True
+
+        # clean up 
+        try:
+            os.remove(helpers.get_data_path(f"mock_manifests/mock_title.xlsx"))
+        except FileNotFoundError:
+            pass

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,30 +19,6 @@ def metadata_model(helpers):
     yield metadata_model
 
 
-class TestPopulateManifest:
-    @pytest.mark.parametrize("return_excel", [True, False])
-    @pytest.mark.google_credentials_needed
-    def test_populate_manifest(self, metadata_model, helpers, return_excel):
-        #Get path of manifest 
-        manifestPath = helpers.get_data_path("mock_manifests/Valid_Test_Manifest.csv")
-    
-        #Call populateModelManifest class
-        populated_manifest_route= metadata_model.populateModelManifest(title="mock_title", manifestPath=manifestPath, rootNode="MockComponent", return_excel=return_excel)
-
-        if not return_excel:
-            # return a url
-            assert type(populated_manifest_route) is str
-            assert populated_manifest_route.startswith("https://docs.google.com/spreadsheets/")
-        else: 
-            # return a valid file path
-            assert os.path.exists(populated_manifest_route) == True
-
-        # clean up 
-        try:
-            os.remove(helpers.get_data_path(f"mock_manifests/mock_title.xlsx"))
-        except FileNotFoundError:
-            pass
-
 class TestMetadataModel:
     @pytest.mark.parametrize("as_graph", [True, False], ids=["as_graph", "as_list"])
     def test_get_component_requirements(self, metadata_model, as_graph):


### PR DESCRIPTION
This PR is related to the issue mentioned [here](https://github.com/Sage-Bionetworks/schematic/issues/932). I added a parameter for endpoint '/manifest/populate' to control if it is returning a google sheet or an Excel spreadsheet. I have done the following testing: 

- [x] in swagger UI, set return_excel as True, and it would return an Excel workbook with hidden sheet. The formatting of google sheet could still be preserved in Excel and new columns get added. 
- [x] in swagger UI, set return_excel as False, and it would return a google sheet as usual 
- [x] Have the endpoint return Excel file path