### PR TITLE
Added restrict rules param to `manifest/validate`

### DIFF
--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -186,6 +186,12 @@ paths:
           example: Patient
           required: true
         - in: query
+          name: restrict_rules
+          schema:
+            type: boolean
+            default: false
+          description: If True, validation suite will only run with in-house validation rule. If False, the Great Expectations suite will be utilized and all rules will be available.
+        - in: query
           name: json_str
           required: false
           schema:

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -394,7 +394,11 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
 
 #####profile validate manifest route function 
 #@profile(sort_by='cumulative', strip_dirs=True)
-def validate_manifest_route(schema_url, data_type, json_str=None):
+def validate_manifest_route(schema_url, data_type, restrict_rules=None, json_str=None):
+    # if restrict rules is set to None, default it to False
+    if not restrict_rules:
+        restrict_rules=False
+        
     # call config_handler()
     config_handler()
 


### PR DESCRIPTION
added restrict rules param to `manifest/validate` endpoint. This will make it easier to control if GE rules gets applied. 