### PR TITLE
Set default of "table_manipulation" as "replace" in API endpoint when users enter None and updated tests

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -303,6 +303,7 @@ paths:
           schema:
             type: string
             enum: ["replace", "upsert"]
+          required: true
       operationId: api.routes.submit_manifest_route
       responses:
         "200":

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -300,10 +300,11 @@ paths:
           }]'
         - in: query
           name: table_manipulation
+          description: Specify the way the manifest tables should be store as on Synapse when one with the same name already exists. Options are 'replace' and 'upsert'.replace' will remove the rows and columns from the existing table and store the new rows and columns, preserving the name and synID.'upsert' will add the new rows to the table and preserve the exisitng rows and columns in the existing table. If nothing is selected, the default is "replace"
           schema:
             type: string
             enum: ["replace", "upsert"]
-          required: true
+          required: false
       operationId: api.routes.submit_manifest_route
       responses:
         "200":

--- a/api/routes.py
+++ b/api/routes.py
@@ -378,7 +378,7 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
         validate_component = data_type
 
     manifest_id = metadata_model.submit_metadata_manifest(
-        path_to_json_ld = schema_url, manifest_path=temp_path, dataset_id=dataset_id, validate_component=validate_component, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules, table_manipulation=table_manipulation)
+        path_to_json_ld = schema_url, manifest_path=temp_path, dataset_id=dataset_id, validate_component=validate_component, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules)
 
     return manifest_id
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -349,7 +349,7 @@ def validate_manifest_route(schema_url, data_type, json_str=None):
     return res_dict
 
 
-def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None, json_str=None):
+def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None, json_str=None, table_manipulation=None):
     # call config_handler()
     config_handler(asset_view = asset_view)
 
@@ -370,7 +370,8 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
 
     input_token = connexion.request.args["input_token"]
 
-    table_manipulation = connexion.request.args["table_manipulation"]
+    if not table_manipulation: 
+        table_manipulation = "replace"
 
     if data_type == 'None':
         validate_component = None
@@ -378,7 +379,7 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
         validate_component = data_type
 
     manifest_id = metadata_model.submit_metadata_manifest(
-        path_to_json_ld = schema_url, manifest_path=temp_path, dataset_id=dataset_id, validate_component=validate_component, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules)
+        path_to_json_ld = schema_url, manifest_path=temp_path, dataset_id=dataset_id, validate_component=validate_component, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules, table_manipulation = table_manipulation)
 
     return manifest_id
 

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1604,7 +1604,7 @@ class ManifestGenerator(object):
         writer = pd.ExcelWriter(existing_excel_path, engine='openpyxl')
         writer.book = workbook
         writer.worksheets = {ws.title: ws for ws in workbook.worksheets}
-        worksheet = writer.sheets["Sheet1"]
+        worksheet = writer.worksheets["Sheet1"]
 
         # add additional content to the existing spreadsheet
         additional_df.to_excel(writer, sheet_name = "Sheet1", startrow=1, index = False, header=False)

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1603,7 +1603,7 @@ class ManifestGenerator(object):
         # initalize excel writer
         writer = pd.ExcelWriter(existing_excel_path, engine='openpyxl')
         writer.book = workbook
-        writer.sheets = {ws.title: ws for ws in workbook.worksheets}
+        writer.worksheets = {ws.title: ws for ws in workbook.worksheets}
         worksheet = writer.sheets["Sheet1"]
 
         # add additional content to the existing spreadsheet

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -512,7 +512,8 @@ class TestManifestOperation:
             assert response_path.endswith(".csv")
 
     @pytest.mark.parametrize("json_str", [None, '[{ "Patient ID": 123, "Sex": "Female", "Year of Birth": "", "Diagnosis": "Healthy", "Component": "Patient", "Cancer Type": "Breast", "Family History": "Breast, Lung", }]'])
-    def test_submit_manifest(self, client, syn_token, data_model_jsonld, json_str, test_manifest_csv):
+    @pytest.mark.parametrize("table_manipulation", ["replace", "upsert"])
+    def test_submit_manifest(self, client, syn_token, data_model_jsonld, json_str, test_manifest_csv, table_manipulation):
         params = {
             "input_token": syn_token,
             "schema_url": data_model_jsonld,
@@ -521,6 +522,7 @@ class TestManifestOperation:
             "manifest_record_type": "table",
             "asset_view": "syn44259375",
             "dataset_id": "syn44259313",
+            "table_manipulation": table_manipulation
         }
 
         if json_str:


### PR DESCRIPTION
I noticed that the `table_manipulation` is using `replace` as the default option. ~~If that's the case, table_manipulation parameter should be set as "required" so that users can't set an empty string or None to `table_manipulation` parameter on swagger UI~~.  To match with the downstream submit function, I set "table_manipulation" as an optional parameter, and if users don't set anything, we would pass "replace" by default. I also updated the description of the parameter for clarify. 

Context:  I discovered this issue when running tests for #1101 