### PR TITLE
Remove Manifest Table Submission Dependency on Project Scope when not Validating

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -717,16 +717,16 @@ class SynapseStorage(BaseStorage):
 
         return df, results
 
-    def _get_tables(self) -> List[Table]:
-        project = self.syn.get(self.project_scope[0])
+    def _get_tables(self, datasetId: str = None) -> List[Table]:
+        project = self.syn.get(self.getDatasetProject(datasetId))
         return list(self.syn.getChildren(project, includeTypes=["table"]))
 
-    def get_table_info(self) -> List[str]:
+    def get_table_info(self, datasetId: str = None) -> List[str]:
         """Gets the names of the tables in the schema
         Returns:
             list[str]: A list of table names
         """
-        tables = self._get_tables()
+        tables = self._get_tables(datasetId)
         if tables:
             return {table["name"]: table["id"] for table in tables}
         else: 
@@ -735,7 +735,7 @@ class SynapseStorage(BaseStorage):
     @missing_entity_handler
     def upload_format_manifest_table(self, se, manifest, datasetId, table_name, restrict, useSchemaLabel):
         # Rename the manifest columns to display names to match fileview
-        table_info = self.get_table_info()
+        table_info = self.get_table_info(datasetId)
 
         blacklist_chars = ['(', ')', '.', ' ']
         manifest_columns = manifest.columns.tolist()


### PR DESCRIPTION
The project synID is necessary for table replacements. currently it is being taken from the `--project_scope` argument when calling the manifest submission command but it can cause errors as this was not previously required to facilitate the command. This pr removes the requirement of including the project scope in the command and gathers the information with a different method.