### PR TITLE
BugFIx: Table Schema Replace

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1446,6 +1446,7 @@ class SynapseStorage(BaseStorage):
                             cols.append(Column(name=col, columnType='STRING', maximumSize=500))
                     
                     schema = Schema(name=table_name, columns=cols, parent=datasetParentProject)
+                    schema.id = existingTableId
                     table = Table(schema, table_to_load, etag = existing_results.etag)
                     table = self.syn.store(table, isRestricted = restrict)
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -139,8 +139,6 @@ class SynapseStorage(BaseStorage):
             except(SynapseHTTPError) as ex:
                 
                 str_message = str(ex).replace("\n","")
-                logging.warning(str_message)
-                return None
                 if 'missing' in str_message:
                     logging.warning(str_message)
                 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1410,7 +1410,7 @@ class SynapseStorage(BaseStorage):
                 sleep(1)
 
                 datasetParentProject = self.getDatasetProject(dataset_id)
-                
+                if specify_schema:
                     if column_type_dictionary == {}:
                         logger.error("Did not provide a column_type_dictionary.")
                     #create list of columns:
@@ -1421,6 +1421,10 @@ class SynapseStorage(BaseStorage):
                     schema.id = existingTableId
                     table = Table(schema, table_to_load, etag = existing_results.etag)
                     table = self.syn.store(table, isRestricted = restrict)
+                else:
+                    logger.error("Must specify schema when replacing table")
+
+                
 
 
             # remove system metadata from manifest

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1407,7 +1407,7 @@ class SynapseStorage(BaseStorage):
                 self.syn.delete(existing_results)
 
                 # wait for row deletion to finish on synapse before getting empty table
-                sleep(5)
+                sleep(1)
                 # removes all current columns
                 current_table = self.syn.get(existingTableId)
                 current_columns = self.syn.getTableColumns(current_table)

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -137,9 +137,17 @@ class SynapseStorage(BaseStorage):
             try:
                 return method(*args, **kwargs)
             except(SynapseHTTPError) as ex:
+                
                 str_message = str(ex).replace("\n","")
                 logging.warning(str_message)
                 return None
+                if 'missing' in str_message:
+                    logging.warning(str_message)
+                
+                    return None
+                else:
+                    raise ex
+                
         return wrapper
 
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1406,24 +1406,11 @@ class SynapseStorage(BaseStorage):
                 # remove rows
                 self.syn.delete(existing_results)
 
-                # wait for row deletion to finish on synapse before getting empty table
+                # wait for row deletion to finish on synapse 
                 sleep(1)
-                # removes all current columns
-                current_table = self.syn.get(existingTableId)
-                current_columns = self.syn.getTableColumns(current_table)
-                for col in current_columns:
-                    current_table.removeColumn(col)
-
-                # adds new columns to schema
-                new_columns = as_table_columns(table_to_load)
-                for col in new_columns:
-                    current_table.addColumn(col)
-                #self.syn.store(current_table, isRestricted = restrict)
-
-
 
                 datasetParentProject = self.getDatasetProject(dataset_id)
-                if specify_schema:
+                
                     if column_type_dictionary == {}:
                         logger.error("Did not provide a column_type_dictionary.")
                     #create list of columns:
@@ -1482,7 +1469,7 @@ class SynapseStorage(BaseStorage):
             Returns:
                 cols: list of columns processed to be used in schema generation
         """
-        
+
         cols = []
         for col in table_to_load.columns:
             if col in column_type_dictionary:


### PR DESCRIPTION
Fixes the error raised that `UUID` strings are too long when trying to upload a manifest as a table to replace an existing table