### PR TITLE
Develop use display names as schema labels.

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -782,6 +782,13 @@ paths:
           description: Display label of a node
           example: FamilyHistory
           required: true
+        - in: query
+          name: display_name_as_schema_label
+          schema:
+            type: boolean
+            nullable: true
+          description: Use the display name as schema label
+          required: false
       responses:
         "200":
           description: return a boolean 
@@ -793,7 +800,7 @@ paths:
   /schemas/get_nodes_display_names:
     get:
       summary: Get display names for nodes labels in a list.
-      description: et display names for nodes labels in a list.
+      description: Get display names for nodes labels in a list.
       operationId: api.routes.get_nodes_display_names
       parameters:
         - in: query
@@ -845,6 +852,13 @@ paths:
           description: Display label of node
           example: CheckRegexList
           required: true
+        - in: query
+          name: display_name_as_schema_label
+          schema:
+            type: boolean
+            nullable: true
+          description: Use the display name as schema label
+          required: false
       responses:
         "200":
           description: return a list
@@ -928,6 +942,14 @@ paths:
             nullable: false
           description: If true the more strict way of
             converting to camel case is used.
+        - in: query
+          name: display_name_as_schema_label
+          schema:
+            type: boolean
+            nullable: true
+          description: Use the display name as schema label
+          required: false
+          example: false
       responses:
         "200":
           description: The property label of the display name.

--- a/api/routes.py
+++ b/api/routes.py
@@ -660,7 +660,8 @@ def get_node_dependencies(
 def get_property_label_from_display_name(
     schema_url: str,
     display_name: str,
-    strict_camel_case: bool = False
+    strict_camel_case: bool = False,
+    display_name_as_schema_label: bool = False,
 ) -> str:
     """Converts a given display name string into a proper property label string
 
@@ -675,7 +676,7 @@ def get_property_label_from_display_name(
     """
     explorer = SchemaExplorer()
     explorer.load_schema(schema_url)
-    label = explorer.get_property_label_from_display_name(display_name, strict_camel_case)
+    label = explorer.get_property_label_from_display_name(display_name, strict_camel_case, display_name_as_schema_label)
     return label
 
 
@@ -699,7 +700,7 @@ def get_node_range(
     node_range = gen.get_node_range(node_label, return_display_names)
     return node_range
 
-def get_if_node_required(schema_url: str, node_display_name: str) -> bool:
+def get_if_node_required(schema_url: str, node_display_name: str, display_name_as_schema_label: bool = False) -> bool:
     """Check if the node is required
 
     Args:
@@ -711,11 +712,11 @@ def get_if_node_required(schema_url: str, node_display_name: str) -> bool:
         False: If the given node is not a "required" (i.e., an "optional") node.
     """
     gen = SchemaGenerator(path_to_json_ld=schema_url)
-    is_required = gen.is_node_required(node_display_name)
+    is_required = gen.is_node_required(node_display_name, display_name_as_schema_label)
 
     return is_required
 
-def get_node_validation_rules(schema_url: str, node_display_name: str) -> list:
+def get_node_validation_rules(schema_url: str, node_display_name: str, display_name_as_schema_label: bool = False) -> list:
     """
     Args:
         schema_url (str): Data Model URL
@@ -724,7 +725,7 @@ def get_node_validation_rules(schema_url: str, node_display_name: str) -> list:
         List of valiation rules for a given node.
     """
     gen = SchemaGenerator(path_to_json_ld=schema_url)
-    node_validation_rules = gen.get_node_validation_rules(node_display_name)
+    node_validation_rules = gen.get_node_validation_rules(node_display_name, display_name_as_schema_label)
 
     return node_validation_rules
 

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -166,6 +166,9 @@ schema_commands = {
             "output_jsonld": (
                 "Path to where the generated JSON-LD file needs to be outputted."
             ),
+             "display_name_as_schema_label": (
+                "Flag that indicates the user wants to use their display names as the schema label."
+            ),
         }
     }
 }

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -47,13 +47,19 @@ def schema():  # use as `schematic model ...`
     metavar="<OUTPUT_PATH>",
     help=query_dict(schema_commands, ("schema", "convert", "output_jsonld")),
 )
-def convert(schema_csv, base_schema, output_jsonld):
+@click.option(
+    "--display_name_as_schema_label",
+    "-dn",
+    is_flag=True,
+    help=query_dict(schema_commands, ("schema", "convert", "output_jsonld")),
+    )
+def convert(schema_csv, base_schema, display_name_as_schema_label, output_jsonld):
     """
     Running CLI to convert data model specification in CSV format to
     data model in JSON-LD format.
     """
     # convert RFC to Data Model
-    base_se = _convert_csv_to_data_model(schema_csv, base_schema)
+    base_se = _convert_csv_to_data_model(schema_csv, base_schema, display_name_as_schema_label)
 
     # output JSON-LD file alongside CSV file by default
     if output_jsonld is None:

--- a/schematic/schemas/df_parser.py
+++ b/schematic/schemas/df_parser.py
@@ -330,7 +330,7 @@ def _prop_2_classes(properties: dict) -> dict:
     return prop_2_classes
 
 def create_nx_schema_objects(
-    schema_extension: pd.DataFrame, se: SchemaExplorer, display_name_as_schema_label: bool,
+    schema_extension: pd.DataFrame, se: SchemaExplorer, display_name_as_schema_label: bool = False,
 ) -> SchemaExplorer:
     """Creates classes for all attributes and adds them to the schema.
     Args:

--- a/schematic/schemas/df_parser.py
+++ b/schematic/schemas/df_parser.py
@@ -560,10 +560,8 @@ def create_nx_schema_objects(
                         validation_rules=class_info["validation_rules"],
                         display_name_as_schema_label=display_name_as_schema_label,
                     )
-                    try:
-                        se.edit_schema_object_nx(class_range_edit)
-                    except:
-                        breakpoint()
+                    se.edit_schema_object_nx(class_range_edit)
+
                 else:
                     # the attribute is a property
                     if display_name_as_schema_label:
@@ -588,10 +586,7 @@ def create_nx_schema_objects(
                         validation_rules=property_info["validation_rules"],
                         display_name_as_schema_label=display_name_as_schema_label,
                     )
-                    try:
-                        se.edit_schema_object_nx(property_range_edit)
-                    except:
-                        breakpoint()
+                    se.edit_schema_object_nx(property_range_edit)
 
                 logger.debug(val + " added to value range")
 
@@ -746,10 +741,8 @@ def create_nx_schema_objects(
                         validation_rules=class_info["validation_rules"],
                         display_name_as_schema_label=display_name_as_schema_label,
                     )
-                    try:
-                        se.edit_schema_object_nx(class_dependencies_edit)
-                    except:
-                        breakpoint()
+                    se.edit_schema_object_nx(class_dependencies_edit)
+
                 else:
                     # the attribute is a property then update as a property
                     if display_name_as_schema_label:
@@ -819,10 +812,8 @@ def create_nx_schema_objects(
                 requires_components=class_info["component_dependencies"],
                 display_name_as_schema_label=display_name_as_schema_label,
             )
-            try:
-                se.edit_schema_object_nx(class_component_dependencies_edit)
-            except:
-                breakpoint()
+            se.edit_schema_object_nx(class_component_dependencies_edit)
+
         logger.debug(comp_dep + " added to dependencies")
 
         # TODO check for cycles in component dependencies schema subgraph

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -436,37 +436,43 @@ class SchemaExplorer:
 
         return rules
 
-    def get_property_label_from_display_name(self, display_name, strict_camel_case = False):
+    def get_property_label_from_display_name(self, display_name, strict_camel_case = False, display_name_as_schema_label = False):
         """Convert a given display name string into a proper property label string"""
         """
         label = ''.join(x.capitalize() or ' ' for x in display_name.split(' '))
         label = label[:1].lower() + label[1:] if label else ''
         """
-        # This is the newer more strict method
-        if strict_camel_case:
-            display_name = display_name.strip().translate({ord(c): "_" for c in string.whitespace})
-            label = inflection.camelize(display_name, uppercase_first_letter=False)
-
-        # This method remains for backwards compatibility
+        if display_name_as_schema_label:
+            label = display_name.strip()
         else:
-            display_name = display_name.translate({ord(c): None for c in string.whitespace})
-            label = inflection.camelize(display_name.strip(), uppercase_first_letter=False)
+            # This is the newer more strict method
+            if strict_camel_case:
+                display_name = display_name.strip().translate({ord(c): "_" for c in string.whitespace})
+                label = inflection.camelize(display_name, uppercase_first_letter=False)
+
+            # This method remains for backwards compatibility
+            else:
+                display_name = display_name.translate({ord(c): None for c in string.whitespace})
+                label = inflection.camelize(display_name.strip(), uppercase_first_letter=False, )
 
         return label
 
-    def get_class_label_from_display_name(self, display_name, strict_camel_case = False):
+    def get_class_label_from_display_name(self, display_name, strict_camel_case = False, display_name_as_schema_label = False):
         """Convert a given display name string into a proper class label string"""
         """
         label = ''.join(x.capitalize() or ' ' for x in display_name.split(' '))"""
-        # This is the newer more strict method
-        if strict_camel_case:
-            display_name = display_name.strip().translate({ord(c): "_" for c in string.whitespace})
-            label = inflection.camelize(display_name, uppercase_first_letter=True)
-
-        # This method remains for backwards compatibility
+        if display_name_as_schema_label:
+            label = display_name.strip()
         else:
-            display_name = display_name.translate({ord(c): None for c in string.whitespace})
-            label = inflection.camelize(display_name.strip(), uppercase_first_letter=True)
+            # This is the newer more strict method
+            if strict_camel_case:
+                display_name = display_name.strip().translate({ord(c): "_" for c in string.whitespace})
+                label = inflection.camelize(display_name, uppercase_first_letter=True)
+
+            # This method remains for backwards compatibility
+            else:
+                display_name = display_name.translate({ord(c): None for c in string.whitespace})
+                label = inflection.camelize(display_name.strip(), uppercase_first_letter=True)
 
         return label
 

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -470,10 +470,14 @@ class SchemaExplorer:
 
         return label
 
-    def get_class_by_property(self, property_display_name):
-        schema_property = self.get_property_label_from_display_name(
-            property_display_name
-        )
+    def get_class_by_property(self, property_display_name, display_name_as_schema_label=False):
+        
+        if display_name_as_schema_label:
+            schema_property = property_display_name
+        else:
+            schema_property = self.get_property_label_from_display_name(
+                property_display_name
+            )
 
         for record in self.schema["@graph"]:
             if record["@type"] == "rdf:Property":

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -488,12 +488,6 @@ class SchemaExplorer:
                             self.uri2label(record["@id"]) 
                                 for record in p_domain
                             ]
-                    #return unlist(
-                    #    [
-                    #        self.uri2label(schema_class["@id"])
-                    #        for schema_class in p_domain
-                    #    ]
-                    #)
 
         return None
 

--- a/schematic/schemas/generator.py
+++ b/schematic/schemas/generator.py
@@ -256,7 +256,7 @@ class SchemaGenerator(object):
 
         return required_range
 
-    def get_node_label(self, node_display_name: str) -> str:
+    def get_node_label(self, node_display_name: str, display_name_as_schema_label: bool = False) -> str:
         """Get the node label for a given display name.
 
         Args:
@@ -270,21 +270,27 @@ class SchemaGenerator(object):
         """
         mm_graph = self.se.get_nx_schema()
 
-        node_class_label = self.se.get_class_label_from_display_name(node_display_name)
-        node_property_label = self.se.get_property_label_from_display_name(
-            node_display_name
-        )
-
-        if node_class_label in mm_graph.nodes:
-            node_label = node_class_label
-        elif node_property_label in mm_graph.nodes:
-            node_label = node_property_label
+        if display_name_as_schema_label:
+            if node_display_name in mm_graph.nodes():
+                node_label = node_display_name
+            else:
+                node_label = ""
         else:
-            node_label = ""
+            node_class_label = self.se.get_class_label_from_display_name(node_display_name)
+            node_property_label = self.se.get_property_label_from_display_name(
+                node_display_name
+            )
+
+            if node_class_label in mm_graph.nodes:
+                node_label = node_class_label
+            elif node_property_label in mm_graph.nodes:
+                node_label = node_property_label
+            else:
+                node_label = ""
 
         return node_label
 
-    def get_node_definition(self, node_display_name: str) -> str:
+    def get_node_definition(self, node_display_name: str, display_name_as_schema_label: bool = False) -> str:
         """Get the node definition, i.e., the "comment" associated with a given node display name.
 
         Args:
@@ -293,7 +299,7 @@ class SchemaGenerator(object):
         Returns:
             Comment associated with node, as a string.
         """
-        node_label = self.get_node_label(node_display_name)
+        node_label = self.get_node_label(node_display_name, display_name_as_schema_label)
 
         if not node_label:
             return ""
@@ -303,7 +309,7 @@ class SchemaGenerator(object):
 
         return node_definition
 
-    def get_node_validation_rules(self, node_display_name: str) -> str:
+    def get_node_validation_rules(self, node_display_name: str, display_name_as_schema_label: bool = False) -> str:
         """Get validation rules associated with a node,
 
         Args:
@@ -312,7 +318,7 @@ class SchemaGenerator(object):
         Returns:
             A set of validation rules associated with node, as a list.
         """
-        node_label = self.get_node_label(node_display_name)
+        node_label = self.get_node_label(node_display_name, display_name_as_schema_label)
 
         if not node_label:
             return []
@@ -322,7 +328,7 @@ class SchemaGenerator(object):
 
         return node_validation_rules
 
-    def is_node_required(self, node_display_name: str) -> bool:
+    def is_node_required(self, node_display_name: str, display_name_as_schema_label=False) -> bool:
         """Check if a given node is required or not.
 
         Note: The possible options that a node can be associated with -- "required" / "optional".
@@ -334,7 +340,7 @@ class SchemaGenerator(object):
             True: If the given node is a "required" node.
             False: If the given node is not a "required" (i.e., an "optional") node.
         """
-        node_label = self.get_node_label(node_display_name)
+        node_label = self.get_node_label(node_display_name, display_name_as_schema_label)
 
         mm_graph = self.se.get_nx_schema()
         node_required = mm_graph.nodes[node_label]["required"]


### PR DESCRIPTION
This PR addresses the use case outlined in issue #1112.

Add a command line flag `--display_name_as_schema_label` to be used in the convert step, so that the user specified `display_names` are used as the schema label in the model.

To use this functionality can run the following from the command line:
`schematic schema convert path/to/your.model.csv --display_name_as_schema_label`

Changes will be reflected in the JSON-LD.

I have tested, the convert for the iAtlas, HTAN and example models and it works for all of them with no noticeable error.

I further tested, manifest generation, validation and submission using the iAtlas model and all results were as anticipated (except one error raised for a non-required value which should not be impacted by my changes and which I will further explore).