### PR TITLE
update error messages in synapseStore when `manifest_basename` key is missing in config.yml 

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -84,13 +84,13 @@ class SynapseStorage(BaseStorage):
         # check if "master_fileview" has been set
         try: 
             self.storageFileview = CONFIG["synapse"]["master_fileview"]
-        except: 
+        except KeyError: 
             raise MissingConfigValueError(("synapse", "master_fileview"))
 
         # check if "master_basename" has been set
         try: 
             self.manifest = CONFIG["synapse"]["manifest_basename"]
-        except: 
+        except KeyError: 
             raise MissingConfigValueError(("synapse", "master_basename"))
 
         try:

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -79,8 +79,23 @@ class SynapseStorage(BaseStorage):
 
         self.syn = self.login(token, access_token, input_token)
         self.project_scope = project_scope
+
+
+        # check if "master_fileview" has been set
+        try: 
+            self.storageFileview = CONFIG["synapse"]["master_fileview"]
+        except: 
+            raise MissingConfigValueError(("synapse", "master_fileview"))
+
+        # check if "master_basename" has been set
+        try: 
+            self.manifest = CONFIG["synapse"]["manifest_basename"]
+        except: 
+            raise MissingConfigValueError(("synapse", "master_basename"))
+
         try:
             self.storageFileview = CONFIG["synapse"]["master_fileview"]
+            self.manifest = CONFIG["synapse"]["manifest_basename"]
             if self.project_scope:
                 self.storageFileviewTable = self.syn.tableQuery(
                     f"SELECT * FROM {self.storageFileview} WHERE projectId IN {tuple(self.project_scope + [''])}"
@@ -90,17 +105,10 @@ class SynapseStorage(BaseStorage):
                 self.storageFileviewTable = self.syn.tableQuery(
                     "SELECT * FROM " + self.storageFileview
                 ).asDataFrame()
-
-            self.manifest = CONFIG["synapse"]["manifest_basename"]
-        
-        except KeyError:
-            raise MissingConfigValueError(("synapse", "master_fileview"))
         except AttributeError:
             raise AttributeError("storageFileview attribute has not been set.")
         except SynapseHTTPError:
             raise AccessCredentialsError(self.storageFileview)
-        except ValueError:
-            raise MissingConfigValueError(("synapse", "master_fileview"))
 
     @staticmethod
     def login(token=None, access_token=None, input_token=None):


### PR DESCRIPTION
It seems like our `SynapseStorage` class mixes the error of missing `master_fileview` key in the config.yml and missing `manifest_basename` key. 

Currently, if the `manifest_basename` key is missing in the `config.yml`, it would raise the error of missing `master_fileview` key

This PR is for separating the error messages for these two. 