### PR TITLE
HOTFIX: Extend table replacement sleep duration to ensure synapse deletion operation completes

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1413,7 +1413,7 @@ class SynapseStorage(BaseStorage):
                 # remove rows
                 self.syn.delete(existing_results)
                 # wait for row deletion to finish on synapse before getting empty table
-                sleep(1)
+                sleep(10)
                 
                 # removes all current columns
                 current_table = self.syn.get(existingTableId)


### PR DESCRIPTION
Temporary fix while JIRA issue [SYNPY-1239](https://sagebionetworks.jira.com/plugins/servlet/mobile?originPath=%2Fbrowse%2FSYNPY-1239#issue/SYNPY-1239) is in progress. Will slow down performance, but allows table replacement operations to complete without error or disconnect. `sleep`s will likely be unnecessary altogether once permanent solution is developed.

Addresses @adamjtaylor [comment on #/31](https://github.com/ncihtan/HTAN-data-curator/issues/31#issuecomment-1302236700)