### PR TITLE
Fix DCA disconnect on submission, cast UUIDs to type string

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1055,7 +1055,7 @@ class SynapseStorage(BaseStorage):
 
         for idx,row in manifest.iterrows():
             if not row["Uuid"]:
-                gen_uuid = uuid.uuid4()
+                gen_uuid = str(uuid.uuid4())
                 row["Uuid"] = gen_uuid
                 manifest.loc[idx, 'Uuid'] = gen_uuid
 


### PR DESCRIPTION
DCA disconnect at submission occurred when adding new rows to a manifest that had already been submitted. The error occurred because the UUID for the new rows was being added to the manifest as type `uuid` and not type `str`. This fix casts the UUIDs as type `str` before adding to the manifest.