### PR TITLE
Create API endpoint for get_node_validation_rules

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -770,7 +770,35 @@ paths:
       tags:
         - Schema Operation
 
-
+  /schemas/get_node_validation_rules:
+    get:
+      summary: Get validation rules for a given node
+      description: Get validation rules for a given node
+      operationId: api.routes.get_node_validation_rules
+      parameters:
+        - in: query
+          name: schema_url
+          schema:
+            type: string
+          description: Data Model URL
+          example: >-
+            https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld
+          required: true
+        - in: query
+          name: node_display_name
+          schema:
+            type: string
+            nullable: false
+          description: Display label of node
+          example: CheckRegexList
+          required: true
+      responses:
+        "200":
+          description: return a list
+        "500":
+          description: Check schematic log. 
+      tags:
+        - Schema Operation
 
 
   /explorer/get_node_dependencies:

--- a/api/routes.py
+++ b/api/routes.py
@@ -688,4 +688,16 @@ def get_if_node_required(schema_url: str, node_display_name: str) -> bool:
 
     return is_required
 
+def get_node_validation_rules(schema_url: str, node_display_name: str) -> list:
+    """
+    Args:
+        schema_url (str): Data Model URL
+        node_display_name (str): node display name
+    Returns:
+        List of valiation rules for a given node.
+    """
+    gen = SchemaGenerator(path_to_json_ld=schema_url)
+    node_validation_rules = gen.get_node_validation_rules(node_display_name)
+
+    return node_validation_rules
 


### PR DESCRIPTION
Exposed an endpoint for `SchemaGenerator.get_node_validation_rules()`.

Addresses issue #1083 