### PR TITLE
Removed validity requirement for unrequired attribute entries, allow users to specify validation rule conformity required for entries, fix DCA disconnect caused by JSON Schema validation errors

### DIFF
--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -409,15 +409,17 @@ class GreatExpectationsHelpers(object):
                 #call functions to generate error messages and add to error list
                 if validation_types[rule.split(" ")[0]]['type']=='type_validation':
                     for row, value in zip(indices,values):
-                        errors.append(
-                            GenerateError.generate_type_error(
+                        vr_errors, vr_warnings = GenerateError.generate_type_error(
                                 val_rule = rule,
                                 row_num = row+2,
                                 attribute_name = errColumn,
                                 invalid_entry = value,
                                 sg = sg,
                             )
-                        )          
+                    if vr_errors:
+                        errors.append(vr_errors)  
+                    if vr_warnings:
+                        warnings.append(vr_warnings) 
                 elif validation_types[rule.split(" ")[0]]['type']=='regex_validation':
                     expression=result_dict['expectation_config']['kwargs']['regex']
 
@@ -434,22 +436,22 @@ class GreatExpectationsHelpers(object):
                             )
                         )    
                 elif validation_types[rule.split(" ")[0]]['type']=='content_validation':     
-                    content_errors, content_warnings = GenerateError.generate_content_error(
+                    vr_errors, vr_warnings = GenerateError.generate_content_error(
                                                             val_rule = rule, 
                                                             attribute_name = errColumn,
                                                             row_num = list(np.array(indices)+2),
                                                             error_val = values,  
                                                             sg = self.sg
                                                         )       
-                    if content_errors:
-                        errors.append(content_errors)  
+                    if vr_errors:
+                        errors.append(vr_errors)  
                         if rule.startswith('protectAges'):
-                            self.censor_ages(content_errors,errColumn)
+                            self.censor_ages(vr_errors,errColumn)
                             pass
-                    elif content_warnings:
-                        warnings.append(content_warnings)  
+                    if vr_warnings:
+                        warnings.append(vr_warnings)  
                         if rule.startswith('protectAges'):
-                            self.censor_ages(content_warnings,errColumn)
+                            self.censor_ages(vr_warnings,errColumn)
                             pass
 
         return errors, warnings

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -416,16 +416,14 @@ class GreatExpectationsHelpers(object):
                                 invalid_entry = value,
                                 sg = sg,
                             )
-                    if vr_errors:
-                        errors.append(vr_errors)  
-                    if vr_warnings:
-                        warnings.append(vr_warnings) 
+                        if vr_errors:
+                            errors.append(vr_errors)  
+                        if vr_warnings:
+                            warnings.append(vr_warnings) 
                 elif validation_types[rule.split(" ")[0]]['type']=='regex_validation':
                     expression=result_dict['expectation_config']['kwargs']['regex']
-
                     for row, value in zip(indices,values):   
-                        errors.append(
-                            GenerateError.generate_regex_error(
+                        vr_errors, vr_warnings = GenerateError.generate_regex_error(
                                 val_rule= rule,
                                 reg_expression = expression,
                                 row_num = row+2,
@@ -434,7 +432,10 @@ class GreatExpectationsHelpers(object):
                                 invalid_entry = value,
                                 sg = sg,
                             )
-                        )    
+                        if vr_errors:
+                            errors.append(vr_errors)  
+                        if vr_warnings:
+                            warnings.append(vr_warnings)                          
                 elif validation_types[rule.split(" ")[0]]['type']=='content_validation':     
                     vr_errors, vr_warnings = GenerateError.generate_content_error(
                                                             val_rule = rule, 

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -23,6 +23,7 @@ from great_expectations.data_context.types.base import DataContextConfig, Dataso
 from great_expectations.data_context.types.resource_identifiers import ExpectationSuiteIdentifier
 
 from schematic.models.validate_attribute import GenerateError
+from schematic.schemas.generator import SchemaGenerator
 from schematic.utils.validate_utils import rule_in_rule_list
 
 logger = logging.getLogger(__name__)
@@ -350,7 +351,8 @@ class GreatExpectationsHelpers(object):
         validation_results: Dict,
         validation_types: Dict,
         errors: List,
-        warnings: List
+        warnings: List,
+        sg: SchemaGenerator,
         ):
         """
             Purpose:
@@ -413,6 +415,7 @@ class GreatExpectationsHelpers(object):
                                 row_num = row+2,
                                 attribute_name = errColumn,
                                 invalid_entry = value,
+                                sg = sg,
                             )
                         )          
                 elif validation_types[rule.split(" ")[0]]['type']=='regex_validation':
@@ -427,6 +430,7 @@ class GreatExpectationsHelpers(object):
                                 module_to_call = 'match',
                                 attribute_name = errColumn,
                                 invalid_entry = value,
+                                sg = sg,
                             )
                         )    
                 elif validation_types[rule.split(" ")[0]]['type']=='content_validation':     

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -160,7 +160,7 @@ class GreatExpectationsHelpers(object):
             if validation_rules:
                 #iterate through all validation rules for an attribute
                 for rule in validation_rules:
-                    
+                    base_rule = rule.split(" ")[0]
             
                     #check if rule has an implemented expectation
                     if rule_in_rule_list(rule,self.unimplemented_expectations):
@@ -170,8 +170,9 @@ class GreatExpectationsHelpers(object):
                     args["column"] = col
                     args["result_format"] = "COMPLETE"
 
+
                     #Validate num
-                    if rule=='num':
+                    if base_rule=='num':
                         args["mostly"]=1.0
                         args["type_list"]=['int','int64', 'float', 'float64']
                         meta={
@@ -183,7 +184,7 @@ class GreatExpectationsHelpers(object):
                         }
                 
                     #Validate float
-                    elif rule=='float':
+                    elif base_rule=='float':
                         args["mostly"]=1.0
                         args["type_list"]=['float', 'float64']
                         meta={
@@ -195,7 +196,7 @@ class GreatExpectationsHelpers(object):
                         }
                 
                     #Validate int
-                    elif rule=='int':
+                    elif base_rule=='int':
                         args["mostly"]=1.0
                         args["type_list"]=['int','int64']
                         meta={
@@ -207,7 +208,7 @@ class GreatExpectationsHelpers(object):
                         }
                 
                     #Validate string
-                    elif rule=='str':
+                    elif base_rule=='str':
                         args["mostly"]=1.0
                         args["type_"]='str'
                         meta={
@@ -218,7 +219,7 @@ class GreatExpectationsHelpers(object):
                             "validation_rule": rule
                         }
 
-                    elif rule.startswith("recommended"):
+                    elif base_rule==("recommended"):
                         args["mostly"]=0.0000000001
                         args["regex_list"]=['^$']
                         meta={
@@ -229,7 +230,7 @@ class GreatExpectationsHelpers(object):
                             "validation_rule": rule
                         }
 
-                    elif rule.startswith("protectAges"):
+                    elif base_rule==("protectAges"):
                         #Function to convert to different age limit formats
                         min_age, max_age = self.get_age_limits()
 
@@ -244,7 +245,7 @@ class GreatExpectationsHelpers(object):
                             "validation_rule": rule
                         }
 
-                    elif rule.startswith("unique"):
+                    elif base_rule==("unique"):
                         args["mostly"]=1.0
                         meta={
                             "notes": {
@@ -254,7 +255,7 @@ class GreatExpectationsHelpers(object):
                             "validation_rule": rule
                         }
                     
-                    elif rule.startswith("inRange"):
+                    elif base_rule==("inRange"):
                         args["mostly"]=1.0
                         args["min_value"]=float(rule.split(" ")[1])
                         args["max_value"]=float(rule.split(" ")[2])

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -655,8 +655,6 @@ class ValidateAttribute(object):
                         re_to_check
                     ):
                         vr_errors, vr_warnings = GenerateError.generate_regex_error(
-                                val_rule,
-                                reg_expression,
                                 val_rule = val_rule,
                                 reg_expression = reg_expression,
                                 row_num=str(i + 2),
@@ -678,8 +676,6 @@ class ValidateAttribute(object):
                     re_to_check
                 ):
                     vr_errors, vr_warnings = GenerateError.generate_regex_error(
-                            val_rule,
-                            reg_expression,
                             val_rule = val_rule,
                             reg_expression = reg_expression,
                             row_num=str(i + 2),
@@ -729,7 +725,7 @@ class ValidateAttribute(object):
             for i, value in enumerate(manifest_col):
                 if bool(value) and not isinstance(value, specified_type[val_rule]):
                     vr_errors, vr_warnings = GenerateError.generate_type_error(
-                            val_rule = val_rule,
+                            val_rule = val_rule ,
                             row_num=str(i + 2),
                             attribute_name=manifest_col.name,
                             invalid_entry=str(manifest_col[i]),
@@ -743,7 +739,7 @@ class ValidateAttribute(object):
             for i, value in enumerate(manifest_col):
                 if bool(value) and not isinstance(value, specified_type[val_rule]):
                     vr_errors, vr_warnings = GenerateError.generate_type_error(
-                            val_rule = val_rule ,
+                            val_rule = val_rule,
                             row_num=str(i + 2),
                             attribute_name=manifest_col.name,
                             invalid_entry=str(manifest_col[i]),

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -506,7 +506,7 @@ class GenerateError:
             # If not required or recommended raise nothing. 
             ## Redundant setting to None here again but including for clarity
             else:
-                level = None 
+                level = 'warning' 
                 return level
 
         

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -843,6 +843,7 @@ class ValidateAttribute(object):
                                     argument=arg,
                                     invalid_entry=manifest_col[i],
                                     sg = sg,
+                                    val_rule = val_rule,
                                 )
                             if vr_errors:
                                 errors.append(vr_errors)

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -47,7 +47,7 @@ class GenerateError:
 
     def generate_list_error(
         list_string: str, row_num: str, attribute_name: str, list_error: str,
-        invalid_entry:str, sg: SchemaGenerator,
+        invalid_entry:str, sg: SchemaGenerator, val_rule: str,
     ) -> List[str]:
         """
             Purpose:
@@ -67,6 +67,7 @@ class GenerateError:
         
         #Determine which, if any, message to raise
         raises = GenerateError.get_message_level(
+            val_rule = val_rule,
             attribute_name = attribute_name,
             sg = sg,
             invalid_entry = invalid_entry,
@@ -127,6 +128,7 @@ class GenerateError:
         
         #Determine which, if any, message to raise
         raises = GenerateError.get_message_level(
+            val_rule = val_rule,
             attribute_name = attribute_name,
             sg = sg,
             invalid_entry = invalid_entry,
@@ -178,6 +180,7 @@ class GenerateError:
         
         #Determine which, if any, message to raise
         raises = GenerateError.get_message_level(
+            val_rule = val_rule,
             attribute_name = attribute_name,
             sg = sg,
             invalid_entry = invalid_entry,
@@ -211,7 +214,7 @@ class GenerateError:
 
     def generate_url_error(
         url: str, url_error: str, row_num: str, attribute_name: str, argument: str,
-        invalid_entry:str, sg: SchemaGenerator,
+        invalid_entry:str, sg: SchemaGenerator, val_rule: str,
     ) -> List[str]:
         """
             Purpose:
@@ -242,6 +245,7 @@ class GenerateError:
         
         #Determine which, if any, message to raise
         raises = GenerateError.get_message_level(
+            val_rule = val_rule,
             attribute_name = attribute_name,
             sg = sg,
             invalid_entry = invalid_entry,
@@ -321,7 +325,7 @@ class GenerateError:
         
         #Determine which, if any, message to raise
         raises = GenerateError.get_message_level(
-            val_rule=val_rule,
+            val_rule = val_rule,
             attribute_name = attribute_name,
             sg = sg,
             invalid_entry = invalid_entry,
@@ -461,7 +465,7 @@ class GenerateError:
         sg: SchemaGenerator,
         attribute_name: str,
         invalid_entry,
-        val_rule: str = None,
+        val_rule: str,
         ) -> str:
         """
         Purpose:
@@ -584,6 +588,7 @@ class ValidateAttribute(object):
                             list_error=list_error,
                             invalid_entry=manifest_col[i],
                             sg = sg,
+                            val_rule = val_rule, 
                         )
                     if vr_errors:
                         errors.append(vr_errors)
@@ -652,6 +657,8 @@ class ValidateAttribute(object):
                         vr_errors, vr_warnings = GenerateError.generate_regex_error(
                                 val_rule,
                                 reg_expression,
+                                val_rule = val_rule,
+                                reg_expression = reg_expression,
                                 row_num=str(i + 2),
                                 module_to_call=reg_exp_rules[1],
                                 attribute_name=manifest_col.name,
@@ -673,6 +680,8 @@ class ValidateAttribute(object):
                     vr_errors, vr_warnings = GenerateError.generate_regex_error(
                             val_rule,
                             reg_expression,
+                            val_rule = val_rule,
+                            reg_expression = reg_expression,
                             row_num=str(i + 2),
                             module_to_call=reg_exp_rules[1],
                             attribute_name=manifest_col.name,
@@ -720,7 +729,7 @@ class ValidateAttribute(object):
             for i, value in enumerate(manifest_col):
                 if bool(value) and not isinstance(value, specified_type[val_rule]):
                     vr_errors, vr_warnings = GenerateError.generate_type_error(
-                            val_rule,
+                            val_rule = val_rule,
                             row_num=str(i + 2),
                             attribute_name=manifest_col.name,
                             invalid_entry=str(manifest_col[i]),
@@ -734,7 +743,7 @@ class ValidateAttribute(object):
             for i, value in enumerate(manifest_col):
                 if bool(value) and not isinstance(value, specified_type[val_rule]):
                     vr_errors, vr_warnings = GenerateError.generate_type_error(
-                            val_rule,
+                            val_rule = val_rule ,
                             row_num=str(i + 2),
                             attribute_name=manifest_col.name,
                             invalid_entry=str(manifest_col[i]),
@@ -786,6 +795,7 @@ class ValidateAttribute(object):
                         argument=url_args,
                         invalid_entry=manifest_col[i],
                         sg = sg,
+                        val_rule = val_rule,
                     )
                 if vr_errors:
                     errors.append(vr_errors)
@@ -813,6 +823,7 @@ class ValidateAttribute(object):
                             argument=url_args,
                             invalid_entry=manifest_col[i],
                             sg = sg,
+                            val_rule = val_rule,
                         )
                     if vr_errors:
                         errors.append(vr_errors)

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -464,44 +464,35 @@ class GenerateError:
         """
         Purpose:
             Determine whether an error or warning message should be logged and displayed
+            
+            if node is not required, 
+                return warning
+            if node is recommended and requried, 
+                return None    
+            for other rules, parse possible, if not use default specified in validation_rule_info
 
-            Types of error/warning included:
-                - recommended - Raised when an attribute is empty and recommended but not required.
-                - unique - Raised when attribute values are not unique.
-                - protectAges - Raised when an attribute contains ages below 18YO or over 90YO that should be censored.
         Input:
                 val_rule: str, defined in the schema.
                 sg: schemaGenerator object
                 attribute_name: str, attribute being validated
         Returns:
             'error', 'warning' or None
+        # TODO: recommended and other rules
         """
 
         level = None
         rule_parts = val_rule.split(" ")
-        # if node is not required, return None
-        # if node is recommended and requried, return None
-            # TODO: recommended and other rules
-        # if validion type is cross manifest, default to warning but parse
-        # if validation type is content, default to warning but parse
-        # if validation rule is other, default to error but parse
-
-
-        print(rule_parts) 
-
-
         rule_info = validation_rule_info()
 
         if not sg.is_node_required(node_display_name=attribute_name):
             # raise warning if recommended but not required
             if 'recommended' in val_rule:
                 level = 'warning'
-            # If not required or recommended raise nothing. 
-            ## Redundant setting to None here again but including for clarity
+            # If not required or recommended raise warnings to notify
             else:
                 level = 'warning' 
                 return level
-
+        
         
         # Parse rule for level, set to default if not specified
         if rule_parts[-1].lower() == 'error':
@@ -511,7 +502,6 @@ class GenerateError:
         else:
             level = rule_info[rule_parts[0]]['default_message_level']
             
-        print(level)
         return level
 
 class ValidateAttribute(object):

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -71,7 +71,6 @@ class GenerateError:
             val_rule = val_rule,
             attribute_name = attribute_name,
             sg = sg,
-            invalid_entry = invalid_entry,
             )
 
         #if a message needs to be raised, get the approrpiate function to do so
@@ -132,7 +131,6 @@ class GenerateError:
             val_rule = val_rule,
             attribute_name = attribute_name,
             sg = sg,
-            invalid_entry = invalid_entry,
             )
 
         #if a message needs to be raised, get the approrpiate function to do so
@@ -184,7 +182,6 @@ class GenerateError:
             val_rule = val_rule,
             attribute_name = attribute_name,
             sg = sg,
-            invalid_entry = invalid_entry,
             )
 
         #if a message needs to be raised, get the approrpiate function to do so
@@ -249,7 +246,6 @@ class GenerateError:
             val_rule = val_rule,
             attribute_name = attribute_name,
             sg = sg,
-            invalid_entry = invalid_entry,
             )
 
         #if a message needs to be raised, get the approrpiate function to do so
@@ -329,7 +325,6 @@ class GenerateError:
             val_rule = val_rule,
             attribute_name = attribute_name,
             sg = sg,
-            invalid_entry = invalid_entry,
             )
 
         #if a message needs to be raised, get the approrpiate function to do so
@@ -409,7 +404,6 @@ class GenerateError:
             val_rule=val_rule,
             attribute_name = attribute_name,
             sg = sg,
-            invalid_entry = error_val,
             )
 
         #if a message needs to be raised, get the approrpiate function to do so
@@ -465,7 +459,6 @@ class GenerateError:
     def get_message_level(
         sg: SchemaGenerator,
         attribute_name: str,
-        invalid_entry,
         val_rule: str,
         ) -> str:
         """

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -1,28 +1,26 @@
 import builtins
-from jsonschema import ValidationError
 import logging
+import re
+import sys
+import time
+from os import getenv
+# allows specifying explicit variable types
+from typing import Any, Dict, List, Optional, Text
+from urllib import error
+from urllib.parse import urlparse
+from urllib.request import (HTTPDefaultErrorHandler, OpenerDirector, Request,
+                            urlopen)
 
 import numpy as np
 import pandas as pd
-import re
-import sys
-from os import getenv
+from jsonschema import ValidationError
 
-# allows specifying explicit variable types
-from typing import Any, Dict, Optional, Text, List
-from urllib.parse import urlparse
-from urllib.request import urlopen, OpenerDirector, HTTPDefaultErrorHandler
-from urllib.request import Request
-from urllib import error
-
-from schematic.store.synapse import SynapseStorage
-from schematic.store.base import BaseStorage
 from schematic.schemas.generator import SchemaGenerator
-from schematic.utils.validate_utils import comma_separated_list_regex
+from schematic.store.base import BaseStorage
+from schematic.store.synapse import SynapseStorage
 from schematic.utils.validate_rules_utils import validation_rule_info
-import time
-
-from schematic.utils.validate_utils import parse_str_series_to_list
+from schematic.utils.validate_utils import (comma_separated_list_regex,
+                                            parse_str_series_to_list)
 
 logger = logging.getLogger(__name__)
 

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -492,6 +492,8 @@ class GenerateError:
             else:
                 level = 'warning' 
                 return level
+        elif sg.is_node_required(node_display_name=attribute_name) and 'recommended' in val_rule:
+            level = None
         
         
         # Parse rule for level, set to default if not specified

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -238,15 +238,12 @@ class ValidateManifest(object):
                 errorMsg = error.message[0:500]
                 errorVal = error.instance if len(error.path) > 0 else "Wrong schema"
 
-                errors.append([errorRow, errorCol, errorMsg, errorVal])
-                col_attr[errorCol] = errorColName
-        if errors: 
-            for error in errors: 
-                row_num = error[0]
-                col_index = error[1]
-                attr_name = col_attr[col_index]
-                errorMsg = error[2]
-                GenerateError.generate_schema_error(row_num = row_num, attribute_name = attr_name, error_msg = errorMsg, sg = sg)
+                val_errors, val_warnings =  GenerateError.generate_schema_error(row_num = errorRow, attribute_name = errorColName, error_msg = errorMsg, invalid_entry = errorVal, sg = sg)
+
+                if val_errors:
+                    errors.append(val_errors)
+                if val_warnings:
+                    warnings.append(val_warnings)
 
         return errors, warnings
 

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -160,6 +160,7 @@ class ValidateManifest(object):
                 warnings = warnings,
                 validation_results = validation_results,
                 validation_types = validation_types,
+                sg = sg,
                 )               
         else:             
             logging.info("Great Expetations suite will not be utilized.")  
@@ -196,16 +197,16 @@ class ValidateManifest(object):
 
                     if validation_type == "list":
                         vr_errors, vr_warnings, manifest_col = validation_method(
-                            self, rule, manifest[col]
+                            self, rule, manifest[col], sg,
                         )
                         manifest[col] = manifest_col
                     elif validation_type.lower().startswith("match"):
                         vr_errors, vr_warnings = validation_method(
-                            self, rule, manifest[col], project_scope,
+                            self, rule, manifest[col], project_scope, sg,
                         )
                     else:
                         vr_errors, vr_warnings = validation_method(
-                            self, rule, manifest[col]
+                            self, rule, manifest[col], sg,
                         )
                     # Check for validation rule errors and add them to other errors.
                     if vr_errors:
@@ -215,7 +216,7 @@ class ValidateManifest(object):
 
         return manifest, errors, warnings
 
-    def validate_manifest_values(self, manifest, jsonSchema
+    def validate_manifest_values(self, manifest, jsonSchema, sg
     ) -> (List[List[str]], List[List[str]]):
         
         errors = []
@@ -245,7 +246,7 @@ class ValidateManifest(object):
                 col_index = error[1]
                 attr_name = col_attr[col_index]
                 errorMsg = error[2]
-                GenerateError.generate_schema_error(row_num = row_num, attribute_name = attr_name, error_msg = errorMsg)
+                GenerateError.generate_schema_error(row_num = row_num, attribute_name = attr_name, error_msg = errorMsg, sg = sg)
 
         return errors, warnings
 
@@ -258,7 +259,7 @@ def validate_all(self, errors, warnings, manifest, manifestPath, sg, jsonSchema,
     if vmr_warnings:
         warnings.extend(vmr_warnings)
 
-    vmv_errors, vmv_warnings = vm.validate_manifest_values(manifest, jsonSchema)
+    vmv_errors, vmv_warnings = vm.validate_manifest_values(manifest, jsonSchema, sg)
     if vmv_errors:
         errors.extend(vmv_errors)
     if vmv_warnings:

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -22,68 +22,81 @@ def validation_rule_info():
             "int": {
                 'arguments':(1, 0),
                 'type': "type_validation",
-                'complementary_rules': ['inRange',]},
+                'complementary_rules': ['inRange',],
+                'default_message_level': 'error'},
 
             "float": {
                 'arguments':(1, 0),
                 'type': "type_validation",
-                'complementary_rules': ['inRange',]},
+                'complementary_rules': ['inRange',],
+                'default_message_level': 'error'},
 
             "num": {
                 'arguments':(1, 0),
                 'type': "type_validation",
-                'complementary_rules': ['inRange',]},
+                'complementary_rules': ['inRange',],
+                'default_message_level': 'error'},
 
             "str": {
                 'arguments':(1, 0),
                 'type': "type_validation",
-                'complementary_rules': None},
+                'complementary_rules': None,
+                'default_message_level': 'error'},
 
             "regex": {
                 'arguments':(3, 2), 
                 'fixed_arg': ['strict'], 
                 'type': "regex_validation",
-                'complementary_rules': ['list']},
+                'complementary_rules': ['list'],
+                'default_message_level': 'error'},
 
             "url" : {
                 'arguments':(101, 0), 
                 'type': "url_validation",
-                'complementary_rules': None},
+                'complementary_rules': None,
+                'default_message_level': 'error'},
 
             "list": {
                 'arguments':(2, 0), 
                 'type': "list_validation",
-                'complementary_rules': ['regex']},
+                'complementary_rules': ['regex'],
+                'default_message_level': 'error'},
                 
             "matchAtLeastOne": {
                 'arguments':(3, 2), 
                 'type': "cross_validation",
-                'complementary_rules': None},
+                'complementary_rules': None,
+                'default_message_level': 'warning'},
 
             "matchExactlyOne": {
                 'arguments':(3, 2), 
                 'type': "cross_validation",
-                'complementary_rules': None},
+                'complementary_rules': None,
+                'default_message_level': 'warning'},
                 
             "recommended": {
                 'arguments':(1, 0), 
                 'type': "content_validation",
-                'complementary_rules': None},
+                'complementary_rules': None,
+                'default_message_level': 'warning'},
 
             "protectAges": {
                 'arguments':(1, 0), 
                 'type': "content_validation",
-                'complementary_rules': ['inRange',]},
+                'complementary_rules': ['inRange',],
+                'default_message_level': 'warning'},
 
             "unique": {
                 'arguments':(1, 0), 
                 'type': "content_validation",
-                'complementary_rules': None},
+                'complementary_rules': None,
+                'default_message_level': 'error'},
                 
             "inRange": {
                 'arguments':(3, 2), 
                 'type': "content_validation",
-                'complementary_rules': ['int','float','num','protectAges']},
+                'complementary_rules': ['int','float','num','protectAges'],
+                'default_message_level': 'error'},
             }
 
     return rule_dict

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -20,53 +20,53 @@ def validation_rule_info():
     '''
     rule_dict = {
             "int": {
-                'arguments':(None, None),
+                'arguments':(1, 0),
                 'type': "type_validation",
                 'complementary_rules': ['inRange',]},
 
             "float": {
-                'arguments':(None, None), 
+                'arguments':(1, 0),
                 'type': "type_validation",
                 'complementary_rules': ['inRange',]},
 
             "num": {
-                'arguments':(None, None), 
+                'arguments':(1, 0),
                 'type': "type_validation",
                 'complementary_rules': ['inRange',]},
 
             "str": {
-                'arguments':(None, None), 
+                'arguments':(1, 0),
                 'type': "type_validation",
                 'complementary_rules': None},
 
             "regex": {
-                'arguments':(2, 2), 
+                'arguments':(3, 2), 
                 'fixed_arg': ['strict'], 
                 'type': "regex_validation",
                 'complementary_rules': ['list']},
 
             "url" : {
-                'arguments':(None, None), 
+                'arguments':(101, 0), 
                 'type': "url_validation",
                 'complementary_rules': None},
 
             "list": {
-                'arguments':(1, 0), 
+                'arguments':(2, 0), 
                 'type': "list_validation",
                 'complementary_rules': ['regex']},
                 
             "matchAtLeastOne": {
-                'arguments':(2, 2), 
+                'arguments':(3, 2), 
                 'type': "cross_validation",
                 'complementary_rules': None},
 
             "matchExactlyOne": {
-                'arguments':(2, 2), 
+                'arguments':(3, 2), 
                 'type': "cross_validation",
                 'complementary_rules': None},
                 
             "recommended": {
-                'arguments':(None, None), 
+                'arguments':(1, 0), 
                 'type': "content_validation",
                 'complementary_rules': None},
 

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -19,20 +19,20 @@ CSV/TSV,,,Genome Build,,FALSE,ValidValue,,,
 Genome Build,,"GRCh37, GRCh38, GRCm38, GRCm39",,,TRUE,DataProperty,,,
 Genome FASTA,,,,,TRUE,DataProperty,,,
 MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range",,FALSE,DataType,,,
-Check List,,"ab, cd, ef, gh",,,FALSE,DataProperty,,,list strict
-Check Regex List,,,,,FALSE,DataProperty,,,list strict::regex match [a-f]
-Check Regex Single,,,,,FALSE,DataProperty,,,regex search [a-f]
-Check Regex Format,,,,,FALSE,DataProperty,,,regex match [a-f]
-Check Num,,,,,FALSE,DataProperty,,,num
-Check Float,,,,,FALSE,DataProperty,,,float
-Check Int,,,,,FALSE,DataProperty,,,int
-Check String,,,,,FALSE,DataProperty,,,str
-Check URL,,,,,FALSE,DataProperty,,,url
-Check Match at Least,,,,,FALSE,DataProperty,,,matchAtLeastOne Patient.PatientID set
-Check Match Exactly,,,,,FALSE,DataProperty,,,matchExactlyOne MockComponent.checkMatchExactly set
-Check Match at Least values,,,,,FALSE,DataProperty,,,matchAtLeastOne MockComponent.checkMatchatLeastvalues value
-Check Match Exactly values,,,,,FALSE,DataProperty,,,matchExactlyOne MockComponent.checkMatchExactlyvalues value
+Check List,,"ab, cd, ef, gh",,,TRUE,DataProperty,,,list strict 
+Check Regex List,,,,,TRUE,DataProperty,,,list strict::regex match [a-f]
+Check Regex Single,,,,,TRUE,DataProperty,,,regex search [a-f]
+Check Regex Format,,,,,TRUE,DataProperty,,,regex match [a-f]
+Check Num,,,,,TRUE,DataProperty,,,num
+Check Float,,,,,TRUE,DataProperty,,,float
+Check Int,,,,,TRUE,DataProperty,,,int
+Check String,,,,,TRUE,DataProperty,,,str
+Check URL,,,,,TRUE,DataProperty,,,url
+Check Match at Least,,,,,TRUE,DataProperty,,,matchAtLeastOne Patient.PatientID set
+Check Match Exactly,,,,,TRUE,DataProperty,,,matchExactlyOne MockComponent.checkMatchExactly set
+Check Match at Least values,,,,,TRUE,DataProperty,,,matchAtLeastOne MockComponent.checkMatchatLeastvalues value
+Check Match Exactly values,,,,,TRUE,DataProperty,,,matchExactlyOne MockComponent.checkMatchExactlyvalues value
 Check Recommended,,,,,FALSE,DataProperty,,,recommended
-Check Ages,,,,,FALSE,DataProperty,,,protectAges
-Check Unique,,,,,FALSE,DataProperty,,,unique error
-Check Range,,,,,FALSE,DataProperty,,,inRange 50 100 error
+Check Ages,,,,,TRUE,DataProperty,,,protectAges
+Check Unique,,,,,TRUE,DataProperty,,,unique error
+Check Range,,,,,TRUE,DataProperty,,,inRange 50 100 error

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2189,28 +2189,6 @@
             ]
         },
         {
-            "@id": "bts:ClinicalData",
-            "@type": "rdfs:Class",
-            "rdfs:comment": "TBD",
-            "rdfs:label": "ClinicalData",
-            "rdfs:subClassOf": [
-                {
-                    "@id": "bts:ValidValue"
-                }
-            ],
-            "schema:isPartOf": {
-                "@id": "http://schema.biothings.io"
-            },
-            "sms:displayName": "Clinical Data",
-            "sms:required": "sms:false",
-            "sms:requiresDependency": [
-                {
-                    "@id": "bts:FamilyHistory"
-                }
-            ],
-            "sms:validationRules": []
-        },
-        {
             "@id": "bts:Biospecimen",
             "@type": "rdfs:Class",
             "rdfs:comment": "TBD",
@@ -2590,7 +2568,7 @@
                 }
             ],
             "sms:displayName": "Check List",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "list strict"
             ]
@@ -2609,7 +2587,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Regex List",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "list strict",
                 "regex match [a-f]"
@@ -2629,7 +2607,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Regex Single",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "regex search [a-f]"
             ]
@@ -2648,7 +2626,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Regex Format",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "regex match [a-f]"
             ]
@@ -2667,7 +2645,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Num",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "num"
             ]
@@ -2686,7 +2664,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Float",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "float"
             ]
@@ -2705,7 +2683,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Int",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "int"
             ]
@@ -2724,7 +2702,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check String",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "str"
             ]
@@ -2743,7 +2721,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check URL",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "url"
             ]
@@ -2762,7 +2740,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Match at Least",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "matchAtLeastOne Patient.PatientID set"
             ]
@@ -2781,7 +2759,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Match Exactly",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "matchExactlyOne MockComponent.checkMatchExactly set"
             ]
@@ -2800,7 +2778,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Match at Least values",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "matchAtLeastOne MockComponent.checkMatchatLeastvalues value"
             ]
@@ -2819,7 +2797,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Match Exactly values",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "matchExactlyOne MockComponent.checkMatchExactlyvalues value"
             ]
@@ -2857,7 +2835,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Ages",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "protectAges"
             ]
@@ -2876,7 +2854,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Unique",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "unique error"
             ]
@@ -2895,7 +2873,7 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Check Range",
-            "sms:required": "sms:false",
+            "sms:required": "sms:true",
             "sms:validationRules": [
                 "inRange 50 100 error"
             ]

--- a/tests/data/mock_manifests/Valid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Valid_Test_Manifest.csv
@@ -1,4 +1,4 @@
-Component,Check List,Check Regex List,Check Regex Single,Check Regex Format, Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range
+Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range
 MockComponent,"ab,cd","a,c,f",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,,6571,str1,75
 MockComponent,"ab,cd","a,c,f",e,b,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80
 MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,present,32849,str3,95

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -91,6 +91,7 @@ class TestManifestValidation:
             )[0] in errors
 
         assert GenerateError.generate_list_error(
+            val_rule = 'list strict',
             list_string = 'invalid list values',
             row_num = '3',
             attribute_name = 'Check List',
@@ -100,6 +101,7 @@ class TestManifestValidation:
             )[0] in errors
 
         assert GenerateError.generate_list_error(
+            val_rule = 'list strict',
             list_string = 'ab cd ef',
             row_num = '3',
             attribute_name = 'Check Regex List',
@@ -129,6 +131,7 @@ class TestManifestValidation:
             )[0] in errors   
 
         assert GenerateError.generate_url_error(
+            val_rule = 'url',
             url = 'http://googlef.com/',
             url_error = 'invalid_url',
             row_num = '3',
@@ -247,6 +250,7 @@ class TestManifestValidation:
             )[0] in errors
             
         assert GenerateError.generate_list_error(
+            val_rule = 'list strict',
             list_string = 'invalid list values',
             row_num = '3',
             attribute_name = 'Check List',
@@ -256,6 +260,7 @@ class TestManifestValidation:
             )[0] in errors
 
         assert GenerateError.generate_list_error(
+            val_rule = 'list strict',
             list_string = 'ab cd ef',
             row_num = '3',
             attribute_name = 'Check Regex List',
@@ -285,6 +290,7 @@ class TestManifestValidation:
             )[0] in errors     
 
         assert GenerateError.generate_url_error(
+            val_rule = 'url',
             url = 'http://googlef.com/',
             url_error = 'invalid_url',
             row_num = '3',

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -70,38 +70,43 @@ class TestManifestValidation:
             val_rule = 'num',
             row_num = 3,
             attribute_name = 'Check Num', 
-            invalid_entry = 'c'
-            ) in errors
+            invalid_entry = 'c',
+            sg = sg,
+            )[0] in errors
 
         assert GenerateError.generate_type_error(
             val_rule = 'int',
             row_num = 3,
             attribute_name = 'Check Int', 
-            invalid_entry = 5.63
-            ) in errors
+            invalid_entry = 5.63,
+            sg = sg,
+            )[0] in errors
 
         assert GenerateError.generate_type_error(
             val_rule = 'str',
             row_num = 3,
             attribute_name = 'Check String', 
-            invalid_entry = 94
-            ) in errors
+            invalid_entry = 94,
+            sg = sg,
+            )[0] in errors
 
         assert GenerateError.generate_list_error(
             list_string = 'invalid list values',
             row_num = '3',
             attribute_name = 'Check List',
             list_error = "not_comma_delimited",
-            invalid_entry = 'invalid list values'
-            ) in errors
+            invalid_entry = 'invalid list values',
+            sg = sg,
+            )[0] in errors
 
         assert GenerateError.generate_list_error(
             list_string = 'ab cd ef',
             row_num = '3',
             attribute_name = 'Check Regex List',
             list_error = "not_comma_delimited",
-            invalid_entry = 'ab cd ef'
-            ) in errors
+            invalid_entry = 'ab cd ef',
+            sg = sg,
+            )[0] in errors
 
         assert GenerateError.generate_regex_error(
             val_rule = 'regex',
@@ -109,8 +114,9 @@ class TestManifestValidation:
             row_num = '3',
             attribute_name = 'Check Regex Format',
             module_to_call = 'match',
-            invalid_entry = 'm'
-            ) in errors   
+            invalid_entry = 'm',
+            sg = sg,
+            )[0] in errors   
 
         assert GenerateError.generate_regex_error(
             val_rule = 'regex',
@@ -118,8 +124,9 @@ class TestManifestValidation:
             row_num = '3',
             attribute_name = 'Check Regex Single',
             module_to_call = 'search',
-            invalid_entry = 'q'
-            ) in errors   
+            invalid_entry = 'q',
+            sg = sg,
+            )[0] in errors   
 
         assert GenerateError.generate_url_error(
             url = 'http://googlef.com/',
@@ -127,8 +134,9 @@ class TestManifestValidation:
             row_num = '3',
             attribute_name = 'Check URL',
             argument = None,
-            invalid_entry = 'http://googlef.com/'
-            ) in errors
+            invalid_entry = 'http://googlef.com/',
+            sg = sg,
+            )[0] in errors
 
         assert GenerateError.generate_content_error(
             val_rule = 'unique error', 
@@ -167,34 +175,39 @@ class TestManifestValidation:
             attribute_name='Check Match at Least',
             invalid_entry = '[7163]',
             missing_manifest_ID = ['syn27600110', 'syn29381803'],
-            ) in warnings
+            sg = sg,
+            )[1] in warnings
 
         assert  GenerateError.generate_cross_warning(
             val_rule = 'matchAtLeastOne MockComponent.checkMatchatLeastvalues value',
             row_num = '[3]',
             attribute_name = 'Check Match at Least values',
             invalid_entry = '[51100]',
-            ) in warnings      
+            sg = sg,
+            )[1] in warnings      
 
         assert \
             GenerateError.generate_cross_warning(
             val_rule = 'matchExactlyOne',
             attribute_name='Check Match Exactly',
-            matching_manifests = ['syn29862078', 'syn27648165']
-            ) in warnings \
+            matching_manifests = ['syn29862078', 'syn27648165'],
+            sg = sg,
+            )[1] in warnings \
             or \
             GenerateError.generate_cross_warning(
             val_rule = 'matchExactlyOne',
             attribute_name='Check Match Exactly',
-            matching_manifests = ['syn29862066', 'syn27648165']
-            ) in warnings
+            matching_manifests = ['syn29862066', 'syn27648165'],
+            sg = sg,
+            )[1] in warnings
                     
         assert  GenerateError.generate_cross_warning(
             val_rule = 'matchExactlyOne MockComponent.checkMatchExactlyvalues MockComponent.checkMatchExactlyvalues value',
             row_num = '[2, 3, 4]',
             attribute_name='Check Match Exactly values',
             invalid_entry = '[71738, 98085, 210065]',
-            ) in warnings 
+            sg = sg,
+            )[1] in warnings 
         
         
 
@@ -213,38 +226,43 @@ class TestManifestValidation:
             val_rule = 'num',
             row_num = '3',
             attribute_name = 'Check Num', 
-            invalid_entry = 'c'
-            ) in errors
+            invalid_entry = 'c',
+            sg = sg,
+            )[0] in errors
 
         assert GenerateError.generate_type_error(
             val_rule = 'int',
             row_num = '3',
             attribute_name = 'Check Int', 
-            invalid_entry = '5.63'
-            ) in errors
+            invalid_entry = '5.63',
+            sg = sg,
+            )[0] in errors
 
         assert GenerateError.generate_type_error(
             val_rule = 'str',
             row_num = '3',
             attribute_name = 'Check String', 
-            invalid_entry = '94'
-            ) in errors
+            invalid_entry = '94',
+            sg = sg,
+            )[0] in errors
             
         assert GenerateError.generate_list_error(
             list_string = 'invalid list values',
             row_num = '3',
             attribute_name = 'Check List',
             list_error = "not_comma_delimited",
-            invalid_entry = 'invalid list values'
-            ) in errors
+            invalid_entry = 'invalid list values',
+            sg = sg,
+            )[0] in errors
 
         assert GenerateError.generate_list_error(
             list_string = 'ab cd ef',
             row_num = '3',
             attribute_name = 'Check Regex List',
             list_error = "not_comma_delimited",
-            invalid_entry = 'ab cd ef'
-            ) in errors
+            invalid_entry = 'ab cd ef',
+            sg = sg,
+            )[0] in errors
 
         assert GenerateError.generate_regex_error(
             val_rule = 'regex',
@@ -252,8 +270,9 @@ class TestManifestValidation:
             row_num = '3',
             attribute_name = 'Check Regex Single',
             module_to_call = 'search',
-            invalid_entry = 'q'
-            ) in errors 
+            invalid_entry = 'q',
+            sg = sg,
+            )[0] in errors 
 
         assert GenerateError.generate_regex_error(
             val_rule = 'regex',
@@ -261,8 +280,9 @@ class TestManifestValidation:
             row_num = '3',
             attribute_name = 'Check Regex Format',
             module_to_call = 'match',
-            invalid_entry = 'm'
-            ) in errors     
+            invalid_entry = 'm',
+            sg = sg,
+            )[0] in errors     
 
         assert GenerateError.generate_url_error(
             url = 'http://googlef.com/',
@@ -270,8 +290,9 @@ class TestManifestValidation:
             row_num = '3',
             attribute_name = 'Check URL',
             argument = None,
-            invalid_entry = 'http://googlef.com/'
-            ) in errors
+            invalid_entry = 'http://googlef.com/',
+            sg = sg,
+            )[0] in errors
 
         
         #Check Warnings
@@ -281,34 +302,39 @@ class TestManifestValidation:
             attribute_name='Check Match at Least',
             invalid_entry = '[7163]',
             missing_manifest_ID = ['syn27600110', 'syn29381803'],
-            ) in warnings
+            sg = sg,
+            )[1] in warnings
 
         assert  GenerateError.generate_cross_warning(
             val_rule = 'matchAtLeastOne MockComponent.checkMatchatLeastvalues value',
             row_num = '[3]',
             attribute_name = 'Check Match at Least values',
             invalid_entry = '[51100]',
-            ) in warnings      
+            sg = sg,
+            )[1] in warnings      
 
         assert \
             GenerateError.generate_cross_warning(
             val_rule = 'matchExactlyOne',
             attribute_name='Check Match Exactly',
-            matching_manifests = ['syn29862078', 'syn27648165']
-            ) in warnings \
+            matching_manifests = ['syn29862078', 'syn27648165'],
+            sg = sg,
+            )[1] in warnings \
             or \
             GenerateError.generate_cross_warning(
             val_rule = 'matchExactlyOne',
             attribute_name='Check Match Exactly',
-            matching_manifests = ['syn29862066', 'syn27648165']
-            ) in warnings
+            matching_manifests = ['syn29862066', 'syn27648165'],
+            sg = sg,
+            )[1] in warnings
                     
         assert  GenerateError.generate_cross_warning(
             val_rule = 'matchExactlyOne MockComponent.checkMatchExactlyvalues MockComponent.checkMatchExactlyvalues value',
             row_num = '[2, 3, 4]',
             attribute_name='Check Match Exactly values',
             invalid_entry = '[71738, 98085, 210065]',
-            ) in warnings 
+            sg = sg,
+            )[1] in warnings 
         
 
     @pytest.mark.rule_combos(reason = 'This introduces a great number of tests covering every possible rule combination that are only necessary on occasion.')


### PR DESCRIPTION
This PR addresses #941, where invalid entries for unrequired attributes would raise errors and prevent manifest submission. Validation rule violations for unrequired attributes will now raise warnings; this allows users to be notified of invalid entries for unrequired attributes without preventing them from submitting their manifest. Violations in unrequired attributes will also raise warnings when validated with the `JSONSchemaValidator` as well.

This PR also extends the functionality of **all** existing validation rules, and allows their behavior to be more customizable. Based on needs identified in previous discussions with @milen-sage, users can now control whether each validation rule raises an error and prevents manifest submission, or raises a warning and notifies submitters of invalidity. Note that this control only extends to validation rules, and not `JSONSchema` validation like `valid values`. Specification of errors or warnings is not necessary, as each rule has a default message type that it will raise in the absence of explicit specification.

Information about each rule and the default message each raises will be added to [SchemaHub](https://sagebionetworks.jira.com/wiki/spaces/SCHEM/pages/2645262364/Data+Model+Validation+Rules) in #1002. 