### PR TITLE
Increase buffer size to a higher limit to deal with long token

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -19,3 +19,4 @@ harakiri-verbose = true
 http-timeout = 300 # for testing
 uwsgi_read_timeout = 300 # for testing
 uwsgi_send_timeout = 300 # for testing
+buffer-size = 32768 # for dealing with long token in DCA and DFA


### PR DESCRIPTION
DCA and DFA need to pass long token from oauth to `input_token` parameter. The long token could be passed to flask development server, but @afwillia and Loren got the following error is swagger UI: 
Undocumented  TypeError: NetworkError when attempting to fetch resource, and the error here in console: invalid request block size: 5161 (max 4096)...skip

When we checked AWS log, we can't find the corresponding request which suggested that the request didn't go through. The solution seems to be increasing buffer size like this post here: https://stackoverflow.com/questions/15878176/uwsgi-invalid-request-block-size suggested