### PR TITLE
Bug Fix: remedy negation of table manipulation specification

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1153,7 +1153,7 @@ class SynapseStorage(BaseStorage):
             table_name = component_name + '_synapse_storage_manifest_table'
         else:
             component_name = ''
-            tabsle_name = 'synapse_storage_manifest_table'
+            table_name = 'synapse_storage_manifest_table'
         return table_name, component_name
 
     def _add_annotations(self, se, schemaGenerator, row, entityId, useSchemaLabel, hideBlanks):

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -762,7 +762,6 @@ class SynapseStorage(BaseStorage):
         table_name: str, 
         restrict: bool = False, 
         useSchemaLabel: bool = True, 
-        existingTableId: str = None,
         table_manipulation: str = 'replace',
         ):
         """


### PR DESCRIPTION
Fixes issue described by @mialy-defelice on slack (#1185) where attempting to upsert a table would replace a table instead. 

It was caused by switching from keyword arguments to positional arguments when calling `uploadDB` where there was an extra input that was not being used. Switching to positional arguments caused the value for `table_manipulation` to be stored in the variable `existingTableId`, and no positional value would be passed to the `table_manipulation` variable, causing it to default to `replace` instead of the entered parameter.

TableOperations tests are now passing (locally, does not run on remote currently)