### PR TITLE
Remove `try: catch:` block from manifest submission command function

### DIFF
--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -117,35 +117,35 @@ def submit_manifest(
         inputMModelLocation=jsonld, inputMModelLocationType=model_file_type
     )
 
-    try:
-        manifest_id = metadata_model.submit_metadata_manifest(
-            path_to_json_ld = jsonld,
-            manifest_path=manifest_path,
-            dataset_id=dataset_id,
-            validate_component=validate_component,
-            manifest_record_type=manifest_record_type,
-            restrict_rules=restrict_rules,
-            use_schema_label=use_schema_label,
-            hide_blanks=hide_blanks,
-            project_scope=project_scope,
-            table_manipulation=table_manipulation,
-        )
 
-        '''
-        if censored_manifest_id:
-            logger.info(
-                f"File at '{manifest_path}' was censored and successfully associated "
-                f"with dataset '{dataset_id}'. "
-                f"An uncensored version has also been associated with dataset '{dataset_id}' "
-                f"and submitted to the Synapse Access Control Team to begin the process "
-                f"of adding terms of use or review board approval."
-            )
-        '''
-        if manifest_id:
-            logger.info(
-                f"File at '{manifest_path}' was successfully associated "
-                f"with dataset '{dataset_id}'."
-            )
+    manifest_id = metadata_model.submit_metadata_manifest(
+        path_to_json_ld = jsonld,
+        manifest_path=manifest_path,
+        dataset_id=dataset_id,
+        validate_component=validate_component,
+        manifest_record_type=manifest_record_type,
+        restrict_rules=restrict_rules,
+        use_schema_label=use_schema_label,
+        hide_blanks=hide_blanks,
+        project_scope=project_scope,
+        table_manipulation=table_manipulation,
+    )
+
+    '''
+    if censored_manifest_id:
+        logger.info(
+            f"File at '{manifest_path}' was censored and successfully associated "
+            f"with dataset '{dataset_id}'. "
+            f"An uncensored version has also been associated with dataset '{dataset_id}' "
+            f"and submitted to the Synapse Access Control Team to begin the process "
+            f"of adding terms of use or review board approval."
+        )
+    '''
+    if manifest_id:
+        logger.info(
+            f"File at '{manifest_path}' was successfully associated "
+            f"with dataset '{dataset_id}'."
+        )
 
 # prototype based on validateModelManifest()
 @model.command(

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -146,10 +146,6 @@ def submit_manifest(
                 f"File at '{manifest_path}' was successfully associated "
                 f"with dataset '{dataset_id}'."
             )
-    except ValueError:
-        logger.error(
-            f"Component '{validate_component}' is not present in '{jsonld}', or is invalid."
-        )
     except ValidationError:
         logger.error(
             f"Validation errors resulted while validating with '{validate_component}'."

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -146,10 +146,6 @@ def submit_manifest(
                 f"File at '{manifest_path}' was successfully associated "
                 f"with dataset '{dataset_id}'."
             )
-    except ValidationError:
-        logger.error(
-            f"Validation errors resulted while validating with '{validate_component}'."
-        )
 
 # prototype based on validateModelManifest()
 @model.command(

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -154,11 +154,6 @@ def submit_manifest(
         logger.error(
             f"Validation errors resulted while validating with '{validate_component}'."
         )
-    except LookupError:
-        logger.error(
-            f"'{dataset_id}' could not be found in the asset view (or file view for Synapse user)"
-        )
-
 
 # prototype based on validateModelManifest()
 @model.command(

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -130,17 +130,7 @@ def submit_manifest(
         project_scope=project_scope,
         table_manipulation=table_manipulation,
     )
-
-    '''
-    if censored_manifest_id:
-        logger.info(
-            f"File at '{manifest_path}' was censored and successfully associated "
-            f"with dataset '{dataset_id}'. "
-            f"An uncensored version has also been associated with dataset '{dataset_id}' "
-            f"and submitted to the Synapse Access Control Team to begin the process "
-            f"of adding terms of use or review board approval."
-        )
-    '''
+    
     if manifest_id:
         logger.info(
             f"File at '{manifest_path}' was successfully associated "


### PR DESCRIPTION
Remove `try: catch:` block in `commands.submit_manifest` and verify that errors are handled elsewhere in the codebase at the appropriate function.