### PR TITLE
Save all properties that are Included in the domain of a Class

### DIFF
--- a/schematic/schemas/df_parser.py
+++ b/schematic/schemas/df_parser.py
@@ -504,7 +504,7 @@ def create_nx_schema_objects(
                         se,
                         attribute["Attribute"],
                         description=attribute["Description"],
-                        subclass_of=attribute["Parent"],
+                        subclass_of=[attribute["Parent"]],
                         requires_dependencies=class_info["dependencies"],
                         requires_range=class_info["range"],
                         required=class_info["required"],

--- a/schematic/schemas/df_parser.py
+++ b/schematic/schemas/df_parser.py
@@ -470,7 +470,7 @@ def create_nx_schema_objects(
                     # determine parent class of the new value class
                     # if this attribute is not a property, set it as a parent class
                     if not attribute["Attribute"] in all_properties:
-                        parent = attribute["Attribute"]
+                        parent = [attribute["Attribute"]]
                     else:
                         # this attribute is a property, set the parent to the domain class of this attribute
                         
@@ -482,7 +482,7 @@ def create_nx_schema_objects(
                                 "must have a class parent. The extension could not be added to the schema."
                             )
                     new_class = get_class(
-                        se, val, description=None, subclass_of=[parent]
+                        se, val, description=None, subclass_of=parent
                     )
 
                     # check if attribute doesn't already exist and add it

--- a/schematic/schemas/df_parser.py
+++ b/schematic/schemas/df_parser.py
@@ -98,7 +98,6 @@ def get_class(
                     for sub in subclass_of
                 ]
             }
-
     else:
         parent = {"rdfs:subClassOf": [{"@id": "schema:Thing"}]}
 
@@ -483,7 +482,7 @@ def create_nx_schema_objects(
                                 "must have a class parent. The extension could not be added to the schema."
                             )
                     new_class = get_class(
-                        se, val, description=None, subclass_of=parent
+                        se, val, description=None, subclass_of=[parent]
                     )
 
                     # check if attribute doesn't already exist and add it

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -234,24 +234,22 @@ class SchemaExplorer:
         properties = []
         for record in self.schema["@graph"]:
             if record["@type"] == "rdf:Property":
-                try:
-                    if (
-                        type(record["schema:domainIncludes"]) == dict
-                        and record["schema:domainIncludes"]["@id"] == schema_uri
-                    ):
-                        properties.append(record["rdfs:label"])
-                    elif (
-                        type(record["schema:domainIncludes"]) == list
-                        and [
-                            item
-                            for item in record["schema:domainIncludes"]
-                            if item["@id"] == schema_uri
-                        ]
-                        != []
-                    ):
-                        properties.append(record["rdfs:label"])
-                except:
-                    breakpoint()
+                if (
+                    type(record["schema:domainIncludes"]) == dict
+                    and record["schema:domainIncludes"]["@id"] == schema_uri
+                ):
+                    properties.append(record["rdfs:label"])
+                elif (
+                     type(record["schema:domainIncludes"]) == list
+                     and [
+                         item
+                         for item in record["schema:domainIncludes"]
+                         if item["@id"] == schema_uri
+                     ]
+                     != []
+                     ):
+                   
+                     properties.append(record["rdfs:label"])
         return properties
 
     def find_all_class_properties(self, schema_class, display_as_table=False):
@@ -480,13 +478,18 @@ class SchemaExplorer:
         for record in self.schema["@graph"]:
             if record["@type"] == "rdf:Property":
                 if record["rdfs:label"] == schema_property:
-                    p_domain = dict2list(record["schema:domainIncludes"])
-                    return unlist(
-                        [
-                            self.uri2label(schema_class["@id"])
-                            for schema_class in p_domain
-                        ]
-                    )
+                    p_domain = record["schema:domainIncludes"]
+
+                    return [
+                            self.uri2label(record["@id"]) 
+                                for record in p_domain
+                            ]
+                    #return unlist(
+                    #    [
+                    #        self.uri2label(schema_class["@id"])
+                    #        for schema_class in p_domain
+                    #    ]
+                    #)
 
         return None
 
@@ -505,15 +508,9 @@ class SchemaExplorer:
                     property_info["description"] = record["rdfs:comment"]
                     property_info["uri"] = curie2uri(record["@id"], namespaces)
 
-                    if "schema:domainIncludes" in record:
-                         p_domain = dict2list(record["schema:domainIncludes"])
-                         property_info["domain"] = unlist(
-                            [self.uri2label(record["@id"]) for record in p_domain]
-                         )
-                         breakpoint()
-                    else:
-                        property_info["domain"] = []
-
+                    p_domain = record["schema:domainIncludes"]
+                    property_info["domain"] = [self.uri2label(record["@id"]) for record in p_domain]
+                    
                     if "schema:rangeIncludes" in record:
                         p_range = dict2list(record["schema:rangeIncludes"])
                         property_info["range"] = [

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -509,8 +509,11 @@ class SchemaExplorer:
                     property_info["uri"] = curie2uri(record["@id"], namespaces)
 
                     p_domain = record["schema:domainIncludes"]
-                    property_info["domain"] = [self.uri2label(record["@id"]) for record in p_domain]
-                    
+                    if type(p_domain) == list:
+                        property_info["domain"] = [self.uri2label(record["@id"]) for record in p_domain]
+                    elif type(p_domain) == dict:
+                        property_info["domain"] = [self.uri2label(record["@id"])]
+
                     if "schema:rangeIncludes" in record:
                         p_range = dict2list(record["schema:rangeIncludes"])
                         property_info["range"] = [

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -234,21 +234,24 @@ class SchemaExplorer:
         properties = []
         for record in self.schema["@graph"]:
             if record["@type"] == "rdf:Property":
-                if (
-                    type(record["schema:domainIncludes"]) == dict
-                    and record["schema:domainIncludes"]["@id"] == schema_uri
-                ):
-                    properties.append(record["rdfs:label"])
-                elif (
-                    type(record["schema:domainIncludes"]) == list
-                    and [
-                        item
-                        for item in record["schema:domainIncludes"]
-                        if item["@id"] == schema_uri
-                    ]
-                    != []
-                ):
-                    properties.append(record["rdfs:label"])
+                try:
+                    if (
+                        type(record["schema:domainIncludes"]) == dict
+                        and record["schema:domainIncludes"]["@id"] == schema_uri
+                    ):
+                        properties.append(record["rdfs:label"])
+                    elif (
+                        type(record["schema:domainIncludes"]) == list
+                        and [
+                            item
+                            for item in record["schema:domainIncludes"]
+                            if item["@id"] == schema_uri
+                        ]
+                        != []
+                    ):
+                        properties.append(record["rdfs:label"])
+                except:
+                    breakpoint()
         return properties
 
     def find_all_class_properties(self, schema_class, display_as_table=False):
@@ -502,10 +505,15 @@ class SchemaExplorer:
                     property_info["description"] = record["rdfs:comment"]
                     property_info["uri"] = curie2uri(record["@id"], namespaces)
 
-                    p_domain = dict2list(record["schema:domainIncludes"])
-                    property_info["domain"] = unlist(
-                        [self.uri2label(record["@id"]) for record in p_domain]
-                    )
+                    if "schema:domainIncludes" in record:
+                         p_domain = dict2list(record["schema:domainIncludes"])
+                         property_info["domain"] = unlist(
+                            [self.uri2label(record["@id"]) for record in p_domain]
+                         )
+                         breakpoint()
+                    else:
+                        property_info["domain"] = []
+
                     if "schema:rangeIncludes" in record:
                         p_range = dict2list(record["schema:rangeIncludes"])
                         property_info["range"] = [

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2965,13 +2965,7 @@
             "rdfs:label": "Female",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:X"
+                    "@id": "bts:Sex"
                 }
             ],
             "schema:isPartOf": {
@@ -2988,13 +2982,7 @@
             "rdfs:label": "Male",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:X"
+                    "@id": "bts:Sex"
                 }
             ],
             "schema:isPartOf": {
@@ -3011,13 +2999,7 @@
             "rdfs:label": "Other",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:X"
+                    "@id": "bts:Sex"
                 }
             ],
             "schema:isPartOf": {
@@ -3034,31 +3016,7 @@
             "rdfs:label": "Healthy",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:D"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:A"
-                },
-                {
-                    "@id": "bts:G"
-                },
-                {
-                    "@id": "bts:N"
-                },
-                {
-                    "@id": "bts:O"
-                },
-                {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:S"
+                    "@id": "bts:Diagnosis"
                 }
             ],
             "schema:isPartOf": {
@@ -3075,37 +3033,7 @@
             "rdfs:label": "Breast",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:A"
-                },
-                {
-                    "@id": "bts:N"
-                },
-                {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:R"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:T"
-                },
-                {
-                    "@id": "bts:Y"
-                },
-                {
-                    "@id": "bts:P"
-                },
-                {
-                    "@id": "bts:E"
+                    "@id": "bts:CancerType"
                 }
             ],
             "schema:isPartOf": {
@@ -3122,37 +3050,7 @@
             "rdfs:label": "Colorectal",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:A"
-                },
-                {
-                    "@id": "bts:N"
-                },
-                {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:R"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:T"
-                },
-                {
-                    "@id": "bts:Y"
-                },
-                {
-                    "@id": "bts:P"
-                },
-                {
-                    "@id": "bts:E"
+                    "@id": "bts:CancerType"
                 }
             ],
             "schema:isPartOf": {
@@ -3169,37 +3067,7 @@
             "rdfs:label": "Lung",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:A"
-                },
-                {
-                    "@id": "bts:N"
-                },
-                {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:R"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:T"
-                },
-                {
-                    "@id": "bts:Y"
-                },
-                {
-                    "@id": "bts:P"
-                },
-                {
-                    "@id": "bts:E"
+                    "@id": "bts:CancerType"
                 }
             ],
             "schema:isPartOf": {
@@ -3216,37 +3084,7 @@
             "rdfs:label": "Prostate",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:A"
-                },
-                {
-                    "@id": "bts:N"
-                },
-                {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:R"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:T"
-                },
-                {
-                    "@id": "bts:Y"
-                },
-                {
-                    "@id": "bts:P"
-                },
-                {
-                    "@id": "bts:E"
+                    "@id": "bts:CancerType"
                 }
             ],
             "schema:isPartOf": {
@@ -3263,37 +3101,7 @@
             "rdfs:label": "Skin",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:A"
-                },
-                {
-                    "@id": "bts:N"
-                },
-                {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:R"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:T"
-                },
-                {
-                    "@id": "bts:Y"
-                },
-                {
-                    "@id": "bts:P"
-                },
-                {
-                    "@id": "bts:E"
+                    "@id": "bts:CancerType"
                 }
             ],
             "schema:isPartOf": {
@@ -3310,43 +3118,7 @@
             "rdfs:label": "Malignant",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:T"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:U"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:T"
-                },
-                {
-                    "@id": "bts:A"
-                },
-                {
-                    "@id": "bts:T"
-                },
-                {
-                    "@id": "bts:U"
-                },
-                {
-                    "@id": "bts:S"
+                    "@id": "bts:TissueStatus"
                 }
             ],
             "schema:isPartOf": {
@@ -3363,37 +3135,7 @@
             "rdfs:label": "FASTQ",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:F"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:L"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:F"
-                },
-                {
-                    "@id": "bts:O"
-                },
-                {
-                    "@id": "bts:R"
-                },
-                {
-                    "@id": "bts:M"
-                },
-                {
-                    "@id": "bts:A"
-                },
-                {
-                    "@id": "bts:T"
+                    "@id": "bts:FileFormat"
                 }
             ],
             "schema:isPartOf": {
@@ -3410,40 +3152,7 @@
             "rdfs:label": "GRCh37",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:G"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:N"
-                },
-                {
-                    "@id": "bts:O"
-                },
-                {
-                    "@id": "bts:M"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:B"
-                },
-                {
-                    "@id": "bts:U"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:L"
-                },
-                {
-                    "@id": "bts:D"
+                    "@id": "bts:GenomeBuild"
                 }
             ],
             "schema:isPartOf": {
@@ -3460,40 +3169,7 @@
             "rdfs:label": "GRCh38",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:G"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:N"
-                },
-                {
-                    "@id": "bts:O"
-                },
-                {
-                    "@id": "bts:M"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:B"
-                },
-                {
-                    "@id": "bts:U"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:L"
-                },
-                {
-                    "@id": "bts:D"
+                    "@id": "bts:GenomeBuild"
                 }
             ],
             "schema:isPartOf": {
@@ -3510,40 +3186,7 @@
             "rdfs:label": "GRCm38",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:G"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:N"
-                },
-                {
-                    "@id": "bts:O"
-                },
-                {
-                    "@id": "bts:M"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:B"
-                },
-                {
-                    "@id": "bts:U"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:L"
-                },
-                {
-                    "@id": "bts:D"
+                    "@id": "bts:GenomeBuild"
                 }
             ],
             "schema:isPartOf": {
@@ -3560,40 +3203,7 @@
             "rdfs:label": "GRCm39",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:G"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:N"
-                },
-                {
-                    "@id": "bts:O"
-                },
-                {
-                    "@id": "bts:M"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:B"
-                },
-                {
-                    "@id": "bts:U"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:L"
-                },
-                {
-                    "@id": "bts:D"
+                    "@id": "bts:GenomeBuild"
                 }
             ],
             "schema:isPartOf": {
@@ -3610,34 +3220,7 @@
             "rdfs:label": "Ab",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:H"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:K"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:L"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:T"
+                    "@id": "bts:CheckList"
                 }
             ],
             "schema:isPartOf": {
@@ -3654,34 +3237,7 @@
             "rdfs:label": "Cd",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:H"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:K"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:L"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:T"
+                    "@id": "bts:CheckList"
                 }
             ],
             "schema:isPartOf": {
@@ -3698,34 +3254,7 @@
             "rdfs:label": "Ef",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:H"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:K"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:L"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:T"
+                    "@id": "bts:CheckList"
                 }
             ],
             "schema:isPartOf": {
@@ -3742,34 +3271,7 @@
             "rdfs:label": "Gh",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:H"
-                },
-                {
-                    "@id": "bts:E"
-                },
-                {
-                    "@id": "bts:C"
-                },
-                {
-                    "@id": "bts:K"
-                },
-                {
-                    "@id": "bts:"
-                },
-                {
-                    "@id": "bts:L"
-                },
-                {
-                    "@id": "bts:I"
-                },
-                {
-                    "@id": "bts:S"
-                },
-                {
-                    "@id": "bts:T"
+                    "@id": "bts:CheckList"
                 }
             ],
             "schema:isPartOf": {

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2893,7 +2893,9 @@
             },
             "sms:displayName": "Check Date",
             "sms:required": "sms:true",
-            "sms:validationRules": ["date"]
+            "sms:validationRules": [
+                "date"
+            ]
         },
         {
             "@id": "bts:MockRDB",
@@ -2963,7 +2965,13 @@
             "rdfs:label": "Female",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:Sex"
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:X"
                 }
             ],
             "schema:isPartOf": {
@@ -2980,7 +2988,13 @@
             "rdfs:label": "Male",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:Sex"
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:X"
                 }
             ],
             "schema:isPartOf": {
@@ -2997,7 +3011,13 @@
             "rdfs:label": "Other",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:Sex"
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:X"
                 }
             ],
             "schema:isPartOf": {
@@ -3014,7 +3034,31 @@
             "rdfs:label": "Healthy",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:Diagnosis"
+                    "@id": "bts:D"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:A"
+                },
+                {
+                    "@id": "bts:G"
+                },
+                {
+                    "@id": "bts:N"
+                },
+                {
+                    "@id": "bts:O"
+                },
+                {
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:S"
                 }
             ],
             "schema:isPartOf": {
@@ -3031,7 +3075,37 @@
             "rdfs:label": "Breast",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:CancerType"
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:A"
+                },
+                {
+                    "@id": "bts:N"
+                },
+                {
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:R"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:T"
+                },
+                {
+                    "@id": "bts:Y"
+                },
+                {
+                    "@id": "bts:P"
+                },
+                {
+                    "@id": "bts:E"
                 }
             ],
             "schema:isPartOf": {
@@ -3048,7 +3122,37 @@
             "rdfs:label": "Colorectal",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:CancerType"
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:A"
+                },
+                {
+                    "@id": "bts:N"
+                },
+                {
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:R"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:T"
+                },
+                {
+                    "@id": "bts:Y"
+                },
+                {
+                    "@id": "bts:P"
+                },
+                {
+                    "@id": "bts:E"
                 }
             ],
             "schema:isPartOf": {
@@ -3065,7 +3169,37 @@
             "rdfs:label": "Lung",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:CancerType"
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:A"
+                },
+                {
+                    "@id": "bts:N"
+                },
+                {
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:R"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:T"
+                },
+                {
+                    "@id": "bts:Y"
+                },
+                {
+                    "@id": "bts:P"
+                },
+                {
+                    "@id": "bts:E"
                 }
             ],
             "schema:isPartOf": {
@@ -3082,7 +3216,37 @@
             "rdfs:label": "Prostate",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:CancerType"
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:A"
+                },
+                {
+                    "@id": "bts:N"
+                },
+                {
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:R"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:T"
+                },
+                {
+                    "@id": "bts:Y"
+                },
+                {
+                    "@id": "bts:P"
+                },
+                {
+                    "@id": "bts:E"
                 }
             ],
             "schema:isPartOf": {
@@ -3099,7 +3263,37 @@
             "rdfs:label": "Skin",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:CancerType"
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:A"
+                },
+                {
+                    "@id": "bts:N"
+                },
+                {
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:R"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:T"
+                },
+                {
+                    "@id": "bts:Y"
+                },
+                {
+                    "@id": "bts:P"
+                },
+                {
+                    "@id": "bts:E"
                 }
             ],
             "schema:isPartOf": {
@@ -3116,7 +3310,43 @@
             "rdfs:label": "Malignant",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:TissueStatus"
+                    "@id": "bts:T"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:U"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:T"
+                },
+                {
+                    "@id": "bts:A"
+                },
+                {
+                    "@id": "bts:T"
+                },
+                {
+                    "@id": "bts:U"
+                },
+                {
+                    "@id": "bts:S"
                 }
             ],
             "schema:isPartOf": {
@@ -3133,7 +3363,37 @@
             "rdfs:label": "FASTQ",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:FileFormat"
+                    "@id": "bts:F"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:L"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:F"
+                },
+                {
+                    "@id": "bts:O"
+                },
+                {
+                    "@id": "bts:R"
+                },
+                {
+                    "@id": "bts:M"
+                },
+                {
+                    "@id": "bts:A"
+                },
+                {
+                    "@id": "bts:T"
                 }
             ],
             "schema:isPartOf": {
@@ -3150,7 +3410,40 @@
             "rdfs:label": "GRCh37",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:GenomeBuild"
+                    "@id": "bts:G"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:N"
+                },
+                {
+                    "@id": "bts:O"
+                },
+                {
+                    "@id": "bts:M"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:B"
+                },
+                {
+                    "@id": "bts:U"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:L"
+                },
+                {
+                    "@id": "bts:D"
                 }
             ],
             "schema:isPartOf": {
@@ -3167,7 +3460,40 @@
             "rdfs:label": "GRCh38",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:GenomeBuild"
+                    "@id": "bts:G"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:N"
+                },
+                {
+                    "@id": "bts:O"
+                },
+                {
+                    "@id": "bts:M"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:B"
+                },
+                {
+                    "@id": "bts:U"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:L"
+                },
+                {
+                    "@id": "bts:D"
                 }
             ],
             "schema:isPartOf": {
@@ -3184,7 +3510,40 @@
             "rdfs:label": "GRCm38",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:GenomeBuild"
+                    "@id": "bts:G"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:N"
+                },
+                {
+                    "@id": "bts:O"
+                },
+                {
+                    "@id": "bts:M"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:B"
+                },
+                {
+                    "@id": "bts:U"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:L"
+                },
+                {
+                    "@id": "bts:D"
                 }
             ],
             "schema:isPartOf": {
@@ -3201,7 +3560,40 @@
             "rdfs:label": "GRCm39",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:GenomeBuild"
+                    "@id": "bts:G"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:N"
+                },
+                {
+                    "@id": "bts:O"
+                },
+                {
+                    "@id": "bts:M"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:B"
+                },
+                {
+                    "@id": "bts:U"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:L"
+                },
+                {
+                    "@id": "bts:D"
                 }
             ],
             "schema:isPartOf": {
@@ -3218,7 +3610,34 @@
             "rdfs:label": "Ab",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:CheckList"
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:H"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:K"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:L"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:T"
                 }
             ],
             "schema:isPartOf": {
@@ -3235,7 +3654,34 @@
             "rdfs:label": "Cd",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:CheckList"
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:H"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:K"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:L"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:T"
                 }
             ],
             "schema:isPartOf": {
@@ -3252,7 +3698,34 @@
             "rdfs:label": "Ef",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:CheckList"
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:H"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:K"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:L"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:T"
                 }
             ],
             "schema:isPartOf": {
@@ -3269,7 +3742,34 @@
             "rdfs:label": "Gh",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:CheckList"
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:H"
+                },
+                {
+                    "@id": "bts:E"
+                },
+                {
+                    "@id": "bts:C"
+                },
+                {
+                    "@id": "bts:K"
+                },
+                {
+                    "@id": "bts:"
+                },
+                {
+                    "@id": "bts:L"
+                },
+                {
+                    "@id": "bts:I"
+                },
+                {
+                    "@id": "bts:S"
+                },
+                {
+                    "@id": "bts:T"
                 }
             ],
             "schema:isPartOf": {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -94,7 +94,7 @@ class TestDfParser:
         actual = df_parser.get_property(
             se=se_obj,
             property_display_name="Test",
-            property_class_name="Prop_Class",
+            property_class_names=["Prop_Class"],
             description="This is a dummy test property",
             requires_range=["Test_Start", "Test_End"],
             requires_dependencies=["Test_Dep_1", "Test_Dep_2"],
@@ -111,7 +111,7 @@ class TestDfParser:
             "schema:rangeIncludes": [{"@id": "bts:TestStart"}, {"@id": "bts:TestEnd"}],
             "sms:displayName": "Test",
             "sms:required": "sms:true",
-            "schema:domainIncludes": {"@id": "bts:PropClass"},
+            "schema:domainIncludes": [{"@id": "bts:PropClass"}],
             "sms:requiresDependency": [
                 {"@id": "bts:Test_Dep_1"},
                 {"@id": "bts:Test_Dep_2"},


### PR DESCRIPTION
Previously the way the JSONLD was constructed, if properties were in the domain of a Class only one property would be saved. This ignored other properties in the domain of that class, but also meant when doing the reverse lookup (all the classes that a property belongs to) would be incorrect. 

This addresses the specific case where the outputs of the API call `find_class_specific_properties` was outputting incorrect results when properties were in the domain of multiple classes.

This PR makes changes to the `df_parser.py` and `explorer.py` to correct this issue.

To work, user will need to recreate their JSON LD using:
```
 schematic schema convert path/to/test_model.model.csv 
```
then upload to GitHub and call API function.