### PR TITLE
Add `use_schema_label` parameter to manifest submission endpoint, separate manifest submission and table upsert tests

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -311,6 +311,13 @@ paths:
             type: string
             enum: ["replace", "upsert"]
           required: false
+        - in: query
+          name: use_schema_label
+          description: "Store attributes using the schema label (true, default) or store attributes using the display label (false). Attribute display names in the schema must not only include characters that are not accepted by Synapse. Annotation names may only contain: letters, numbers, '_' and '.'"
+          schema:
+            type: boolean
+            default: true
+          required: true
       operationId: api.routes.submit_manifest_route
       responses:
         "200":

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -317,7 +317,7 @@ paths:
           schema:
             type: boolean
             default: true
-          required: true
+          required: false
       operationId: api.routes.submit_manifest_route
       responses:
         "200":

--- a/api/routes.py
+++ b/api/routes.py
@@ -379,7 +379,12 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
 
     input_token = connexion.request.args["input_token"]
 
-    use_schema_label = parse_bool(connexion.request.args["use_schema_label"])
+
+    use_schema_label = connexion.request.args["use_schema_label"]
+    if use_schema_label == 'None':
+        use_schema_label = True
+    else:
+        use_schema_label = parse_bool(use_schema_label)
 
     if not table_manipulation: 
         table_manipulation = "replace"

--- a/api/routes.py
+++ b/api/routes.py
@@ -369,7 +369,7 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
 
     data_type = connexion.request.args["data_type"]
 
-    restrict_rules = connexion.request.args["restrict_rules"]
+    restrict_rules = parse_bool(connexion.request.args["restrict_rules"])
 
     metadata_model = initalize_metadata_model(schema_url)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -164,8 +164,12 @@ class JsonConverter:
 def parse_bool(str_bool):
     if str_bool.lower().startswith('t'):
         return True
-    else:
+    elif str_bool.lower().startswith('f'):
         return False
+    else:
+        raise ValueError(
+            "String boolean does not appear to be true or false. Please verify input"
+        )
         
 def save_file(file_key="csv_file"):
     '''

--- a/api/routes.py
+++ b/api/routes.py
@@ -161,7 +161,11 @@ class JsonConverter:
             temp_path = save_file(file_key='file_name')
             return temp_path
         
-
+def parse_bool(str_bool):
+    if str_bool.lower().startswith('t'):
+        return True
+    else:
+        return False
         
 def save_file(file_key="csv_file"):
     '''

--- a/api/routes.py
+++ b/api/routes.py
@@ -168,7 +168,7 @@ def parse_bool(str_bool):
         return False
     else:
         raise ValueError(
-            "String boolean does not appear to be true or false. Please verify input"
+            "String boolean does not appear to be true or false. Please verify input."
         )
         
 def save_file(file_key="csv_file"):

--- a/api/routes.py
+++ b/api/routes.py
@@ -375,6 +375,8 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
 
     input_token = connexion.request.args["input_token"]
 
+    use_schema_label = parse_bool(connexion.request.args["use_schema_label"])
+
     if not table_manipulation: 
         table_manipulation = "replace"
 
@@ -384,7 +386,15 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
         validate_component = data_type
 
     manifest_id = metadata_model.submit_metadata_manifest(
-        path_to_json_ld = schema_url, manifest_path=temp_path, dataset_id=dataset_id, validate_component=validate_component, input_token=input_token, manifest_record_type = manifest_record_type, restrict_rules = restrict_rules, table_manipulation = table_manipulation)
+        path_to_json_ld = schema_url, 
+        manifest_path=temp_path, 
+        dataset_id=dataset_id, 
+        validate_component=validate_component, 
+        input_token=input_token, 
+        manifest_record_type = manifest_record_type, 
+        restrict_rules = restrict_rules, 
+        table_manipulation = table_manipulation, 
+        use_schema_label=use_schema_label)
 
     return manifest_id
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,7 +28,12 @@ def client(app, config_path):
 def test_manifest_csv(helpers):
     test_manifest_path = helpers.get_data_path("mock_manifests/Valid_Test_Manifest.csv")
     yield test_manifest_path
-    
+
+@pytest.fixture(scope="class")
+def test_upsert_manifest_csv(helpers):
+    test_upsert_manifest_path = helpers.get_data_path("mock_manifests/rdb_table_manifest.csv")
+    yield test_upsert_manifest_path
+
 @pytest.fixture(scope="class")
 def test_manifest_json(helpers):
     test_manifest_path = helpers.get_data_path("mock_manifests/Example.Patient.manifest.json")
@@ -565,7 +570,35 @@ class TestManifestOperation:
             # test uploading a csv file
             response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")}, headers=headers)            
             assert response_csv.status_code == 200     
+    
+    @pytest.mark.parametrize("json_str", [None, '[{ "Component": "MockRDB", "MockRDB_id": 5 }]'])
+    def test_submit_manifest_upsert(self, client, syn_token, data_model_jsonld, json_str, test_upsert_manifest_csv, ):
+        params = {
+            "input_token": syn_token,
+            "schema_url": data_model_jsonld,
+            "data_type": "MockRDB",
+            "restrict_rules": False, 
+            "manifest_record_type": "table",
+            "asset_view": "syn44259375",
+            "dataset_id": "syn44259313",
+            "table_manipulation": 'upsert',
+            "use_schema_label": False
+        }
 
+        if json_str:
+            params["json_str"] = json_str
+            response = client.post('http://localhost:3001/v1/model/submit', query_string = params, data={"file_name":''})
+            assert response.status_code == 200
+        else: 
+            headers = {
+            'Content-Type': "multipart/form-data",
+            'Accept': "application/json"
+            }
+            params["data_type"] = "MockRDB"
+
+            # test uploading a csv file
+            response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_upsert_manifest_csv, 'rb'), "test.csv")}, headers=headers)            
+            assert response_csv.status_code == 200     
 
 @pytest.mark.schematic_api
 class TestSchemaVisualization:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -538,7 +538,8 @@ class TestManifestOperation:
 
     @pytest.mark.parametrize("json_str", [None, '[{ "Patient ID": 123, "Sex": "Female", "Year of Birth": "", "Diagnosis": "Healthy", "Component": "Patient", "Cancer Type": "Breast", "Family History": "Breast, Lung", }]'])
     @pytest.mark.parametrize("table_manipulation", ["replace", "upsert"])
-    def test_submit_manifest(self, client, syn_token, data_model_jsonld, json_str, test_manifest_csv, table_manipulation):
+    @pytest.mark.parametrize("use_schema_label", ['true','false'])
+    def test_submit_manifest(self, client, syn_token, data_model_jsonld, json_str, test_manifest_csv, table_manipulation, use_schema_label):
         params = {
             "input_token": syn_token,
             "schema_url": data_model_jsonld,
@@ -547,7 +548,8 @@ class TestManifestOperation:
             "manifest_record_type": "table",
             "asset_view": "syn44259375",
             "dataset_id": "syn44259313",
-            "table_manipulation": table_manipulation
+            "table_manipulation": table_manipulation,
+            "use_schema_label": use_schema_label
         }
 
         if json_str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -537,9 +537,8 @@ class TestManifestOperation:
             assert response_path.endswith(".csv")
 
     @pytest.mark.parametrize("json_str", [None, '[{ "Patient ID": 123, "Sex": "Female", "Year of Birth": "", "Diagnosis": "Healthy", "Component": "Patient", "Cancer Type": "Breast", "Family History": "Breast, Lung", }]'])
-    @pytest.mark.parametrize("table_manipulation", ["replace", "upsert"])
     @pytest.mark.parametrize("use_schema_label", ['true','false'])
-    def test_submit_manifest(self, client, syn_token, data_model_jsonld, json_str, test_manifest_csv, table_manipulation, use_schema_label):
+    def test_submit_manifest(self, client, syn_token, data_model_jsonld, json_str, test_manifest_csv, use_schema_label):
         params = {
             "input_token": syn_token,
             "schema_url": data_model_jsonld,
@@ -548,7 +547,7 @@ class TestManifestOperation:
             "manifest_record_type": "table",
             "asset_view": "syn44259375",
             "dataset_id": "syn44259313",
-            "table_manipulation": table_manipulation,
+            "table_manipulation": 'replace',
             "use_schema_label": use_schema_label
         }
 


### PR DESCRIPTION
Add `use_schema_label` paramter to manifest submission endpoint as a boolean with default value `true`, preserving previous behavior.
Also add new function `parse_bool` to parse inputs from api that are type `string` as type `bool` so that they can be used correctly by downstream functions.

Manifest submission api tests are passing, ~~excluding the upsert tests because it has not been implemented on this branch~~. Also manually tested by uploading manifests to synapse through swagger.

This PR also separates out the normal manifest submission tests from the upsert submission tests because of the requirements to only use `--use_display_label` and a different component from the other submission tests.