### PR TITLE
Fixed `getProjectManifests` function in synapse storage 

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -571,9 +571,10 @@ class SynapseStorage(BaseStorage):
                             logging.warning(
                             f"Manifest {manifestId} is composed of multiple components. Schematic does not support mulit-component manifests at this time."
                             "Behavior of manifests with multiple components is undefined"
-                            )              
-
-            #save manifest list with applicable informaiton
+                            )
+            else:
+                manifest_name = ""
+                component = None              
             if component:
                 manifest = (
                     (datasetId, datasetName),
@@ -593,6 +594,8 @@ class SynapseStorage(BaseStorage):
                     ("", ""),
                     ("", ""),
                 )
+
+            print('manifest', manifest)
 
             if manifest:
                 manifests.append(manifest)

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -595,8 +595,6 @@ class SynapseStorage(BaseStorage):
                     ("", ""),
                 )
 
-            print('manifest', manifest)
-
             if manifest:
                 manifests.append(manifest)
                 


### PR DESCRIPTION
Related to the issue Loren reported #1065 

All the rows marked as yellow are rows that are incorrect. When there's no manifest (check the row with dataset_name `h_and_e`, column `dataset` and column `manifest_csv` should be empty. But as you could see from the screen shot, the code wrongly took the value from previous rows and put it there. 

<img width="1378" alt="Screen Shot 2023-01-19 at 5 37 43 PM" src="https://user-images.githubusercontent.com/55448354/213577898-4a7116b2-8df7-4b77-888e-6fb74be48622.png">

I think this is because we didn't reset "manifest_name" and "component" when running loop `for (datasetId, datasetName) in datasets`
