### PR TITLE
Display exceptions raised during validation with Great expectations, allow exclusion of upper bound OR lower bound for `inRange` rule

### DIFF
--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -272,8 +272,8 @@ class GreatExpectationsHelpers(object):
                     
                     elif base_rule==("inRange"):
                         args["mostly"]=1.0
-                        args["min_value"]=float(rule.split(" ")[1])
-                        args["max_value"]=float(rule.split(" ")[2])
+                        args["min_value"]=float(rule.split(" ")[1]) if rule.split(" ")[1] != 'None' else None
+                        args["max_value"]=float(rule.split(" ")[2]) if rule.split(" ")[2] != 'None' else None
                         args['allow_cross_type_comparisons']=True
                         meta={
                             "notes": {

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -252,6 +252,7 @@ class GreatExpectationsHelpers(object):
                         args["mostly"]=1.0
                         args["min_value"]=min_age
                         args["max_value"]=max_age
+                        #args['allow_cross_type_comparisons']=True # TODO Can allow after issue #980 is completed
                         meta={
                             "notes": {
                                 "format": "markdown",

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -275,8 +275,8 @@ class GreatExpectationsHelpers(object):
                     
                     elif base_rule==("inRange"):
                         args["mostly"]=1.0
-                        args["min_value"]=float(rule.split(" ")[1]) if rule.split(" ")[1] != 'None' else None
-                        args["max_value"]=float(rule.split(" ")[2]) if rule.split(" ")[2] != 'None' else None
+                        args["min_value"]=float(rule.split(" ")[1]) if rule.split(" ")[1].lower() != 'none' else None
+                        args["max_value"]=float(rule.split(" ")[2]) if rule.split(" ")[2].lower() != 'none' else None
                         args['allow_cross_type_comparisons']=True # TODO Should follow up with issue #980
                         meta={
                             "notes": {

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -408,7 +408,7 @@ class GreatExpectationsHelpers(object):
                 rule        = result_dict['expectation_config']['meta']['validation_rule']
 
 
-                if 'exception_info' in result_dict.keys():
+                if 'exception_info' in result_dict.keys() and result_dict['exception_info']['exception_message']:
                     raise Exception(result_dict['exception_info']['exception_traceback'])
                 
                 #only some expectations explicitly list unexpected values and indices, read or find if not present

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -408,8 +408,11 @@ class GreatExpectationsHelpers(object):
                 rule        = result_dict['expectation_config']['meta']['validation_rule']
 
 
+                if 'exception_info' in result_dict.keys():
+                    raise Exception(result_dict['exception_info']['exception_traceback'])
+                
                 #only some expectations explicitly list unexpected values and indices, read or find if not present
-                if 'unexpected_index_list' in result_dict['result']:
+                elif 'unexpected_index_list' in result_dict['result']:
                     indices = result_dict['result']['unexpected_index_list']
                     values  = result_dict['result']['unexpected_list']
 

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -21,6 +21,8 @@ from great_expectations.core.expectation_configuration import ExpectationConfigu
 from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import DataContextConfig, DatasourceConfig, FilesystemStoreBackendDefaults
 from great_expectations.data_context.types.resource_identifiers import ExpectationSuiteIdentifier
+from great_expectations.exceptions.exceptions import GreatExpectationsError
+
 
 from schematic.models.validate_attribute import GenerateError
 from schematic.schemas.generator import SchemaGenerator
@@ -411,7 +413,7 @@ class GreatExpectationsHelpers(object):
 
 
                 if 'exception_info' in result_dict.keys() and result_dict['exception_info']['exception_message']:
-                    raise Exception(result_dict['exception_info']['exception_traceback'])
+                    raise GreatExpectationsError(result_dict['exception_info']['exception_traceback'])
                 
                 #only some expectations explicitly list unexpected values and indices, read or find if not present
                 elif 'unexpected_index_list' in result_dict['result']:

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -274,7 +274,7 @@ class GreatExpectationsHelpers(object):
                         args["mostly"]=1.0
                         args["min_value"]=float(rule.split(" ")[1]) if rule.split(" ")[1] != 'None' else None
                         args["max_value"]=float(rule.split(" ")[2]) if rule.split(" ")[2] != 'None' else None
-                        args['allow_cross_type_comparisons']=True
+                        args['allow_cross_type_comparisons']=True # TODO Should follow up with issue #980
                         meta={
                             "notes": {
                                 "format": "markdown",

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -277,7 +277,7 @@ class GreatExpectationsHelpers(object):
                         meta={
                             "notes": {
                                 "format": "markdown",
-                                "content": "Expect column values to be Unique. **Markdown** `Supported`",
+                                "content": "Expect column values to be within a specified range. **Markdown** `Supported`",
                             },
                             "validation_rule": rule
                         }

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -274,6 +274,7 @@ class GreatExpectationsHelpers(object):
                         args["mostly"]=1.0
                         args["min_value"]=float(rule.split(" ")[1])
                         args["max_value"]=float(rule.split(" ")[2])
+                        args['allow_cross_type_comparisons']=True
                         meta={
                             "notes": {
                                 "format": "markdown",

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -510,25 +510,28 @@ class GenerateError:
         rule_parts = val_rule.split(" ")
         rule_info = validation_rule_info()
 
-        if not sg.is_node_required(node_display_name=attribute_name):
+        #set message level to default and change after
+        if rule_parts[0] != 'schema':
+            level = rule_info[rule_parts[0]]['default_message_level']
+
+        # Parse rule for level, set to default if not specified
+        if rule_parts[-1].lower() == 'error' or rule_parts[0] == 'schema':
+            level = 'error'
+            return level
+        elif rule_parts[-1].lower() == 'warning':
+            level = 'warning'
+            return level 
+        
+        elif not sg.is_node_required(node_display_name=attribute_name):
             # raise warning if recommended but not required
             if 'recommended' in val_rule:
                 level = 'warning'
             # If not required or recommended raise warnings to notify
             else:
                 level = 'warning' 
-                return level
         elif sg.is_node_required(node_display_name=attribute_name) and 'recommended' in val_rule:
             level = None
-        
-        
-        # Parse rule for level, set to default if not specified
-        if rule_parts[-1].lower() == 'error' or rule_parts[0] == 'schema':
-            level = 'error'
-        elif rule_parts[-1].lower() == 'warning':
-            level = 'warning'
-        else:
-            level = rule_info[rule_parts[0]]['default_message_level']
+            
             
         return level
 

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -517,21 +517,13 @@ class GenerateError:
         # Parse rule for level, set to default if not specified
         if rule_parts[-1].lower() == 'error' or rule_parts[0] == 'schema':
             level = 'error'
-            return level
         elif rule_parts[-1].lower() == 'warning':
-            level = 'warning'
-            return level 
-        
+            level = 'warning'        
         elif not sg.is_node_required(node_display_name=attribute_name):
-            # raise warning if recommended but not required
-            if 'recommended' in val_rule:
-                level = 'warning'
-            # If not required or recommended raise warnings to notify
-            else:
-                level = 'warning' 
+            # If not required raise warnings to notify
+            level = 'warning' 
         elif sg.is_node_required(node_display_name=attribute_name) and 'recommended' in val_rule:
             level = None
-            
             
         return level
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -65,8 +65,6 @@ class TestManifestValidation:
             rootNode=rootNode
             )
 
-        logging.warning(errors)
-
         #Check errors
         assert GenerateError.generate_type_error(
             val_rule = 'num',


### PR DESCRIPTION
- Raise `GreatExpectationsError` if an exception is raised during the GE expectation suite validation
- Allow comparison across types for `inRange` rule
  - _note: while comparisons across types are now permitted, non-numerical values will raise validation errors/warnings_
- Allow exclusion of upper bound OR lower bound for `inRange` rule
- Re-order logic for message level determination so that user spec overrides default behavior and whether attribute is required or not