### PR TITLE
Standardize validation error format and type

### DIFF
--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -464,7 +464,7 @@ class GreatExpectationsHelpers(object):
                                                             val_rule = rule, 
                                                             attribute_name = errColumn,
                                                             row_num = np_array_to_str_list(np.array(indices)+2),
-                                                            error_val = iterable_to_str_list(set(values)),  
+                                                            error_val = iterable_to_str_list(values),  
                                                             sg = self.sg
                                                         )       
                     if vr_errors:

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -26,7 +26,7 @@ from great_expectations.exceptions.exceptions import GreatExpectationsError
 
 from schematic.models.validate_attribute import GenerateError
 from schematic.schemas.generator import SchemaGenerator
-from schematic.utils.validate_utils import rule_in_rule_list
+from schematic.utils.validate_utils import rule_in_rule_list, np_array_to_str_list
 
 logger = logging.getLogger(__name__)
 
@@ -463,7 +463,7 @@ class GreatExpectationsHelpers(object):
                     vr_errors, vr_warnings = GenerateError.generate_content_error(
                                                             val_rule = rule, 
                                                             attribute_name = errColumn,
-                                                            row_num = list(np.array(indices)+2),
+                                                            row_num = np_array_to_str_list(np.array(indices)+2),
                                                             error_val = values,  
                                                             sg = self.sg
                                                         )       
@@ -515,10 +515,13 @@ class GreatExpectationsHelpers(object):
                     name of column containing ages
             Returns:
                 updates self.manifest with censored ages
-            
+            TODO: Speed up conversion from str list to int list
         """
+        censor_rows = []
         
-        censor_rows = list(np.array(message[0]) - 2) 
+        for row in message[0]:
+            censor_rows.append(int(row) - 2)
+
         self.manifest.loc[censor_rows,(col)] = 'age censored'
 
         # update the manifest file, so that ages are censored

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -471,12 +471,12 @@ class GreatExpectationsHelpers(object):
                         errors.append(vr_errors)  
                         if rule.startswith('protectAges'):
                             self.censor_ages(vr_errors,errColumn)
-                            pass
+                            
                     if vr_warnings:
                         warnings.append(vr_warnings)  
                         if rule.startswith('protectAges'):
                             self.censor_ages(vr_warnings,errColumn)
-                            pass
+                            
 
         return errors, warnings
 

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -464,7 +464,7 @@ class GreatExpectationsHelpers(object):
                                                             val_rule = rule, 
                                                             attribute_name = errColumn,
                                                             row_num = np_array_to_str_list(np.array(indices)+2),
-                                                            error_val = iterable_to_str_list(values),  
+                                                            error_val = iterable_to_str_list(set(values)),  
                                                             sg = self.sg
                                                         )       
                     if vr_errors:

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -434,9 +434,9 @@ class GreatExpectationsHelpers(object):
                     for row, value in zip(indices,values):
                         vr_errors, vr_warnings = GenerateError.generate_type_error(
                                 val_rule = rule,
-                                row_num = row+2,
+                                row_num = str(row+2),
                                 attribute_name = errColumn,
-                                invalid_entry = value,
+                                invalid_entry = str(value),
                                 sg = sg,
                             )
                         if vr_errors:

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -449,7 +449,7 @@ class GreatExpectationsHelpers(object):
                         vr_errors, vr_warnings = GenerateError.generate_regex_error(
                                 val_rule= rule,
                                 reg_expression = expression,
-                                row_num = row+2,
+                                row_num = str(row+2),
                                 module_to_call = 'match',
                                 attribute_name = errColumn,
                                 invalid_entry = value,

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -26,7 +26,7 @@ from great_expectations.exceptions.exceptions import GreatExpectationsError
 
 from schematic.models.validate_attribute import GenerateError
 from schematic.schemas.generator import SchemaGenerator
-from schematic.utils.validate_utils import rule_in_rule_list, np_array_to_str_list
+from schematic.utils.validate_utils import rule_in_rule_list, np_array_to_str_list, iterable_to_str_list
 
 logger = logging.getLogger(__name__)
 
@@ -464,7 +464,7 @@ class GreatExpectationsHelpers(object):
                                                             val_rule = rule, 
                                                             attribute_name = errColumn,
                                                             row_num = np_array_to_str_list(np.array(indices)+2),
-                                                            error_val = values,  
+                                                            error_val = iterable_to_str_list(values),  
                                                             sg = self.sg
                                                         )       
                     if vr_errors:

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -448,11 +448,11 @@ class GenerateError:
         
         #log warning or error message
         if val_rule.startswith('recommended'):
-            cross_error_str = (
+            content_error_str = (
                 f"Column {attribute_name} is recommended but empty."
             )
-            logLevel(cross_error_str)
-            error_message = cross_error_str
+            logLevel(content_error_str)
+            error_message = content_error_str
 
             if raises == 'error':
                 error_list = [error_col, error_message]
@@ -463,26 +463,26 @@ class GenerateError:
             return error_list, warning_list
 
         elif val_rule.startswith('unique'):    
-            cross_error_str = (
+            content_error_str = (
                 f"Column {attribute_name} has the duplicate value(s) {error_val} in rows: {row_num}."
             )
 
         elif val_rule.startswith('protectAges'):
-            cross_error_str = (
+            content_error_str = (
                 f"Column {attribute_name} contains ages that should be censored in rows: {row_num}."
             )           
 
         elif val_rule.startswith('inRange'):
-            cross_error_str = (
+            content_error_str = (
                 f"{attribute_name} values in rows {row_num} are out of the specified range."
             )
         elif val_rule.startswith('date'):
-            cross_error_str = (
+            content_error_str = (
                 f"{attribute_name} values in rows {row_num} are not parsable as dates."
             )  
-        logLevel(cross_error_str)
+        logLevel(content_error_str)
         error_row = row_num 
-        error_message = cross_error_str
+        error_message = content_error_str
 
         #return error and empty list for warnings
         if raises == 'error':

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -20,7 +20,10 @@ from schematic.store.base import BaseStorage
 from schematic.store.synapse import SynapseStorage
 from schematic.utils.validate_rules_utils import validation_rule_info
 from schematic.utils.validate_utils import (comma_separated_list_regex,
-                                            parse_str_series_to_list)
+                                            parse_str_series_to_list,
+                                            np_array_to_str_list,
+                                            iterable_to_str_list,
+                                            )
 
 logger = logging.getLogger(__name__)
 
@@ -950,11 +953,12 @@ class ValidateAttribute(object):
             
             if val_rule.__contains__('matchAtLeastOne') and not missing_values.empty:
                 missing_rows = missing_values.index.to_numpy() + 2
+                missing_rows = np_array_to_str_list(missing_rows)
                 vr_errors, vr_warnings = GenerateError.generate_cross_warning(
                         val_rule = val_rule,
-                        row_num = str(list(missing_rows)),
+                        row_num = missing_rows,
                         attribute_name = source_attribute,
-                        invalid_entry = str(missing_values.values.tolist()),
+                        invalid_entry = iterable_to_str_list(missing_values),
                         sg = sg,
                     )
                 if vr_errors:
@@ -964,11 +968,12 @@ class ValidateAttribute(object):
             elif val_rule.__contains__('matchExactlyOne') and (duplicated_values.any() or missing_values.any()):
                 invalid_values  = pd.merge(duplicated_values,missing_values,how='outer')
                 invalid_rows    = pd.merge(duplicated_values,missing_values,how='outer',left_index=True,right_index=True).index.to_numpy() + 2
+                invalid_rows    = np_array_to_str_list(invalid_rows)
                 vr_errors, vr_warnings = GenerateError.generate_cross_warning(
                         val_rule = val_rule,
-                        row_num = str(list(invalid_rows)), 
+                        row_num = invalid_rows,
                         attribute_name = source_attribute, 
-                        invalid_entry = str(pd.Series(invalid_values.squeeze()).values.tolist()),
+                        invalid_entry = iterable_to_str_list(invalid_values.squeeze()),
                         sg = sg,
                     )
                 if vr_errors:
@@ -987,15 +992,14 @@ class ValidateAttribute(object):
                     missing_rows.append(missing_entry.index[0]+2)
                     missing_values.append(missing_entry.values[0])
                     
-                missing_rows=list(set(missing_rows))
-                missing_values=list(set(missing_values))
-                #print(missing_rows,missing_values)
-
+                missing_rows=iterable_to_str_list(set(missing_rows))
+                missing_values=iterable_to_str_list(set(missing_values))
+                
                 vr_errors, vr_warnings = GenerateError.generate_cross_warning(
                         val_rule = val_rule,
-                        row_num = str(missing_rows),
+                        row_num = missing_rows,
                         attribute_name = source_attribute,
-                        invalid_entry = str(missing_values),
+                        invalid_entry = missing_values,
                         missing_manifest_ID = missing_manifest_IDs,
                         sg = sg,
                     )

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -464,7 +464,7 @@ class GenerateError:
 
         elif val_rule.startswith('unique'):    
             cross_error_str = (
-                f"Column {attribute_name} has the duplicate value(s) {set(error_val)} in rows: {row_num}."
+                f"Column {attribute_name} has the duplicate value(s) {error_val} in rows: {row_num}."
             )
 
         elif val_rule.startswith('protectAges'):

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -486,10 +486,10 @@ class GenerateError:
 
         #return error and empty list for warnings
         if raises == 'error':
-            error_list = [error_row, error_col, error_message, set(error_val)]
+            error_list = [error_row, error_col, error_message, error_val]
         #return warning and empty list for errors
         elif raises == 'warning':
-            warning_list = [error_row, error_col, error_message, set(error_val)]
+            warning_list = [error_row, error_col, error_message, error_val]
         
         return error_list, warning_list
 

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -432,7 +432,9 @@ class GenerateError:
         error_list = []
         warning_list = []
         error_col = attribute_name  # Attribute name
-        
+        if error_val:
+            error_val = iterable_to_str_list(set(error_val))
+
         #Determine which, if any, message to raise
         raises = GenerateError.get_message_level(
             val_rule=val_rule,
@@ -464,7 +466,7 @@ class GenerateError:
 
         elif val_rule.startswith('unique'):    
             content_error_str = (
-                f"Column {attribute_name} has the duplicate value(s) {set(error_val)} in rows: {row_num}."
+                f"Column {attribute_name} has the duplicate value(s) {error_val} in rows: {row_num}."
             )
 
         elif val_rule.startswith('protectAges'):
@@ -486,10 +488,10 @@ class GenerateError:
 
         #return error and empty list for warnings
         if raises == 'error':
-            error_list = [error_row, error_col, error_message, set(error_val)]
+            error_list = [error_row, error_col, error_message, error_val]
         #return warning and empty list for errors
         elif raises == 'warning':
-            warning_list = [error_row, error_col, error_message, set(error_val)]
+            warning_list = [error_row, error_col, error_message, error_val]
         
         return error_list, warning_list
 

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -486,10 +486,10 @@ class GenerateError:
 
         #return error and empty list for warnings
         if raises == 'error':
-            error_list = [error_row, error_col, error_message, error_val]
+            error_list = [error_row, error_col, error_message, set(error_val)]
         #return warning and empty list for errors
         elif raises == 'warning':
-            warning_list = [error_row, error_col, error_message, error_val]
+            warning_list = [error_row, error_col, error_message, set(error_val)]
         
         return error_list, warning_list
 

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -464,7 +464,7 @@ class GenerateError:
 
         elif val_rule.startswith('unique'):    
             content_error_str = (
-                f"Column {attribute_name} has the duplicate value(s) {error_val} in rows: {row_num}."
+                f"Column {attribute_name} has the duplicate value(s) {set(error_val)} in rows: {row_num}."
             )
 
         elif val_rule.startswith('protectAges'):

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -233,7 +233,7 @@ class ValidateManifest(object):
         for i, annotation in enumerate(annotations):
             v = Draft7Validator(jsonSchema)
             for error in sorted(v.iter_errors(annotation), key=exceptions.relevance):
-                errorRow = i + 2
+                errorRow = str(i + 2)
                 errorCol = error.path[-1] if len(error.path) > 0 else "Wrong schema"
                 errorColName = error.path[0] if len(error.path) > 0 else "Wrong schema"
                 errorMsg = error.message[0:500]

--- a/schematic/utils/validate_utils.py
+++ b/schematic/utils/validate_utils.py
@@ -5,6 +5,7 @@ from re import compile, search, IGNORECASE
 from schematic.utils.io_utils import load_json
 from schematic import CONFIG, LOADER
 from typing import List
+import numpy as np
 
 def validate_schema(schema):
     """Validate schema against schema.org standard"""
@@ -66,3 +67,19 @@ def parse_str_series_to_list(col: pd.Series):
     )
 
     return col
+
+def np_array_to_str_list(np_array):
+    """
+    Parse a numpy array of ints to a list of strings
+    """
+    return np.char.mod('%d', np_array).tolist()
+
+def iterable_to_str_list(iterable):
+    "Parse an iterable into a list of strings"
+    strlist = []
+
+    for element in iterable:
+        strlist.append(str(element))
+
+    return strlist
+    

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -182,7 +182,7 @@ class TestManifestValidation:
 
         assert GenerateError.generate_cross_warning(
             val_rule = 'matchAtLeastOne',
-            row_num = '[3]',
+            row_num = ['3'],
             attribute_name='Check Match at Least',
             invalid_entry = ['7163'],
             missing_manifest_ID = ['syn27600110', 'syn29381803'],
@@ -191,7 +191,7 @@ class TestManifestValidation:
 
         assert  GenerateError.generate_cross_warning(
             val_rule = 'matchAtLeastOne MockComponent.checkMatchatLeastvalues value',
-            row_num = '[3]',
+            row_num = ['3'],
             attribute_name = 'Check Match at Least values',
             invalid_entry = ['51100'],
             sg = sg,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -312,7 +312,7 @@ class TestManifestValidation:
         #Check Warnings
         assert GenerateError.generate_cross_warning(
             val_rule = 'matchAtLeastOne',
-            row_num = '[3]',
+            row_num = ['3'],
             attribute_name='Check Match at Least',
             invalid_entry = ['7163'],
             missing_manifest_ID = ['syn27600110', 'syn29381803'],

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -141,13 +141,16 @@ class TestManifestValidation:
             sg = sg,
             )[0] in errors
 
-        assert GenerateError.generate_content_error(
+
+        date_err = GenerateError.generate_content_error(
             val_rule = 'date',
             attribute_name = 'Check Date',
             sg = sg,
             row_num = ['2','3','4'],
             error_val = ['84-43-094', '32-984', 'notADate'],
-            )[0] in errors
+            )[0]
+        error_in_list = [date_err[2] in error for error in errors]
+        assert any(error_in_list)
 
         assert GenerateError.generate_content_error(
             val_rule = 'unique error', 
@@ -211,14 +214,18 @@ class TestManifestValidation:
             matching_manifests = ['syn29862066', 'syn27648165'],
             sg = sg,
             )[1] in warnings
-                    
-        assert  GenerateError.generate_cross_warning(
+
+
+        cross_warning = GenerateError.generate_cross_warning(
             val_rule = 'matchExactlyOne MockComponent.checkMatchExactlyvalues MockComponent.checkMatchExactlyvalues value',
             row_num = ['2', '3', '4'],
             attribute_name='Check Match Exactly values',
             invalid_entry = ['71738', '98085', '210065'],
             sg = sg,
-            )[1] in warnings 
+            )[1]
+        warning_in_list = [cross_warning[1] in warning for warning in warnings]
+        assert any(warning_in_list)
+
         
         
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -76,17 +76,17 @@ class TestManifestValidation:
 
         assert GenerateError.generate_type_error(
             val_rule = 'int',
-            row_num = 3,
+            row_num = '3',
             attribute_name = 'Check Int', 
-            invalid_entry = 5.63,
+            invalid_entry = '5.63',
             sg = sg,
             )[0] in errors
 
         assert GenerateError.generate_type_error(
             val_rule = 'str',
-            row_num = 3,
+            row_num = '3',
             attribute_name = 'Check String', 
-            invalid_entry = 94,
+            invalid_entry = '94',
             sg = sg,
             )[0] in errors
 
@@ -145,7 +145,7 @@ class TestManifestValidation:
             val_rule = 'date',
             attribute_name = 'Check Date',
             sg = sg,
-            row_num = [2,3,4],
+            row_num = ['2','3','4'],
             error_val = ['84-43-094', '32-984', 'notADate'],
             )[0] in errors
 
@@ -153,7 +153,7 @@ class TestManifestValidation:
             val_rule = 'unique error', 
             attribute_name = 'Check Unique',
             sg = sg,
-            row_num = [2,3,4],
+            row_num = ['2','3','4'],
             error_val = ['str1'],  
             )[0] in errors
 
@@ -161,8 +161,8 @@ class TestManifestValidation:
             val_rule = 'inRange 50 100 error', 
             attribute_name = 'Check Range',
             sg = sg,
-            row_num = [3],
-            error_val = [30], 
+            row_num = ['3'],
+            error_val = ['30'], 
             )[0] in errors
 
         #check warnings
@@ -176,8 +176,8 @@ class TestManifestValidation:
             val_rule = 'protectAges', 
             attribute_name = 'Check Ages',
             sg = sg,
-            row_num = [2,3],
-            error_val = [6549,32851], 
+            row_num = ['2','3'],
+            error_val = ['6549','32851'], 
             )[1] in warnings
 
         assert GenerateError.generate_cross_warning(
@@ -193,7 +193,7 @@ class TestManifestValidation:
             val_rule = 'matchAtLeastOne MockComponent.checkMatchatLeastvalues value',
             row_num = '[3]',
             attribute_name = 'Check Match at Least values',
-            invalid_entry = '[51100]',
+            invalid_entry = ['51100'],
             sg = sg,
             )[1] in warnings      
 
@@ -214,9 +214,9 @@ class TestManifestValidation:
                     
         assert  GenerateError.generate_cross_warning(
             val_rule = 'matchExactlyOne MockComponent.checkMatchExactlyvalues MockComponent.checkMatchExactlyvalues value',
-            row_num = '[2, 3, 4]',
+            row_num = ['2', '3', '4'],
             attribute_name='Check Match Exactly values',
-            invalid_entry = '[71738, 98085, 210065]',
+            invalid_entry = ['71738', '98085', '210065'],
             sg = sg,
             )[1] in warnings 
         
@@ -314,16 +314,16 @@ class TestManifestValidation:
             val_rule = 'matchAtLeastOne',
             row_num = '[3]',
             attribute_name='Check Match at Least',
-            invalid_entry = '[7163]',
+            invalid_entry = ['7163'],
             missing_manifest_ID = ['syn27600110', 'syn29381803'],
             sg = sg,
             )[1] in warnings
 
         assert  GenerateError.generate_cross_warning(
             val_rule = 'matchAtLeastOne MockComponent.checkMatchatLeastvalues value',
-            row_num = '[3]',
+            row_num = ['3'],
             attribute_name = 'Check Match at Least values',
-            invalid_entry = '[51100]',
+            invalid_entry = ['51100'],
             sg = sg,
             )[1] in warnings      
 
@@ -344,9 +344,9 @@ class TestManifestValidation:
                     
         assert  GenerateError.generate_cross_warning(
             val_rule = 'matchExactlyOne MockComponent.checkMatchExactlyvalues MockComponent.checkMatchExactlyvalues value',
-            row_num = '[2, 3, 4]',
+            row_num = ['2', '3', '4'],
             attribute_name='Check Match Exactly values',
-            invalid_entry = '[71738, 98085, 210065]',
+            invalid_entry = ['71738', '98085', '210065'],
             sg = sg,
             )[1] in warnings 
         

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -68,7 +68,7 @@ class TestManifestValidation:
         #Check errors
         assert GenerateError.generate_type_error(
             val_rule = 'num',
-            row_num = 3,
+            row_num = '3',
             attribute_name = 'Check Num', 
             invalid_entry = 'c',
             sg = sg,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -184,7 +184,7 @@ class TestManifestValidation:
             val_rule = 'matchAtLeastOne',
             row_num = '[3]',
             attribute_name='Check Match at Least',
-            invalid_entry = '[7163]',
+            invalid_entry = ['7163'],
             missing_manifest_ID = ['syn27600110', 'syn29381803'],
             sg = sg,
             )[1] in warnings


### PR DESCRIPTION
Validation error message inputs differed between rules and implementation (GE vs In-house) this caused issues during the development of validation benchmarking tests using the api causing them to fail.
This PR standardizes the error messages generated so that all rows and invalid values are either a string or a list of strings.
This shouldn't break anything for the front end as there was already a mix of these and other types, but will check with @afwillia to confirm.