### PR TITLE
Fix typo in conditional requirement for schema viz attribute table by adding quotes

### DIFF
--- a/schematic/visualization/attributes_explorer.py
+++ b/schematic/visualization/attributes_explorer.py
@@ -144,7 +144,7 @@ class AttributesExplorer():
 
                     # reformat the conditional requirement 
                     component_name = data_dict[key]['Conditional Requirements'][0].split(' is ')[0]
-                    conditional_statement_str = f" If {component_name} is {attr_str} then {key} is required"
+                    conditional_statement_str = f' If {component_name} is {attr_str} then "{key}" is required'
 
                     data_dict[key]['Conditional Requirements'] = conditional_statement_str
             df = pd.DataFrame(data_dict)


### PR DESCRIPTION
@milen-sage I think you mentioned about adding the quotes during our last show and tell. Here's the fix: 
<img width="925" alt="Screen Shot 2022-11-09 at 4 25 59 PM" src="https://user-images.githubusercontent.com/55448354/200945541-21009db3-8aa1-4455-9879-84c62338cafc.png">
