### PR TITLE
Refactor table operations structure in asset store

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -298,6 +298,11 @@ paths:
           "Cancer Type": "Breast",
           "Family History": "Breast, Lung",
           }]'
+        - in: query
+          name: table_manipulation
+          schema:
+            type: string
+            enum: ["replace", "upsert"]
       operationId: api.routes.submit_manifest_route
       responses:
         "200":

--- a/api/routes.py
+++ b/api/routes.py
@@ -370,13 +370,15 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
 
     input_token = connexion.request.args["input_token"]
 
+    table_manipulation = connexion.request.args["table_manipulation"]
+
     if data_type == 'None':
         validate_component = None
     else:
         validate_component = data_type
 
     manifest_id = metadata_model.submit_metadata_manifest(
-        path_to_json_ld = schema_url, manifest_path=temp_path, dataset_id=dataset_id, validate_component=validate_component, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules)
+        path_to_json_ld = schema_url, manifest_path=temp_path, dataset_id=dataset_id, validate_component=validate_component, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules, table_manipulation=table_manipulation)
 
     return manifest_id
 

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -112,6 +112,12 @@ model_commands = {
                 "'table' will store the manifest as a table and a csv on Synapse. 'both' will do both of the options specified above. "
                 "Default value is 'table'."
             ),      
+            "table_manipulation":(
+                "Specify the way the manifest tables should be store as on Synapse when one with the same name already exists. Options are 'replace' and 'upsert'. "
+                "'replace' will remove the rows and columns from the existing table and store the new rows and columns, preserving the name and synID. "
+                "'upsert' will add the new rows to the table and preserve the exisitng rows and columns in the existing table. "
+                "Default value is 'replace'. "
+            ),  
         },
         "validate": {
             "short_help": ("Validation of manifest files."),

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -128,6 +128,7 @@ def submit_manifest(
             use_schema_label=use_schema_label,
             hide_blanks=hide_blanks,
             project_scope=project_scope,
+            table_manipulation=table_manipulation,
         )
 
         '''

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -202,7 +202,8 @@ def validate_manifest(ctx, manifest_path, data_type, json_schema, restrict_rules
     """
     Running CLI for manifest validation.
     """
-    data_type = fill_in_from_config("data_type", data_type, ("manifest", "data_type"))
+    if not data_type:
+        data_type = fill_in_from_config("data_type", data_type, ("manifest", "data_type"))
     
     try:
         len(data_type) == 1

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -95,9 +95,15 @@ def model(ctx, config):  # use as `schematic model ...`
     callback=parse_synIDs,
     help=query_dict(model_commands, ("model", "validate", "project_scope")),
 )
+@click.option(
+    "--table_manipulation",
+    "-tm",
+    default='replace',
+    type=click.Choice(['replace', 'upsert'], case_sensitive=True),
+    help=query_dict(model_commands, ("model", "submit", "table_manipulation")))
 @click.pass_obj
 def submit_manifest(
-    ctx, manifest_path, dataset_id, validate_component, manifest_record_type, use_schema_label, hide_blanks, restrict_rules, project_scope,
+    ctx, manifest_path, dataset_id, validate_component, manifest_record_type, use_schema_label, hide_blanks, restrict_rules, project_scope, table_manipulation,
 ):
     """
     Running CLI with manifest validation (optional) and submission options.

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -288,6 +288,7 @@ class MetadataModel(object):
         hide_blanks: bool = False,
         input_token: str = None,
         project_scope: List = None,
+        table_manipulation: str = 'replace'
     ) -> string:
         """Wrap methods that are responsible for validation of manifests for a given component, and association of the
         same manifest file with a specified dataset.
@@ -341,6 +342,7 @@ class MetadataModel(object):
                         manifest_record_type = manifest_record_type,
                         useSchemaLabel = use_schema_label,
                         hideBlanks = hide_blanks,
+                        table_manipulation=table_manipulation,
                     )
                     restrict_maniest = True
                 
@@ -352,6 +354,7 @@ class MetadataModel(object):
                     useSchemaLabel = use_schema_label, 
                     hideBlanks = hide_blanks,
                     restrict_manifest=restrict_maniest,
+                    table_manipulation=table_manipulation,
                 )
 
                 logger.info(f"No validation errors occured during validation.")
@@ -372,6 +375,7 @@ class MetadataModel(object):
                 manifest_record_type=manifest_record_type,
                 useSchemaLabel=use_schema_label,
                 hideBlanks=hide_blanks,
+                table_manipulation=table_manipulation,
             )
             restrict_maniest = True
         
@@ -383,6 +387,7 @@ class MetadataModel(object):
             useSchemaLabel=use_schema_label,
             hideBlanks=hide_blanks,
             restrict_manifest=restrict_maniest,
+            table_manipulation=table_manipulation,
         )
 
         logger.debug(

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -781,7 +781,7 @@ class SynapseStorage(BaseStorage):
         """
         
 
-        col_schema, table_manifest = self.formatDB(se, manifest, datasetId, useSchemaLabel)
+        col_schema, table_manifest = self.formatDB(se, manifest, useSchemaLabel)
 
         manifest_table_id = self.buildDB(datasetId, table_name, col_schema, table_manifest, table_manipulation, restrict)
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -870,7 +870,7 @@ class SynapseStorage(BaseStorage):
             if table_manipulation.lower() == 'replace':
                 manifest_table_id = TableOperations.replaceTable(self, tableToLoad=table_manifest, tableName=table_name, existingTableId=table_info[table_name], specifySchema = True, datasetId = datasetId, columnTypeDict=col_schema, restrict=restrict)
             elif table_manipulation.lower() == 'upsert':
-                manifest_table_id = TableOperations.upsertTable(self, table_name=table_name, data = None)
+                manifest_table_id = TableOperations.upsertTable(self, tableName=table_name, data = None)
             elif table_manipulation.lower() == 'update':
                 manifest_table_id = TableOperations.updateTable(self, tableToLoad=table_manifest, existingTableId=table_info[table_name], restrict=restrict)
         else:

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1572,6 +1572,120 @@ class SynapseStorage(BaseStorage):
                 return table.schema.id
 
 
+class TableOperations:
+
+    def createTable(self, tableToLoad: pd.DataFrame = None, datasetID: str = None, columnTypeDict: dict = None, specifySchema: bool = True, restrict: bool = False):
+        datasetEntity = self.syn.get(datasetID, downloadFile = False)
+        datasetName = datasetEntity.name
+        table_schema_by_cname = self._get_table_schema_by_cname(columnTypeDict) 
+
+        if not table_name:
+            table_name = datasetName + 'table'
+        datasetParentProject = self.getDatasetProject(datasetID)
+        if specifySchema:
+            if columnTypeDict == {}:
+                logger.error("Did not provide a columnTypeDict.")
+            #create list of columns:
+            cols = []
+            for col in tableToLoad.columns:
+                if col in table_schema_by_cname:
+                    col_type = table_schema_by_cname[col]['columnType']
+                    max_size = table_schema_by_cname[col]['maximumSize'] if 'maximumSize' in table_schema_by_cname[col].keys() else 100
+                    max_list_len = 250
+                    if max_size and max_list_len:
+                        cols.append(Column(name=col, columnType=col_type, 
+                            maximumSize=max_size, maximumListLength=max_list_len))
+                    elif max_size:
+                        cols.append(Column(name=col, columnType=col_type, 
+                            maximumSize=max_size))
+                    else:
+                        cols.append(Column(name=col, columnType=col_type))
+                else:
+                    #TODO add warning that the given col was not found and it's max size is set to 100
+                    cols.append(Column(name=col, columnType='STRING', maximumSize=100))
+            schema = Schema(name=table_name, columns=cols, parent=datasetParentProject)
+            table = Table(schema, tableToLoad)
+            table = self.syn.store(table, isRestricted = restrict)
+            return table.schema.id
+        else:
+            # For just uploading the tables to synapse using default
+            # column types.
+            table = build_table(table_name, datasetParentProject, tableToLoad)
+            table = self.syn.store(table, isRestricted = restrict)
+            return table.schema.id
+
+    def replaceTable(self, tableToLoad: pd.DataFrame = None, existingTableId: str = None, specifySchema: bool = True, datasetID: str = None, columnTypeDict: dict = None, restrict: bool = False):
+        datasetEntity = self.syn.get(datasetID, downloadFile = False)
+        datasetName = datasetEntity.name
+        table_schema_by_cname = self._get_table_schema_by_cname(columnTypeDict) 
+        existing_table, existing_results = self.get_synapse_table(existingTableId)
+        # remove rows
+        self.syn.delete(existing_results)
+        # wait for row deletion to finish on synapse before getting empty table
+        sleep(10)
+        
+        # removes all current columns
+        current_table = self.syn.get(existingTableId)
+        current_columns = self.syn.getTableColumns(current_table)
+        for col in current_columns:
+            current_table.removeColumn(col)
+
+        if not table_name:
+            table_name = datasetName + 'table'
+        
+        # Process columns according to manifest entries
+        table_schema_by_cname = self._get_table_schema_by_cname(columnTypeDict) 
+        datasetParentProject = self.getDatasetProject(datasetID)
+        if specifySchema:
+            if columnTypeDict == {}:
+                logger.error("Did not provide a columnTypeDict.")
+            #create list of columns:
+            cols = []
+            
+            for col in tableToLoad.columns:
+                
+                if col in table_schema_by_cname:
+                    col_type = table_schema_by_cname[col]['columnType']
+                    max_size = table_schema_by_cname[col]['maximumSize'] if 'maximumSize' in table_schema_by_cname[col].keys() else 100
+                    max_list_len = 250
+                    if max_size and max_list_len:
+                        cols.append(Column(name=col, columnType=col_type, 
+                            maximumSize=max_size, maximumListLength=max_list_len))
+                    elif max_size:
+                        cols.append(Column(name=col, columnType=col_type, 
+                            maximumSize=max_size))
+                    else:
+                        cols.append(Column(name=col, columnType=col_type))
+                else:
+                    
+                    #TODO add warning that the given col was not found and it's max size is set to 100
+                    cols.append(Column(name=col, columnType='STRING', maximumSize=100))
+            
+            # adds new columns to schema
+            for col in cols:
+                current_table.addColumn(col)
+            self.syn.store(current_table, isRestricted = restrict)
+
+            # wait for synapse store to finish
+            sleep(1)
+
+            # build schema and table from columns and store with necessary restrictions
+            schema = Schema(name=table_name, columns=cols, parent=datasetParentProject)
+            schema.id = existingTableId
+            table = Table(schema, tableToLoad, etag = existing_results.etag)
+            table = self.syn.store(table, isRestricted = restrict)
+        else:
+            logging.error("Must specify a schema for table replacements")
+
+        # remove system metadata from manifest
+        existing_table.drop(columns = ['ROW_ID', 'ROW_VERSION'], inplace = True)
+        return existingTableId
+    
+    def upsertTable(self, table_name: str = None, data: pd.DataFrame = None):
+        raise NotImplementedError
+
+
+
 class DatasetFileView:
     """Helper class to create temporary dataset file views.
     This class can be used in conjunction with a 'with' statement.

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -757,12 +757,14 @@ class SynapseStorage(BaseStorage):
         table_name: str, 
         restrict: bool = False, 
         useSchemaLabel: bool = True, 
-        existingTableId: str = None,):
+        existingTableId: str = None,
+        table_manipulation: str = 'replace',
+        ):
         
 
         col_schema, table_manifest = self.formatDB(se, manifest, datasetId, useSchemaLabel)
 
-        manifest_table_id = self.buildDB(datasetId, table_name, col_schema, table_manifest, restrict)
+        manifest_table_id = self.buildDB(datasetId, table_name, col_schema, table_manifest, table_manipulation, restrict)
 
         return manifest_table_id, manifest, table_manifest
 
@@ -807,6 +809,7 @@ class SynapseStorage(BaseStorage):
         table_name: str, 
         col_schema: List,
         table_manifest: pd.DataFrame,
+        table_manipulation: str,
         restrict: bool = False, 
         ):
 
@@ -1034,7 +1037,7 @@ class SynapseStorage(BaseStorage):
 
     def associateMetadataWithFiles(
         self, schemaGenerator: SchemaGenerator, metadataManifestPath: str, datasetId: str, manifest_record_type: str = 'both', 
-        useSchemaLabel: bool = True, hideBlanks: bool = False, restrict_manifest = False,
+        useSchemaLabel: bool = True, hideBlanks: bool = False, restrict_manifest = False, table_manipulation: str = 'replace',
     ) -> str:
         """Associate metadata with files in a storage dataset already on Synapse.
         Upload metadataManifest in the storage dataset folder on Synapse as well. Return synapseId of the uploaded manifest file.
@@ -1117,7 +1120,7 @@ class SynapseStorage(BaseStorage):
         # If specified, upload manifest as a table and get the SynID and manifest
         if manifest_record_type == 'table' or manifest_record_type == 'both':
             manifest_synapse_table_id, manifest, table_manifest = self.uploadDB(
-                                                        se, manifest, datasetId, table_name, restrict = restrict_manifest, useSchemaLabel=useSchemaLabel)
+                                                        se, manifest, datasetId, table_name,  restrict = restrict_manifest, useSchemaLabel=useSchemaLabel,table_manipulation=table_manipulation,)
             
         # Iterate over manifest rows, create Synapse entities and store corresponding entity IDs in manifest if needed
         # also set metadata for each synapse entity as Synapse annotations

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -766,7 +766,7 @@ class SynapseStorage(BaseStorage):
 
         manifest_table_id = self.buildDB(datasetId, table_name, col_schema, table_manifest, table_manipulation, restrict)
 
-        return manifest_table_id, manifest, table_manifest, col_schema
+        return manifest_table_id, manifest, table_manifest
 
     def formatDB(self, se, manifest, datasetId, useSchemaLabel):
         # Rename the manifest columns to display names to match fileview
@@ -1112,7 +1112,7 @@ class SynapseStorage(BaseStorage):
 
         # If specified, upload manifest as a table and get the SynID and manifest
         if manifest_record_type == 'table' or manifest_record_type == 'both':
-            manifest_synapse_table_id, manifest, table_manifest, col_schema = self.uploadDB(
+            manifest_synapse_table_id, manifest, table_manifest = self.uploadDB(
                                                         se, manifest, datasetId, table_name,  restrict = restrict_manifest, useSchemaLabel=useSchemaLabel,table_manipulation=table_manipulation,)
             
         # Iterate over manifest rows, create Synapse entities and store corresponding entity IDs in manifest if needed

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -543,7 +543,7 @@ class SynapseStorage(BaseStorage):
                     manifest_name = entity["properties"]["name"]
 
                 # otherwise download the manifest and parse for information
-                elif 'Component' not in annotations or not annotations:
+                elif not annotations or 'Component' not in annotations:
                     logging.debug(
                         f"No component annotations have been found for manifest {manifestId}. "
                         "The manifest will be downloaded and parsed instead. "

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1614,7 +1614,9 @@ class TableOperations:
         return existingTableId
     
     def upsertTable(synStore, tableName: str = None, data: pd.DataFrame = None):
-        raise NotImplementedError
+        raise NotImplementedError(
+            "Table upsert functionality has not been implemented yet."
+        )
 
     def updateTable(synStore, tableToLoad: pd.DataFrame = None, existingTableId: str = None,  updateCol: str = 'Uuid',  restrict: bool = False):
         """

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -537,7 +537,7 @@ class SynapseStorage(BaseStorage):
                 annotations = self.getFileAnnotations(manifestId)
 
                 # If manifest has annotations specifying component, use that
-                if 'Component' in annotations:
+                if annotations and 'Component' in annotations:
                     component = annotations['Component']
                     entity = self.syn.get(manifestId, downloadFile=False)
                     manifest_name = entity["properties"]["name"]

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -760,6 +760,25 @@ class SynapseStorage(BaseStorage):
         existingTableId: str = None,
         table_manipulation: str = 'replace',
         ):
+        """
+        Method to upload a database to an asset store. In synapse, this will upload a metadata table
+        
+        Args:
+            se: schemaExplorer object
+            manifest: pd.Df manifest to upload
+            datasetId: synID of the dataset for the manifest
+            table_name: name of the table to be uploaded
+            restrict: bool, whether or not the manifest contains sensitive data that will need additional access restrictions 
+            useSchemaLabel: bool whether to use schemaLabel (True) or display label (False)
+            existingTableId: str of the synId of the existing table, if one already exists
+            table_manipulation: str, 'replace' or 'upsert', in the case where a manifest already exists, should the new metadata replace the existing (replace) or be added to it (upsert)
+
+        Returns:
+            manifest_table_id: synID of the uploaded table
+            manifest: the original manifset
+            table_manifest: manifest formatted appropriately for the table
+        
+        """
         
 
         col_schema, table_manifest = self.formatDB(se, manifest, datasetId, useSchemaLabel)
@@ -768,7 +787,20 @@ class SynapseStorage(BaseStorage):
 
         return manifest_table_id, manifest, table_manifest
 
-    def formatDB(self, se, manifest, datasetId, useSchemaLabel):
+    def formatDB(self, se, manifest, useSchemaLabel):
+        """
+        Method to format a manifest appropriatly for upload as table
+        
+        Args:
+            se: schemaExplorer object
+            manifest: pd.Df manifest to upload
+            useSchemaLabel: bool whether to use schemaLabel (True) or display label (False)
+
+        Returns:
+            col_schema: schema for table columns: type, size, etc
+            table_manifest: formatted manifest
+        
+        """
         # Rename the manifest columns to display names to match fileview
 
         blacklist_chars = ['(', ')', '.', ' ', '-']
@@ -812,7 +844,22 @@ class SynapseStorage(BaseStorage):
         table_manipulation: str,
         restrict: bool = False, 
         ):
+        """
+        Method to construct the table appropriately: create new table, replace existing, or upsert new into existing
+        Calls TableOperations class to execute 
+        
+        Args:
+            datasetId: synID of the dataset for the manifest
+            table_name: name of the table to be uploaded
+            col_schema: schema for table columns: type, size, etc from `formatDB`
+            table_manifest: formatted manifest taht can be uploaded as a table
+            table_manipulation: str, 'replace' or 'upsert', in the case where a manifest already exists, should the new metadata replace the existing (replace) or be added to it (upsert)
+            restrict: bool, whether or not the manifest contains sensitive data that will need additional access restrictions 
 
+        Returns:
+            manifest_table_id: synID of the uploaded table
+        
+        """
         table_info = self.get_table_info(datasetId = datasetId)
         # Put table manifest onto synapse
         schema = Schema(name=table_name, columns=col_schema, parent=self.getDatasetProject(datasetId))

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1156,13 +1156,9 @@ class SynapseStorage(BaseStorage):
         if manifest_record_type == 'table' or manifest_record_type == 'both':
             # Update manifest Synapse table with new entity id column.
 
-            TableOperations.replaceTable(self, 
+            TableOperations.updateTable(self, 
                 tableToLoad=table_manifest, 
-                tableName=table_name, 
                 existingTableId=manifest_synapse_table_id, 
-                specifySchema=True, 
-                datasetId=datasetId, 
-                columnTypeDict=col_schema, 
                 restrict=restrict_manifest)
             
             # Set annotations for the table manifest
@@ -1529,7 +1525,14 @@ class TableOperations:
     def upsertTable(synStore, tableName: str = None, data: pd.DataFrame = None):
         raise NotImplementedError
 
+    def updateTable(synStore, tableToLoad: pd.DataFrame = None, existingTableId: str = None,  update_col: str = 'Uuid',  restrict: bool = False):
+        existing_table, existing_results = synStore.get_synapse_table(existingTableId)
+        
+        tableToLoad = update_df(existing_table, tableToLoad, update_col)
+        # store table with existing etag data and impose restrictions as appropriate
+        synStore.syn.store(Table(existingTableId, tableToLoad, etag = existing_results.etag), isRestricted = restrict)
 
+        return
 
 class DatasetFileView:
     """Helper class to create temporary dataset file views.

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -871,6 +871,8 @@ class SynapseStorage(BaseStorage):
                 manifest_table_id = TableOperations.replaceTable(self, tableToLoad=table_manifest, tableName=table_name, existingTableId=table_info[table_name], specifySchema = True, datasetId = datasetId, columnTypeDict=col_schema, restrict=restrict)
             elif table_manipulation.lower() == 'upsert':
                 manifest_table_id = TableOperations.upsertTable(self, table_name=table_name, data = None)
+            elif table_manipulation.lower() == 'update':
+                manifest_table_id = TableOperations.updateTable(self, tableToLoad=table_manifest, existingTableId=table_info[table_name], restrict=restrict)
         else:
             manifest_table_id = TableOperations.createTable(self, tableToLoad=table_manifest, tableName=table_name, datasetId=datasetId, columnTypeDict=col_schema, specifySchema=True, restrict=restrict)
 
@@ -1202,9 +1204,10 @@ class SynapseStorage(BaseStorage):
         
         if manifest_record_type == 'table' or manifest_record_type == 'both':
             # Update manifest Synapse table with new entity id column.
-
-            manifest_synapse_table_id = TableOperations.updateTable(self, tableToLoad=table_manifest, existingTableId=manifest_synapse_table_id, restrict=restrict_manifest)
             
+            manifest_synapse_table_id, manifest, table_manifest = self.uploadDB(
+                                                                    se, manifest, datasetId, table_name,  restrict = restrict_manifest, useSchemaLabel=useSchemaLabel,table_manipulation='update',)
+
             # Set annotations for the table manifest
             manifest_annotations = self.format_manifest_annotations(manifest, manifest_synapse_table_id)
             self.syn.set_annotations(manifest_annotations)

--- a/schematic/utils/cli_utils.py
+++ b/schematic/utils/cli_utils.py
@@ -162,4 +162,7 @@ def parse_comma_str_to_list(
     ctx, param, comma_string,
 ) -> List[str]:
 
-    return comma_string.split(",")
+    if comma_string:
+        return comma_string.split(",")
+    else:
+        return None

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -271,7 +271,7 @@ class TestDatasetFileView:
 class TestTableOperations:
 
     def test_createTable(self, helpers, synapse_store, config, projectId, datasetId):
-
+        table_manipulation = None
 
         # Check if FollowUp table exists if so delete
         existing_tables = synapse_store.get_table_info(projectId = projectId)
@@ -298,6 +298,7 @@ class TestTableOperations:
             useSchemaLabel = True,
             hideBlanks = True,
             restrict_manifest = False,
+            table_manipulation=table_manipulation,
         )
         existing_tables = synapse_store.get_table_info(projectId = projectId)
         
@@ -307,6 +308,8 @@ class TestTableOperations:
         assert table_name in existing_tables.keys()
 
     def test_replaceTable(self, helpers, synapse_store, config, projectId, datasetId):
+        table_manipulation = 'replace'
+
         table_name='followup_synapse_storage_manifest_table'
         manifest_path = "mock_manifests/table_manifest.csv"
         replacement_manifest_path = "mock_manifests/table_manifest_replacement.csv"
@@ -334,6 +337,7 @@ class TestTableOperations:
             useSchemaLabel = True,
             hideBlanks = True,
             restrict_manifest = False,
+            table_manipulation=table_manipulation,
         )
         existing_tables = synapse_store.get_table_info(projectId = projectId)
 
@@ -355,6 +359,7 @@ class TestTableOperations:
             useSchemaLabel = True,
             hideBlanks = True,
             restrict_manifest = False,
+            table_manipulation=table_manipulation,
         )
         existing_tables = synapse_store.get_table_info(projectId = projectId)
         


### PR DESCRIPTION
`make_synapse_table` a method that handled multiple table operations (creation, update, and replace) has been refactored into a `TableOperations` object with functionality separated into distinct methods. This will allow for easier implementation of new table operations in the future and makes the existing code easier to understand.