### PR TITLE
use try: finally: to delete checkpoint even if running the checkpoint fails or errors out

### DIFF
--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -137,19 +137,20 @@ class ValidateManifest(object):
             ge_helpers.build_expectation_suite()
             ge_helpers.build_checkpoint()
 
-        #run GE validation
-            results = ge_helpers.context.run_checkpoint(
-                checkpoint_name=ge_helpers.checkpoint_name,
-                batch_request={
-                    "runtime_parameters": {"batch_data": manifest},
-                    "batch_identifiers": {
-                        "default_identifier_name": "manifestID"
+            try:
+                #run GE validation
+                results = ge_helpers.context.run_checkpoint(
+                    checkpoint_name=ge_helpers.checkpoint_name,
+                    batch_request={
+                        "runtime_parameters": {"batch_data": manifest},
+                        "batch_identifiers": {
+                            "default_identifier_name": "manifestID"
+                        },
                     },
-                },
-                result_format={'result_format': 'COMPLETE'},
-            )       
-
-            ge_helpers.context.delete_checkpoint(ge_helpers.checkpoint_name) 
+                    result_format={'result_format': 'COMPLETE'},
+                )       
+            finally:
+                ge_helpers.context.delete_checkpoint(ge_helpers.checkpoint_name) 
         
             validation_results = results.list_validation_results()
             


### PR DESCRIPTION
Resolves issue raised on [slack](https://sagebionetworks.slack.com/archives/C01ANC02U59/p1677088899378719)
use `try: finally:` to delete checkpoint even if running the checkpoint fails or errors out