### PR TITLE
Strip hyphens from Synapse annotation keys

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -831,7 +831,7 @@ class SynapseStorage(BaseStorage):
         # this could create a divergence between manifest column and annotations. this should be ok for most use cases.
         # columns with special characters are outside of the schema
         metadataSyn = {}
-        blacklist_chars = ['(', ')', '.', ' ']
+        blacklist_chars = ['(', ')', '.', ' ', '-']
         
         for k, v in row.to_dict().items():
 


### PR DESCRIPTION
Blacklist hyphen in annotation key names to avoid a Synapse error when setting an annotation key containing a hyphen. Should resolve #1019. 