### PR TITLE
Develop api node display names

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -770,6 +770,37 @@ paths:
       tags:
         - Schema Operation
 
+  /schemas/get_nodes_display_names:
+    get:
+      summary: Get display names for nodes labels in a list.
+      description: et display names for nodes labels in a list.
+      operationId: api.routes.get_nodes_display_names
+      parameters:
+        - in: query
+          name: schema_url
+          schema:
+            type: string
+          description: Data Model URL
+          example: >-
+            https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld
+          required: true
+        - in: query
+          name: node_list
+          schema:
+            type: array
+            items: 
+              type: string
+            nullable: false
+          description: List of node labels.
+          example: ['FamilyHistory', 'Biospecimen']
+          required: true
+      responses:
+        "200":
+          description: return List[str]
+        "500":
+          description: Check schematic log. 
+      tags:
+        - Schema Operation
 
 
 
@@ -892,37 +923,6 @@ paths:
       tags:
         - Schema Operation
 
-  /schemas/get_nodes_display_names:
-    get:
-      summary: Get display names for nodes labels in a list.
-      description: et display names for nodes labels in a list.
-      operationId: api.routes.get_nodes_display_names
-      parameters:
-        - in: query
-          name: schema_url
-          schema:
-            type: string
-          description: Data Model URL
-          example: >-
-            https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld
-          required: true
-        - in: query
-          name: node_list
-          schema:
-            type: array
-            items: 
-              type: string
-            nullable: false
-          description: List of node labels.
-          example: ['FamilyHistory', 'Biospecimen']
-          required: true
-      responses:
-        "200":
-          description: return List[str]
-        "500":
-          description: Check schematic log. 
-      tags:
-        - Schema Operation
 
   /visualize/tangled_tree/layers:
     get:

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -891,6 +891,39 @@ paths:
           description: Check schematic log.
       tags:
         - Schema Operation
+
+  /schemas/get_nodes_display_names:
+    get:
+      summary: Get display names for nodes labels in a list.
+      description: et display names for nodes labels in a list.
+      operationId: api.routes.get_nodes_display_names
+      parameters:
+        - in: query
+          name: schema_url
+          schema:
+            type: string
+          description: Data Model URL
+          example: >-
+            https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld
+          required: true
+        - in: query
+          name: node_list
+          schema:
+            type: array
+            items: 
+              type: string
+            nullable: false
+          description: List of node labels.
+          example: ['FamilyHistory', 'Biospecimen']
+          required: true
+      responses:
+        "200":
+          description: return List[str]
+        "500":
+          description: Check schematic log. 
+      tags:
+        - Schema Operation
+
   /visualize/tangled_tree/layers:
     get:
       summary: Get layers of tangled tree.

--- a/api/routes.py
+++ b/api/routes.py
@@ -688,4 +688,19 @@ def get_if_node_required(schema_url: str, node_display_name: str) -> bool:
 
     return is_required
 
+def get_nodes_display_names(schema_url: str, node_list: list[str]) -> list:
+    """From a list of node labels retrieve their display names, return as list.
+    
+    Args:
+        schema_url (str): Data Model URL
+        node_list (List[str]): List of node labels.
+        
+    Returns:
+        node_display_names (List[str]): List of node display names.
+
+    """
+    gen = SchemaGenerator(path_to_json_ld=schema_url)
+    mm_graph = gen.se.get_nx_schema()
+    node_display_names = gen.get_nodes_display_names(node_list, mm_graph)
+    return node_display_names
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -213,6 +213,17 @@ class TestSchemaExplorerOperation:
         assert response.status_code == 200
         assert response_dta == True
 
+    def test_get_nodes_display_names(test, client, data_model_jsonld):
+        params = {
+            "schema_url": data_model_jsonld,
+            "node_list": ["FamilyHistory", "Biospecimen"]
+        }
+        response = client.get("http://localhost:3001/v1/schemas/get_nodes_display_names", query_string = params)
+        response_dta = json.loads(response.data)
+        assert response.status_code == 200
+        assert "Family History" and "Biospecimen" in response_dta
+
+
 @pytest.mark.schematic_api
 class TestSchemaGeneratorOperation:
     @pytest.mark.parametrize("relationship", ["parentOf", "requiresDependency", "rangeValue", "domainValue"])


### PR DESCRIPTION
Created an endpoint to expose the `schema/generator` function `get_nodes_display_names`.

Addresses issue #1082.