### PR TITLE
Propagate logger level entered in from command line to other schematic modules

### DIFF
--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -15,7 +15,7 @@ from schematic.schemas.generator import SchemaGenerator
 from schematic.utils.google_api_utils import export_manifest_csv, export_manifest_excel, export_manifest_drive_service
 from schematic.store.synapse import SynapseStorage
 
-logger = logging.getLogger()
+logger = logging.getLogger('schematic')
 click_log.basic_config(logger)
 
 CONTEXT_SETTINGS = dict(help_option_names=["--help", "-h"])  # help options

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -15,7 +15,7 @@ from schematic.schemas.generator import SchemaGenerator
 from schematic.utils.google_api_utils import export_manifest_csv, export_manifest_excel, export_manifest_drive_service
 from schematic.store.synapse import SynapseStorage
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 click_log.basic_config(logger)
 
 CONTEXT_SETTINGS = dict(help_option_names=["--help", "-h"])  # help options

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -15,7 +15,7 @@ from schematic.help import model_commands
 from schematic.exceptions import MissingConfigValueError
 from schematic import CONFIG
 
-logger = logging.getLogger()
+logger = logging.getLogger('schematic')
 click_log.basic_config(logger)
 
 CONTEXT_SETTINGS = dict(help_option_names=["--help", "-h"])  # help options

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -15,7 +15,7 @@ from schematic.help import model_commands
 from schematic.exceptions import MissingConfigValueError
 from schematic import CONFIG
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 click_log.basic_config(logger)
 
 CONTEXT_SETTINGS = dict(help_option_names=["--help", "-h"])  # help options

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -48,7 +48,7 @@ class GenerateError:
 
         #if a message needs to be raised, get the approrpiate function to do so
         if raises:
-            logLevel = getattr(logging,raises)  
+            logLevel = getattr(logger,raises)  
         else:
             return error_list, warning_list
 
@@ -82,7 +82,7 @@ class GenerateError:
                 - row_num: the row the error occurred on.
                 - attribute_name: the attribute the error occurred on.
             Returns:
-                Logging.error.
+                logger.error.
                 Errors: List[str] Error details for further storage.
             """
 
@@ -98,7 +98,7 @@ class GenerateError:
 
         #if a message needs to be raised, get the approrpiate function to do so
         if raises:
-            logLevel = getattr(logging,raises)  
+            logLevel = getattr(logger,raises)  
         else:
             return error_list, warning_list
 
@@ -143,7 +143,7 @@ class GenerateError:
                 module_to_call: re module specified in the schema
                 attribute_name: str, attribute being validated
             Returns:
-                Logging.error.
+                logger.error.
                 Errors: List[str] Error details for further storage.
             """
         error_list = []
@@ -158,7 +158,7 @@ class GenerateError:
 
         #if a message needs to be raised, get the approrpiate function to do so
         if raises:
-            logLevel = getattr(logging,raises)  
+            logLevel = getattr(logger,raises)  
         else:
             return error_list, warning_list
 
@@ -193,7 +193,7 @@ class GenerateError:
                 row_num: str, row where the error was detected
                 attribute_name: str, attribute being validated
             Returns:
-                Logging.error.
+                logger.error.
                 Errors: List[str] Error details for further storage.
             """
 
@@ -209,7 +209,7 @@ class GenerateError:
 
         #if a message needs to be raised, get the approrpiate function to do so
         if raises:
-            logLevel = getattr(logging,raises)  
+            logLevel = getattr(logger,raises)  
         else:
             return error_list, warning_list
 
@@ -257,7 +257,7 @@ class GenerateError:
                 attribute_name: str, attribute being validated
                 argument: str, argument being validated.
             Returns:
-                Logging.error.
+                logger.error.
                 Errors: List[str] Error details for further storage.
             """
 
@@ -273,7 +273,7 @@ class GenerateError:
 
         #if a message needs to be raised, get the approrpiate function to do so
         if raises:
-            logLevel = getattr(logging,raises)  
+            logLevel = getattr(logger,raises)  
         else:
             return error_list, warning_list
 
@@ -337,7 +337,7 @@ class GenerateError:
                 invalid_entry: str, value present in source manifest that is missing in the target
                 row_num: row in source manifest with value missing in target manifests             
             Returns:
-                Logging.error.
+                logger.error.
                 Errors: List[str] Error details for further storage.
             """
         error_list = []
@@ -352,7 +352,7 @@ class GenerateError:
 
         #if a message needs to be raised, get the approrpiate function to do so
         if raises:
-            logLevel = getattr(logging,raises)  
+            logLevel = getattr(logger,raises)  
         else:
             return error_list, warning_list
 
@@ -415,7 +415,7 @@ class GenerateError:
                 error_val: value duplicated
 
         Returns:
-            Logging.error or Logging.warning.
+            logger.error or logger.warning.
             Message: List[str] Error|Warning details for further storage.
         """
         error_list = []
@@ -431,7 +431,7 @@ class GenerateError:
 
         #if a message needs to be raised, get the approrpiate function to do so
         if raises:
-            logLevel = getattr(logging,raises)  
+            logLevel = getattr(logger,raises)  
         else:
             return error_list, warning_list
         
@@ -644,7 +644,7 @@ class ValidateAttribute(object):
         Returns:
             - This function will return errors when the user input value
             does not match schema specifications.
-            Logging.error.
+            logger.error.
             Errors: List[str] Error details for further storage.
         TODO: 
             move validation to convert step.
@@ -728,7 +728,7 @@ class ValidateAttribute(object):
         Returns:
             -This function will return errors when the user input value
             does not match schema specifications.
-            Logging.error.
+            logger.error.
             Errors: List[str] Error details for further storage.
         TODO:
             Convert all inputs to .lower() just to prevent any entry errors.

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -82,8 +82,9 @@ class GenerateError:
                 - row_num: the row the error occurred on.
                 - attribute_name: the attribute the error occurred on.
             Returns:
-                logger.error.
-                Errors: List[str] Error details for further storage.
+            logger.error or logger.warning.
+            Errors: List[str] Error details for further storage.
+            warnings: List[str] Warning details for further storage.
             """
 
         error_list = []
@@ -143,8 +144,9 @@ class GenerateError:
                 module_to_call: re module specified in the schema
                 attribute_name: str, attribute being validated
             Returns:
-                logger.error.
-                Errors: List[str] Error details for further storage.
+            logger.error or logger.warning.
+            Errors: List[str] Error details for further storage.
+            warnings: List[str] Warning details for further storage.
             """
         error_list = []
         warning_list = []
@@ -193,8 +195,9 @@ class GenerateError:
                 row_num: str, row where the error was detected
                 attribute_name: str, attribute being validated
             Returns:
-                logger.error.
-                Errors: List[str] Error details for further storage.
+            logger.error or logger.warning.
+            Errors: List[str] Error details for further storage.
+            warnings: List[str] Warning details for further storage.
             """
 
         error_list = []
@@ -257,8 +260,9 @@ class GenerateError:
                 attribute_name: str, attribute being validated
                 argument: str, argument being validated.
             Returns:
-                logger.error.
-                Errors: List[str] Error details for further storage.
+            logger.error or logger.warning.
+            Errors: List[str] Error details for further storage.
+            warnings: List[str] Warning details for further storage.
             """
 
         error_list = []
@@ -337,8 +341,9 @@ class GenerateError:
                 invalid_entry: str, value present in source manifest that is missing in the target
                 row_num: row in source manifest with value missing in target manifests             
             Returns:
-                logger.error.
-                Errors: List[str] Error details for further storage.
+            logger.error or logger.warning.
+            Errors: List[str] Error details for further storage.
+            warnings: List[str] Warning details for further storage.
             """
         error_list = []
         warning_list = []
@@ -416,7 +421,8 @@ class GenerateError:
 
         Returns:
             logger.error or logger.warning.
-            Message: List[str] Error|Warning details for further storage.
+            Errors: List[str] Error details for further storage.
+            warnings: List[str] Warning details for further storage.
         """
         error_list = []
         warning_list = []
@@ -580,7 +586,9 @@ class ValidateAttribute(object):
             - manifest_col: pd.core.series.Series, column for a given attribute
         Returns:
             - manifest_col: Input values in manifest arere-formatted to a list
-            - Error log, error list
+            logger.error or logger.warning.
+            Errors: List[str] Error details for further storage.
+            warnings: List[str] Warning details for further storage.
         """
 
         # For each 'list' (input as a string with a , delimiter) entered,
@@ -644,8 +652,9 @@ class ValidateAttribute(object):
         Returns:
             - This function will return errors when the user input value
             does not match schema specifications.
-            logger.error.
+            logger.error or logger.warning.
             Errors: List[str] Error details for further storage.
+            warnings: List[str] Warning details for further storage.
         TODO: 
             move validation to convert step.
         """
@@ -728,8 +737,9 @@ class ValidateAttribute(object):
         Returns:
             -This function will return errors when the user input value
             does not match schema specifications.
-            logger.error.
+            logger.error or logger.warning.
             Errors: List[str] Error details for further storage.
+            warnings: List[str] Warning details for further storage.
         TODO:
             Convert all inputs to .lower() just to prevent any entry errors.
         """

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -47,7 +47,7 @@ class ValidateManifest(object):
                 f"For attribute {attribute_name}, the provided validation rules ({validation_rules}) ."
                 f"have too many entries. We currently only specify two rules ('list :: another_rule')."
             )
-            logging.error(error_str)
+            logger.error(error_str)
             error_message = error_str
             error_val = f"Multiple Rules: too many rules"
         if error_type == "list_not_first":
@@ -55,7 +55,7 @@ class ValidateManifest(object):
                 f"For attribute {attribute_name}, the provided validation rules ({validation_rules}) are improperly "
                 f"specified. 'list' must be first."
             )
-            logging.error(error_str)
+            logger.error(error_str)
             error_message = error_str
             error_val = f"Multiple Rules: list not first"
         return ["NA", error_col, error_message, error_val]
@@ -164,7 +164,7 @@ class ValidateManifest(object):
                 sg = sg,
                 )               
         else:             
-            logging.info("Great Expetations suite will not be utilized.")  
+            logger.info("Great Expetations suite will not be utilized.")  
 
 
         regex_re=re.compile('regex.*')
@@ -188,7 +188,7 @@ class ValidateManifest(object):
                 validation_type = rule.split(" ")[0]
                 if rule_in_rule_list(rule,unimplemented_expectations) or (rule_in_rule_list(rule,in_house_rules) and restrict_rules):
                     if not rule_in_rule_list(rule,in_house_rules):
-                        logging.warning(f"Validation rule {rule.split(' ')[0]} has not been implemented in house and cannnot be validated without Great Expectations.")
+                        logger.warning(f"Validation rule {rule.split(' ')[0]} has not been implemented in house and cannnot be validated without Great Expectations.")
                         continue  
 
                     #Validate for each individual validation rule.

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -10,7 +10,7 @@ from schematic.schemas.df_parser import _convert_csv_to_data_model
 from schematic.utils.cli_utils import query_dict
 from schematic.help import schema_commands
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 click_log.basic_config(logger)
 
 CONTEXT_SETTINGS = dict(help_option_names=["--help", "-h"])  # help options

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -10,7 +10,7 @@ from schematic.schemas.df_parser import _convert_csv_to_data_model
 from schematic.utils.cli_utils import query_dict
 from schematic.help import schema_commands
 
-logger = logging.getLogger()
+logger = logging.getLogger('schematic')
 click_log.basic_config(logger)
 
 CONTEXT_SETTINGS = dict(help_option_names=["--help", "-h"])  # help options


### PR DESCRIPTION
Currently, passing in a parameter for `--verbosity` from the command line will only set the verbosity for the origin `schematic.xx.commands` module. For instance, if `--verbosity DEBUG` was set when running the `validate` command and `logging.debug` statements were added, only the statements in `models.commands.py` would show, and not in `metadata.py` or `df_utils.py` that are called subsequently.
Changes made in this PR takes the value passed in and uses it to set the verbosity of the logger for the `schematic` module, so that all submodules called inherit the appropriate level. The `schematic` module logger was set instead of the module under `schematic` so that if `utils` or modules outside the original `commands` module were called, loggers would still inherit the correct level.

If necessary, these changes can also be added to the testing modules files at a later time to allow for debugging/info messages as well