### PR TITLE
Added a parameter to control if GE gets used when using `manifest/validate` endpoint 

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -186,6 +186,13 @@ paths:
           example: Patient
           required: true
         - in: query
+          name: restrict_rules
+          schema:
+            type: boolean
+            default: false
+          description: If True, validation suite will only run with in-house validation rule. If False, the Great Expectations suite will be utilized and all rules will be available.
+          required: false
+        - in: query
           name: json_str
           required: false
           schema:

--- a/api/routes.py
+++ b/api/routes.py
@@ -330,9 +330,13 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
     return all_results
 
 
-def validate_manifest_route(schema_url, data_type, json_str=None):
+def validate_manifest_route(schema_url, data_type, restrict_rules=None, json_str=None):
     # call config_handler()
     config_handler()
+
+    #If restrict_rules parameter is set to None, then default it to False 
+    if not restrict_rules:
+        restrict_rules = False
 
     #Get path to temp file where manifest file contents will be saved
     jsc = JsonConverter()
@@ -350,7 +354,7 @@ def validate_manifest_route(schema_url, data_type, json_str=None):
     )
 
     errors, warnings = metadata_model.validateModelManifest(
-        manifestPath=temp_path, rootNode=data_type
+        manifestPath=temp_path, rootNode=data_type, restrict_rules=restrict_rules
     )
     
     res_dict = {"errors": errors, "warnings": warnings}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -455,12 +455,14 @@ class TestManifestOperation:
         # should return a list with one google sheet link 
         assert isinstance(response_dt[0], str)
         assert response_dt[0].startswith("https://docs.google.com/")
-    
+
+    @pytest.mark.parametrize("restrict_rules", [False, True, None])
     @pytest.mark.parametrize("json_str", [None, '[{"Patient ID": 123, "Sex": "Female", "Year of Birth": "", "Diagnosis": "Healthy", "Component": "Patient", "Cancer Type": "Breast", "Family History": "Breast, Lung"}]'])
-    def test_validate_manifest(self, data_model_jsonld, client, json_str, test_manifest_csv, test_manifest_json):
+    def test_validate_manifest(self, data_model_jsonld, client, json_str, restrict_rules, test_manifest_csv):
 
         params = {
             "schema_url": data_model_jsonld,
+            "restrict_rules": restrict_rules
         }
 
         if json_str:


### PR DESCRIPTION
Added a parameter `restrict_rules` to control if GE should be used when using `manifest/validate` endpoint. This is needed for testing API on AWS and also bypassing reticulate error for Anthony