### PR TITLE
Turned `service_account_creds.json` as an environment variable and default way of authentication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-
     runs-on: ubuntu-latest
     env:
       POETRY_VERSION:  1.2.0rc1
@@ -113,7 +112,8 @@ jobs:
           
       - name: Run tests
         env:
-          SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}          
+          SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
+          SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
         if: ${{ false == contains(github.event.head_commit.message, 'runcombos') }}
         run: >
           source .venv/bin/activate;

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ docker run --rm -p 3001:3001 \
 
 2. Similarly, save the content of `schematic_service_account_creds.json` as `SERVICE_ACCOUNT_CREDS` by doing: `export SERVICE_ACCOUNT_CREDS=$(cat /path/to/schematic_service_account_creds.json)`
 
-2. Pass `SCHEMATIC_CONFIG_CONTENT` and `schematic_service_account_creds` as environment variables by using `docker run`
+3. Pass `SCHEMATIC_CONFIG_CONTENT` and `schematic_service_account_creds` as environment variables by using `docker run`
 
 ```
 docker run --rm -p 3001:3001 \

--- a/README.md
+++ b/README.md
@@ -210,16 +210,19 @@ docker run --rm -p 3001:3001 \
   python /usr/src/app/run_api.py
 ``` 
 
-#### Use content of `config.yml` as an environment variable to run API endpoints: 
-1. save content of `config.yml` as to environment variable `SCHEMATIC_CONFIG_CONTENT` by doing: `export SCHEMATIC_CONFIG_CONTENT=$(cat config.yml)`
+#### Use content of `config.yml` and `schematic_service_account_creds.json`as an environment variable to run API endpoints: 
+1. save content of `config.yml` as to environment variable `SCHEMATIC_CONFIG_CONTENT` by doing: `export SCHEMATIC_CONFIG_CONTENT=$(cat /path/to/config.yml)`
 
-2. Pass `SCHEMATIC_CONFIG_CONTENT` as an environment variable by using `docker run`
+2. Similarly, save the content of `schematic_service_account_creds.json` as `SERVICE_ACCOUNT_CREDS` by doing: `export SERVICE_ACCOUNT_CREDS=$(cat /path/to/schematic_service_account_creds.json)`
+
+2. Pass `SCHEMATIC_CONFIG_CONTENT` and `schematic_service_account_creds` as environment variables by using `docker run`
 
 ```
 docker run --rm -p 3001:3001 \
   -v $(pwd):/schematic -w /schematic --name schematic \
   -e GE_HOME=/usr/src/app/great_expectations/ \
   -e SCHEMATIC_CONFIG_CONTENT=$SCHEMATIC_CONFIG_CONTENT \
+  -e SERVICE_ACCOUNT_CREDS=$SERVICE_ACCOUNT_CREDS \
   sagebionetworks/schematic \
   python /usr/src/app/run_api.py
 ``` 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Please make sure that you run the command before running `schematic init` below
 To obtain ``credentials.json`` and ``token.pickle``, please run:
 
 ```
-schematic init --config ~/path/to/config.yml
+schematic init --config ~/path/to/config.yml --auth token
 ```
 This should prompt you with a URL that will take you through Google OAuth. Your `credentials.json` and `token.pickle` will get automatically downloaded the first time you run this command.
 

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -51,7 +51,7 @@ paths:
           name: oauth
           schema:
             type: boolean
-            default: true
+            default: false
           description: OAuth or Service Account
           required: false
         - in: query

--- a/schematic/__init__.py
+++ b/schematic/__init__.py
@@ -30,7 +30,7 @@ click_log.basic_config(logger)
 @click.option(
     "-a",
     "--auth",
-    default="token",
+    default="service_account",
     type=click.Choice(["token", "service_account"], case_sensitive=False),
     help=query_dict(init_command, ("init", "auth")),
 )

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -38,7 +38,7 @@ class ManifestGenerator(object):
         title: str = None,  # manifest sheet title
         root: str = None,
         additional_metadata: Dict = None,
-        oauth: bool = True,
+        oauth: bool = False, # set the default to use service account credentials
         use_annotations: bool = False,
     ) -> None:
 

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 import logging
-
+import json
 import pygsheets as ps
 
 from typing import Dict, Any
@@ -65,9 +65,13 @@ def build_credentials() -> Dict[str, Any]:
 
 
 def build_service_account_creds() -> Dict[str, Any]:
-    credentials = service_account.Credentials.from_service_account_file(
-        CONFIG.SERVICE_ACCT_CREDS, scopes=SCOPES
-    )
+    if "SERVICE_ACCOUNT_CREDS" in os.environ:
+        dict_creds=json.loads(os.environ["SERVICE_ACCOUNT_CREDS"])
+        credentials = service_account.Credentials.from_service_account_info(dict_creds, scopes=SCOPES)
+    else:
+        credentials = service_account.Credentials.from_service_account_file(
+            CONFIG.SERVICE_ACCT_CREDS, scopes=SCOPES
+        )
 
     # get a Google Sheet API service
     sheet_service = build("sheets", "v4", credentials=credentials)
@@ -81,7 +85,7 @@ def build_service_account_creds() -> Dict[str, Any]:
     }
 
 
-def download_creds_file(auth: str = "token") -> None:
+def download_creds_file(auth: str = "service_account") -> None:
     if auth is None:
         raise ValueError(
             f"'{auth}' is not a valid authentication method. Please "
@@ -89,6 +93,8 @@ def download_creds_file(auth: str = "token") -> None:
         )
 
     syn = SynapseStorage.login()
+
+    # use the service account auth method by default
 
     if auth == "token":
         if not os.path.exists(CONFIG.CREDS_PATH):
@@ -107,7 +113,11 @@ def download_creds_file(auth: str = "token") -> None:
             )
 
     elif auth == "service_account":
-        if not os.path.exists(CONFIG.SERVICE_ACCT_CREDS):
+        # if file path of service_account does not exist
+        # and if an environment variable related to service account is not found
+        # regenerate service_account credentials
+        if not os.path.exists(CONFIG.SERVICE_ACCT_CREDS) and "SERVICE_ACCOUNT_CREDS" not in os.environ:
+
             # synapse ID of the 'schematic_service_account_creds.json' file
             API_CREDS = CONFIG["synapse"]["service_acct_creds"]
 
@@ -121,6 +131,12 @@ def download_creds_file(auth: str = "token") -> None:
             logger.info(
                 "The credentials file has been downloaded "
                 f"to '{CONFIG.SERVICE_ACCT_CREDS}'"
+            )
+
+        elif "SERVICE_ACCOUNT_CREDS" in os.environ:
+            # remind users that "SERVICE_ACCOUNT_CREDS" as an environment variable is being used
+            logger.info(
+                "Using environment variable SERVICE_ACCOUNT_CREDS as the credential file."
             )
 
     else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,6 +44,9 @@ def syn_token(config):
     synapse_config_path = config.SYNAPSE_CONFIG_PATH
     config_parser = configparser.ConfigParser()
     config_parser.read(synapse_config_path)
+    # try using synapse access token
+    if "SYNAPSE_ACCESS_TOKEN" in os.environ:
+        token=os.environ["SYNAPSE_ACCESS_TOKEN"]
     token = config_parser["authentication"]["authtoken"]
     yield token
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -10,15 +10,6 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
-def mock_creds():
-    mock_creds = {
-        "sheet_service": "mock_sheet_service",
-        "drive_service": "mock_drive_service",
-        "creds": "mock_creds",
-    }
-    yield mock_creds
-
 
 @pytest.fixture(
     params=[
@@ -68,19 +59,16 @@ def manifest(dataset_id, manifest_generator, request):
 
 
 class TestManifestGenerator:
-    def test_init(self, monkeypatch, mock_creds, helpers):
-
-        monkeypatch.setattr(
-            "schematic.manifest.generator.build_credentials", lambda: mock_creds
-        )
+    def test_init(self, helpers):
 
         generator = ManifestGenerator(
             title="mock_title",
             path_to_json_ld=helpers.get_data_path("example.model.jsonld"),
+            oauth=False
         )
 
         assert type(generator.title) is str
-        assert generator.sheet_service == mock_creds["sheet_service"]
+        # assert generator.sheet_service == mock_creds["sheet_service"]
         assert generator.root is None
         assert type(generator.sg) is SchemaGenerator
 


### PR DESCRIPTION
related to #986 

I have turned `service_account_creds.json` as an environment variable and set `service_account_creds.json` as a default way of authentication. Try to use it like below: 

```
docker run --rm -p 3001:3001 \
-v $(pwd):/schematic -w /schematic --name schematic2 \
-e APP_HOST=0.0.0.0 \
-e APP_PORT=3001 \
-e GE_HOME=/usr/src/app/great_expectations/ \
-e SCHEMATIC_CONFIG_CONTENT=$SCHEMATIC_CONFIG_CONTENT \
-e SERVICE_ACCOUNT_CREDS=$SERVICE_ACCOUNT_CREDS \
schematic_schematic \
python **/usr/src/app/run_api.py**
```