### PR TITLE
Added workflow to trigger DCA deployment 

### DIFF
--- a/.github/workflows/trigger-dca-deployment.yml
+++ b/.github/workflows/trigger-dca-deployment.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - develop
+      - main
   workflow_dispatch:  # Allow manually triggering the workflow
 concurrency:
   # cancel the current running workflow from the same branch, PR when a new workflow is triggered 
@@ -35,6 +36,11 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
+
+      - name: Get pushed tag, if any
+        run:  |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo ${{ env.RELEASE_VERSION }}
   
       #----------------------------------------------
       #       Trigger DCA testing instance   
@@ -45,5 +51,5 @@ jobs:
           -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \
           -H "Accept: application/vnd.github+json" \
           https://api.github.com/repos/Sage-Bionetworks/data_curator/dispatches \
-          -d '{"event_type": "trigger-frontend", "client_payload": { "branch": "'${{ github.ref_name }}'", "commit-sha": "'${{ steps.vars.outputs.sha_short }}'"}'
+          -d '{"event_type": "trigger-frontend", "client_payload": { "branch": "'${{ steps.extract_branch.outputs.branch }}'", "commit-sha": "'${{ steps.vars.outputs.sha_short }}'",  "release-version": "${{ env.RELEASE_VERSION }}"}'
 

--- a/.github/workflows/trigger-dca-deployment.yml
+++ b/.github/workflows/trigger-dca-deployment.yml
@@ -1,0 +1,49 @@
+name: trigger-dca
+
+# build the documentation whenever there are new commits on main
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:  # Allow manually triggering the workflow
+concurrency:
+  # cancel the current running workflow from the same branch, PR when a new workflow is triggered 
+  # when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group
+  # {{ github.workflow }}: the workflow name is used to generate the concurrency group. This allows you to have more than one workflows
+  # {{ github.ref_type }}: the type of Git ref object created in the repository. Can be either branch or tag 
+  # {{ github.sha }}: full commit sha 
+  # credit: https://github.com/Sage-Bionetworks-Workflows/sagetasks/blob/main/.github/workflows/ci.yml
+  group: >-
+    ${{ github.workflow }}-${{ github.ref_type }}-
+    ${{ github.sha }}
+  cancel-in-progress: true
+jobs:
+  pypi_release:
+    runs-on: ubuntu-latest
+    steps:
+      #----------------------------------------------
+      #       Compute short commit sha
+      #----------------------------------------------
+      - name: Compute short commit SHA ID
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      #----------------------------------------------
+      #       Extract branch name 
+      #----------------------------------------------
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+  
+      #----------------------------------------------
+      #       Trigger DCA testing instance   
+      #----------------------------------------------
+      - name: Trigger DCA testing instance 
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \
+          -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/Sage-Bionetworks/data_curator/dispatches \
+          -d '{"event_type": "trigger-frontend", "client_payload": { "branch": "'${{ github.ref_name }}'", "commit-sha": "'${{ steps.vars.outputs.sha_short }}'"}'
+

--- a/.github/workflows/trigger-dca-deployment.yml
+++ b/.github/workflows/trigger-dca-deployment.yml
@@ -6,6 +6,7 @@ on:
       - 'v[1-9][0-9].[0-9]+.[0-9]+'
     branches:
       - develop
+      - main
   workflow_dispatch:  # Allow manually triggering the workflow
 concurrency:
   # cancel the current running workflow from the same branch, PR when a new workflow is triggered 
@@ -34,7 +35,11 @@ jobs:
       #----------------------------------------------
       #       Open PRs in DCA
       #----------------------------------------------
-      - name: Trigger DCA testing instance 
+      - name: Trigger DCA testing instance
+        # run only when a release tag gets pushed or when the develop branch gets updated
+        # if there's a push to the main branch (without tag), this part would not get triggered
+        # if pushing to main and pushing tag to main both triggering this part, we would end up having the front-end dealing with the same PR
+        if: ${{ env.RELEASE_VERSION != '' }} || github.ref_name == develop
         run: |
           curl -X POST \
           -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \

--- a/.github/workflows/trigger-dca-deployment.yml
+++ b/.github/workflows/trigger-dca-deployment.yml
@@ -3,7 +3,7 @@ name: trigger-dca
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[1-9][0-9].[0-9]+.[0-9]+'
     branches:
       - develop
   workflow_dispatch:  # Allow manually triggering the workflow

--- a/.github/workflows/trigger-dca-deployment.yml
+++ b/.github/workflows/trigger-dca-deployment.yml
@@ -6,7 +6,6 @@ on:
       - 'v[1-9][0-9].[0-9]+.[0-9]+'
     branches:
       - develop
-      - main
   workflow_dispatch:  # Allow manually triggering the workflow
 concurrency:
   # cancel the current running workflow from the same branch, PR when a new workflow is triggered 
@@ -36,10 +35,6 @@ jobs:
       #       Open PRs in DCA
       #----------------------------------------------
       - name: Trigger DCA testing instance
-        # run only when a release tag gets pushed or when the develop branch gets updated
-        # if there's a push to the main branch (without tag), this part would not get triggered
-        # if pushing to main and pushing tag to main both triggering this part, we would end up having the front-end dealing with the same PR
-        if: ${{ env.RELEASE_VERSION != '' }} || github.ref_name == develop
         run: |
           curl -X POST \
           -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \

--- a/.github/workflows/trigger-dca-deployment.yml
+++ b/.github/workflows/trigger-dca-deployment.yml
@@ -37,13 +37,16 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
 
+      #----------------------------------------------
+      #       Get release version
+      #----------------------------------------------
       - name: Get pushed tag, if any
         run:  |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo ${{ env.RELEASE_VERSION }}
   
       #----------------------------------------------
-      #       Trigger DCA testing instance   
+      #       Open PRs in DCA
       #----------------------------------------------
       - name: Trigger DCA testing instance 
         run: |

--- a/.github/workflows/trigger-dca-deployment.yml
+++ b/.github/workflows/trigger-dca-deployment.yml
@@ -1,11 +1,11 @@
 name: trigger-dca
-
-# build the documentation whenever there are new commits on main
+# Trigger PR in DCA when a new tag gets pushed or when the develop branch gets updated
 on:
   push:
+    tags:
+      - 'v*'
     branches:
       - develop
-      - main
   workflow_dispatch:  # Allow manually triggering the workflow
 concurrency:
   # cancel the current running workflow from the same branch, PR when a new workflow is triggered 
@@ -19,28 +19,14 @@ concurrency:
     ${{ github.sha }}
   cancel-in-progress: true
 jobs:
-  pypi_release:
+  trigger-frontend:
     runs-on: ubuntu-latest
     steps:
-      #----------------------------------------------
-      #       Compute short commit sha
-      #----------------------------------------------
-      - name: Compute short commit SHA ID
-        id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-
-      #----------------------------------------------
-      #       Extract branch name 
-      #----------------------------------------------
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
-
       #----------------------------------------------
       #       Get release version
       #----------------------------------------------
       - name: Get pushed tag, if any
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
         run:  |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo ${{ env.RELEASE_VERSION }}
@@ -54,5 +40,5 @@ jobs:
           -H "Authorization: token ${{ secrets.ACCESS_TOKEN }}" \
           -H "Accept: application/vnd.github+json" \
           https://api.github.com/repos/Sage-Bionetworks/data_curator/dispatches \
-          -d '{"event_type": "trigger-frontend", "client_payload": { "branch": "'${{ steps.extract_branch.outputs.branch }}'", "commit-sha": "'${{ steps.vars.outputs.sha_short }}'",  "release-version": "${{ env.RELEASE_VERSION }}"}'
+          -d '{"event_type": "trigger-frontend", "client_payload": { "commit-sha": "'${{ github.sha }}'",  "release-version": "${{ env.RELEASE_VERSION }}"}'
 


### PR DESCRIPTION
Related to #1026 

Based on my discussion with @rrchai , here's the order of operation that we want after updating the `develop` branch in schematic is: 

1) update develop branch of schematic
2) open a PR (included the updates info, i.e. commit or pr#) in DCA
3) trigger testing1 deployment in DCA
4) DCA forks review PR and test in testing1 instance
5) if no problem, merge to develop of DCA; otherwise, request backend for a fix

DCA part: 
https://github.com/Sage-Bionetworks/data_curator/pull/447/files