### PR TITLE
Create example data model for single rule benchmarking

### DIFF
--- a/tests/data/example.single_rule.model.jsonld
+++ b/tests/data/example.single_rule.model.jsonld
@@ -1,0 +1,3289 @@
+{
+    "@context": {
+        "bts": "http://schema.biothings.io/",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "schema": "http://schema.org/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@graph": [
+        {
+            "@id": "schema:Text",
+            "@type": [
+                "schema:DataType",
+                "rdfs:Class"
+            ],
+            "rdfs:comment": "Data type: Text.",
+            "rdfs:label": "Text"
+        },
+        {
+            "@id": "schema:Number",
+            "@type": [
+                "schema:DataType",
+                "rdfs:Class"
+            ],
+            "rdfs:comment": "Data type: Number.",
+            "rdfs:label": "Number"
+        },
+        {
+            "@id": "schema:Integer",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Data type: Integer.",
+            "rdfs:label": "Integer",
+            "rdfs:subClassOf": {
+                "@id": "schema:Number"
+            }
+        },
+        {
+            "@id": "schema:Thing",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Thing",
+            "rdfs:label": "Thing",
+            "schema:isPartOf": {
+                "@id": "http://schema.org"
+            }
+        },
+        {
+            "@id": "bts:BiologicalEntity",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "BiologicalEntity",
+            "rdfs:subClassOf": {
+                "@id": "schema:Thing"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:OntologyClass",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "a concept or class in an ontology, vocabulary or thesaurus",
+            "rdfs:label": "OntologyClass",
+            "rdfs:subClassOf": {
+                "@id": "schema:Thing"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:RelationshipType",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "An OWL property used as an edge label",
+            "rdfs:label": "RelationshipType",
+            "rdfs:subClassOf": {
+                "@id": "bts:OntologyClass"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:GeneOntologyClass",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "an ontology class that describes a functional aspect of a gene, gene prodoct or complex",
+            "rdfs:label": "GeneOntologyClass",
+            "rdfs:subClassOf": {
+                "@id": "bts:OntologyClass"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:OrganismTaxon",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "OrganismTaxon",
+            "rdfs:subClassOf": {
+                "@id": "bts:OntologyClass"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:OrganismalEntity",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A named entity that is either a part of an organism, a whole organism, population or clade of organisms, excluding molecular entities",
+            "rdfs:label": "OrganismalEntity",
+            "rdfs:subClassOf": {
+                "@id": "bts:BiologicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:IndividualOrganism",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "IndividualOrganism",
+            "rdfs:subClassOf": {
+                "@id": "bts:OrganismalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Case",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "An individual organism that has a patient role in some clinical context.",
+            "rdfs:label": "Case",
+            "rdfs:subClassOf": {
+                "@id": "bts:IndividualOrganism"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:PopulationOfIndividualOrganisms",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "PopulationOfIndividualOrganisms",
+            "rdfs:subClassOf": {
+                "@id": "bts:OrganismalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Biosample",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "Biosample",
+            "rdfs:subClassOf": {
+                "@id": "bts:OrganismalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:DiseaseOrPhenotypicFeature",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Either one of a disease or an individual phenotypic feature. Some knowledge resources such as Monarch treat these as distinct, others such as MESH conflate.",
+            "rdfs:label": "DiseaseOrPhenotypicFeature",
+            "rdfs:subClassOf": {
+                "@id": "bts:BiologicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Disease",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "Disease",
+            "rdfs:subClassOf": {
+                "@id": "bts:DiseaseOrPhenotypicFeature"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:PhenotypicFeature",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "PhenotypicFeature",
+            "rdfs:subClassOf": {
+                "@id": "bts:DiseaseOrPhenotypicFeature"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Environment",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A feature of the environment of an organism that influences one or more phenotypic features of that organism, potentially mediated by genes",
+            "rdfs:label": "Environment",
+            "rdfs:subClassOf": {
+                "@id": "bts:BiologicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:InformationContentEntity",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "a piece of information that typically describes some piece of biology or is used as support.",
+            "rdfs:label": "InformationContentEntity",
+            "rdfs:subClassOf": {
+                "@id": "schema:Thing"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:ConfidenceLevel",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Level of confidence in a statement",
+            "rdfs:label": "ConfidenceLevel",
+            "rdfs:subClassOf": {
+                "@id": "bts:InformationContentEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:EvidenceType",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Class of evidence that supports an association",
+            "rdfs:label": "EvidenceType",
+            "rdfs:subClassOf": {
+                "@id": "bts:InformationContentEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Publication",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Any published piece of information. Can refer to a whole publication, or to a part of it (e.g. a figure, figure legend, or section highlighted by NLP). The scope is intended to be general and include information published on the web as well as journals.",
+            "rdfs:label": "Publication",
+            "rdfs:subClassOf": {
+                "@id": "bts:InformationContentEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:MolecularEntity",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A gene, gene product, small molecule or macromolecule (including protein complex)",
+            "rdfs:label": "MolecularEntity",
+            "rdfs:subClassOf": {
+                "@id": "bts:BiologicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:ChemicalSubstance",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "May be a chemical entity or a formulation with a chemical entity as active ingredient, or a complex material with multiple chemical entities as part",
+            "rdfs:label": "ChemicalSubstance",
+            "rdfs:subClassOf": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Drug",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A substance intended for use in the diagnosis, cure, mitigation, treatment, or prevention of disease",
+            "rdfs:label": "Drug",
+            "rdfs:subClassOf": {
+                "@id": "bts:ChemicalSubstance"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Metabolite",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Any intermediate or product resulting from metabolism. Includes primary and secondary metabolites.",
+            "rdfs:label": "Metabolite",
+            "rdfs:subClassOf": {
+                "@id": "bts:ChemicalSubstance"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:AnatomicalEntity",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A subcellular location, cell type or gross anatomical part",
+            "rdfs:label": "AnatomicalEntity",
+            "rdfs:subClassOf": {
+                "@id": "bts:OrganismalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:LifeStage",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A stage of development or growth of an organism, including post-natal adult stages",
+            "rdfs:label": "LifeStage",
+            "rdfs:subClassOf": {
+                "@id": "bts:OrganismalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:PlanetaryEntity",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Any entity or process that exists at the level of the whole planet",
+            "rdfs:label": "PlanetaryEntity",
+            "rdfs:subClassOf": {
+                "@id": "schema:Thing"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:EnvironmentalProcess",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "EnvironmentalProcess",
+            "rdfs:subClassOf": {
+                "@id": "bts:PlanetaryEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:EnvironmentalFeature",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "EnvironmentalFeature",
+            "rdfs:subClassOf": {
+                "@id": "bts:PlanetaryEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:ClinicalEntity",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Any entity or process that exists in the clinical domain and outside the biological realm. Diseases are placed under biological entities",
+            "rdfs:label": "ClinicalEntity",
+            "rdfs:subClassOf": {
+                "@id": "schema:Thing"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:ClinicalTrial",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "ClinicalTrial",
+            "rdfs:subClassOf": {
+                "@id": "bts:ClinicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:ClinicalIntervention",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "ClinicalIntervention",
+            "rdfs:subClassOf": {
+                "@id": "bts:ClinicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Device",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A thing made or adapted for a particular purpose, especially a piece of mechanical or electronic equipment",
+            "rdfs:label": "Device",
+            "rdfs:subClassOf": {
+                "@id": "schema:Thing"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:GenomicEntity",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "an entity that can either be directly located on a genome (gene, transcript, exon, regulatory region) or is encoded in a genome (protein)",
+            "rdfs:label": "GenomicEntity",
+            "rdfs:subClassOf": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Genome",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A genome is the sum of genetic material within a cell or virion.",
+            "rdfs:label": "Genome",
+            "rdfs:subClassOf": {
+                "@id": "bts:GenomicEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Transcript",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "An RNA synthesized on a DNA or RNA template by an RNA polymerase",
+            "rdfs:label": "Transcript",
+            "rdfs:subClassOf": {
+                "@id": "bts:GenomicEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Exon",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A region of the transcript sequence within a gene which is not removed from the primary RNA transcript by RNA splicing",
+            "rdfs:label": "Exon",
+            "rdfs:subClassOf": {
+                "@id": "bts:GenomicEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:CodingSequence",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "CodingSequence",
+            "rdfs:subClassOf": {
+                "@id": "bts:GenomicEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:MacromolecularMachine",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A union of gene, gene product, and macromolecular complex. These are the basic units of function in a cell. They either carry out individual biological activities, or they encode molecules which do this.",
+            "rdfs:label": "MacromolecularMachine",
+            "rdfs:subClassOf": {
+                "@id": "bts:GenomicEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:GeneOrGeneProduct",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "a union of genes or gene products. Frequently an identifier for one will be used as proxy for another",
+            "rdfs:label": "GeneOrGeneProduct",
+            "rdfs:subClassOf": {
+                "@id": "bts:MacromolecularMachine"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Gene",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "Gene",
+            "rdfs:subClassOf": {
+                "@id": "bts:GeneOrGeneProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:GeneProduct",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "The functional molecular product of a single gene. Gene products are either proteins or functional RNA molecules",
+            "rdfs:label": "GeneProduct",
+            "rdfs:subClassOf": {
+                "@id": "bts:GeneOrGeneProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Protein",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A gene product that is composed of a chain of amino acid sequences and is produced by ribosome-mediated translation of mRNA",
+            "rdfs:label": "Protein",
+            "rdfs:subClassOf": {
+                "@id": "bts:GeneProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:GeneProductIsoform",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "This is an abstract class that can be mixed in with different kinds of gene products to indicate that the gene product is intended to represent a specific isoform rather than a canonical or reference or generic product. The designation of canonical or reference may be arbitrary, or it may represent the superclass of all isoforms.",
+            "rdfs:label": "GeneProductIsoform",
+            "rdfs:subClassOf": {
+                "@id": "bts:GeneProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:ProteinIsoform",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Represents a protein that is a specific isoform of the canonical or reference protein. See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4114032/",
+            "rdfs:label": "ProteinIsoform",
+            "rdfs:subClassOf": {
+                "@id": "bts:Protein"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:RnaProduct",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "RnaProduct",
+            "rdfs:subClassOf": {
+                "@id": "bts:GeneProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:RnaProductIsoform",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Represents a protein that is a specific isoform of the canonical or reference RNA",
+            "rdfs:label": "RnaProductIsoform",
+            "rdfs:subClassOf": {
+                "@id": "bts:RnaProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:NoncodingRnaProduct",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "NoncodingRnaProduct",
+            "rdfs:subClassOf": {
+                "@id": "bts:RnaProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Microrna",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "Microrna",
+            "rdfs:subClassOf": {
+                "@id": "bts:NoncodingRnaProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:MacromolecularComplex",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "MacromolecularComplex",
+            "rdfs:subClassOf": {
+                "@id": "bts:MacromolecularMachine"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:GeneFamily",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "any grouping of multiple genes or gene products related by common descent",
+            "rdfs:label": "GeneFamily",
+            "rdfs:subClassOf": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Genotype",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "An information content entity that describes a genome by specifying the total variation in genomic sequence and/or gene expression, relative to some extablished background",
+            "rdfs:label": "Genotype",
+            "rdfs:subClassOf": {
+                "@id": "bts:GenomicEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Haplotype",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A set of zero or more Alleles on a single instance of a Sequence[VMC]",
+            "rdfs:label": "Haplotype",
+            "rdfs:subClassOf": {
+                "@id": "bts:GenomicEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:SequenceVariant",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "An allele that varies in its sequence from what is considered the reference allele at that locus.",
+            "rdfs:label": "SequenceVariant",
+            "rdfs:subClassOf": {
+                "@id": "bts:GenomicEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:DrugExposure",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A drug exposure is an intake of a particular chemical substance",
+            "rdfs:label": "DrugExposure",
+            "rdfs:subClassOf": {
+                "@id": "bts:Environment"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Treatment",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A treatment is targeted at a disease or phenotype and may involve multiple drug 'exposures'",
+            "rdfs:label": "Treatment",
+            "rdfs:subClassOf": {
+                "@id": "bts:Environment"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:GeographicLocation",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "a location that can be described in lat/long coordinates",
+            "rdfs:label": "GeographicLocation",
+            "rdfs:subClassOf": {
+                "@id": "bts:PlanetaryEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:GeographicLocationAtTime",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "a location that can be described in lat/long coordinates, for a particular time",
+            "rdfs:label": "GeographicLocationAtTime",
+            "rdfs:subClassOf": {
+                "@id": "bts:GeographicLocation"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Occurrent",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A processual entity",
+            "rdfs:label": "Occurrent",
+            "rdfs:subClassOf": {
+                "@id": "schema:Thing"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:BiologicalProcessOrActivity",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Either an individual molecular activity, or a collection of causally connected molecular activities",
+            "rdfs:label": "BiologicalProcessOrActivity",
+            "rdfs:subClassOf": {
+                "@id": "bts:BiologicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:MolecularActivity",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "An execution of a molecular function carried out by a gene product or macromolecular complex.",
+            "rdfs:label": "MolecularActivity",
+            "rdfs:subClassOf": {
+                "@id": "bts:BiologicalProcessOrActivity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:ActivityAndBehavior",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "Activity or behavior of any independent integral living, organization or mechanical actor in the world",
+            "rdfs:label": "ActivityAndBehavior",
+            "rdfs:subClassOf": {
+                "@id": "bts:Occurrent"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Procedure",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A series of actions conducted in a certain order or manner",
+            "rdfs:label": "Procedure",
+            "rdfs:subClassOf": {
+                "@id": "bts:Occurrent"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Phenomenon",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "a fact or situation that is observed to exist or happen, especially one whose cause or explanation is in question",
+            "rdfs:label": "Phenomenon",
+            "rdfs:subClassOf": {
+                "@id": "bts:Occurrent"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:BiologicalProcess",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "One or more causally connected executions of molecular functions",
+            "rdfs:label": "BiologicalProcess",
+            "rdfs:subClassOf": {
+                "@id": "bts:BiologicalProcessOrActivity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Pathway",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "Pathway",
+            "rdfs:subClassOf": {
+                "@id": "bts:BiologicalProcess"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:PhysiologicalProcess",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "PhysiologicalProcess",
+            "rdfs:subClassOf": {
+                "@id": "bts:BiologicalProcess"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:CellularComponent",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A location in or around a cell",
+            "rdfs:label": "CellularComponent",
+            "rdfs:subClassOf": {
+                "@id": "bts:AnatomicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:Cell",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "Cell",
+            "rdfs:subClassOf": {
+                "@id": "bts:AnatomicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:CellLine",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "CellLine",
+            "rdfs:subClassOf": {
+                "@id": "bts:Biosample"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:GrossAnatomicalStructure",
+            "@type": "rdfs:Class",
+            "rdfs:comment": null,
+            "rdfs:label": "GrossAnatomicalStructure",
+            "rdfs:subClassOf": {
+                "@id": "bts:AnatomicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            }
+        },
+        {
+            "@id": "bts:ensembl",
+            "@type": "rdf:Property",
+            "rdfs:comment": "Ensembl ID for gene, protein or transcript",
+            "rdfs:label": "ensembl",
+            "schema:domainIncludes": [
+                {
+                    "@id": "bts:Transcript"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "schema:Text"
+            }
+        },
+        {
+            "@id": "bts:hgnc",
+            "@type": "rdf:Property",
+            "rdfs:comment": "HGNC ID for gene",
+            "rdfs:label": "hgnc",
+            "schema:domainIncludes": {
+                "@id": "bts:Gene"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "schema:Integer"
+            }
+        },
+        {
+            "@id": "bts:entrez",
+            "@type": "rdf:Property",
+            "rdfs:comment": "Entrez ID for gene",
+            "rdfs:label": "entrez",
+            "schema:domainIncludes": {
+                "@id": "bts:Gene"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "schema:Integer"
+            }
+        },
+        {
+            "@id": "bts:refseq",
+            "@type": "rdf:Property",
+            "rdfs:comment": "Refseq ID for gene, protein or transcript",
+            "rdfs:label": "refseq",
+            "schema:domainIncludes": [
+                {
+                    "@id": "bts:Transcript"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "schema:Text"
+            }
+        },
+        {
+            "@id": "bts:omim",
+            "@type": "rdf:Property",
+            "rdfs:comment": "Refseq ID for gene, protein or transcript",
+            "rdfs:label": "omim",
+            "schema:domainIncludes": [
+                {
+                    "@id": "bts:Disease"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "schema:Integer"
+            }
+        },
+        {
+            "@id": "bts:umls",
+            "@type": "rdf:Property",
+            "rdfs:comment": "Refseq ID for gene, protein or transcript",
+            "rdfs:label": "umls",
+            "schema:domainIncludes": {
+                "@id": "bts:Disease"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "schema:Text"
+            }
+        },
+        {
+            "@id": "bts:homologousTo",
+            "@type": "rdf:Property",
+            "rdfs:comment": "Shared ancestry between protein or gene",
+            "rdfs:label": "homologousTo",
+            "schema:domainIncludes": {
+                "@id": "bts:GeneOrGeneProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GeneOrGeneProduct"
+            }
+        },
+        {
+            "@id": "bts:molecularlyInteractsWith",
+            "@type": "rdf:Property",
+            "rdfs:comment": null,
+            "rdfs:label": "molecularlyInteractsWith",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:geneticallyInteractsWith",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two genes whose phenotypic effects are dependent on each other in some way - such that their combined phenotypic effects are the result of some interaction between the activity of their gene products. Examples include epistasis and synthetic lethality.",
+            "rdfs:label": "geneticallyInteractsWith",
+            "schema:domainIncludes": {
+                "@id": "bts:Gene"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:Gene"
+            }
+        },
+        {
+            "@id": "bts:affectsAbundanceOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one changes the amount of the other within a system of interest",
+            "rdfs:label": "affectsAbundanceOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesAbundanceOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the amount of the other within a system of interest",
+            "rdfs:label": "increasesAbundanceOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesAbundanceOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the amount of the other within a system of interest",
+            "rdfs:label": "decreasesAbundanceOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsActivityOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one changes the activity of the other within a system of interest",
+            "rdfs:label": "affectsActivityOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesActivityOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the activity of the other within a system of interest",
+            "rdfs:label": "increasesActivityOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesActivityOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the activity of the other within a system of interest",
+            "rdfs:label": "decreasesActivityOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsExpressionOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one changes the level of expression of the other within a system of interest",
+            "rdfs:label": "affectsExpressionOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GenomicEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesExpressionOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the level of expression of the other within a system of interest",
+            "rdfs:label": "increasesExpressionOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GenomicEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesExpressionOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the level of expression of the other within a system of interest",
+            "rdfs:label": "decreasesExpressionOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GenomicEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsFoldingOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one changes the rate or quality of folding of the other ",
+            "rdfs:label": "affectsFoldingOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesFoldingOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the rate or quality of folding of the other ",
+            "rdfs:label": "increasesFoldingOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesFoldingOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the rate or quality of folding of the other ",
+            "rdfs:label": "decreasesFoldingOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsLocalizationOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one changes the localization of the other within a system of interest",
+            "rdfs:label": "affectsLocalizationOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesLocalizationOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the proper localization of the other within a system of interest",
+            "rdfs:label": "increasesLocalizationOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesLocalizationOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the proper localization of the other within a system of interest",
+            "rdfs:label": "decreasesLocalizationOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsMetabolicProcessingOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one impacts the metabolic processing of the other within a system of interest",
+            "rdfs:label": "affectsMetabolicProcessingOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesMetabolicProcessingOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the rate of metabolic processing of the other within a system of interest",
+            "rdfs:label": "increasesMetabolicProcessingOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesMetabolicProcessingOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the rate of metabolic processing of the other within a system of interest",
+            "rdfs:label": "decreasesMetabolicProcessingOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsMolecularModificationOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one leads changes in the molecular modification(s) of the other (e.g. via post-translational modifications of proteins such as the addition of phosphoryl group, or via redox reaction that adds or subtracts electrons)",
+            "rdfs:label": "affectsMolecularModificationOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesMolecularModificationOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one leads to increased molecular modification(s) of the other (e.g. via post-translational modifications of proteins such as the addition of phosphoryl group, or via redox reaction that adds or subtracts electrons)",
+            "rdfs:label": "increasesMolecularModificationOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesMolecularModificationOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one leads to decreased molecular modification(s) of the other (e.g. via post-translational modifications of proteins such as the addition of phosphoryl group, or via redox reaction that adds or subtracts electrons)",
+            "rdfs:label": "decreasesMolecularModificationOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsSynthesisOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one impacts the rate of chemical synthesis of the other",
+            "rdfs:label": "affectsSynthesisOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesSynthesisOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the rate of chemical synthesis of the other",
+            "rdfs:label": "increasesSynthesisOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesSynthesisOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the rate of chemical synthesis of the other",
+            "rdfs:label": "decreasesSynthesisOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsDegradationOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one impacts the rate of degradation of the other within a system of interest",
+            "rdfs:label": "affectsDegradationOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesDegradationOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the rate of degradation of the other within a system of interest",
+            "rdfs:label": "increasesDegradationOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesDegradationOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the rate of degradation of the other within a system of interest",
+            "rdfs:label": "decreasesDegradationOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsMutationRateOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a molecular entity and a genomic entity where the action or effect of the molecular entity impacts the rate of mutation of the genomic entity within a system of interest",
+            "rdfs:label": "affectsMutationRateOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GenomicEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesMutationRateOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a molecular entity and a genomic entity where the action or effect of the molecular entity increases the rate of mutation of the genomic entity within a system of interest",
+            "rdfs:label": "increasesMutationRateOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GenomicEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesMutationRateOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a molecular entity and a genomic entity where the action or effect of the molecular entity decreases the rate of mutation of the genomic entity within a system of interest",
+            "rdfs:label": "decreasesMutationRateOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GenomicEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsResponseTo",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one impacts the susceptibility of a biological entity or system (e.g. an organism, cell, cellular component, macromolecular machine, biological or pathological process) to the other",
+            "rdfs:label": "affectsResponseTo",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesResponseTo",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the susceptibility of a biological entity or system (e.g. an organism, cell, cellular component, macromolecular machine, biological or pathological process) to the other",
+            "rdfs:label": "increasesResponseTo",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesResponseTo",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the susceptibility of a biological entity or system (e.g. an organism, cell, cellular component, macromolecular machine, biological or pathological process) to the other",
+            "rdfs:label": "decreasesResponseTo",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsSplicingOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a molecular entity and an mRNA where the action or effect of the molecular entity impacts the splicing of the mRNA",
+            "rdfs:label": "affectsSplicingOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:Transcript"
+            }
+        },
+        {
+            "@id": "bts:increasesSplicingOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a molecular entity and an mRNA where the action or effect of the molecular entity increases the proper splicing of the mRNA",
+            "rdfs:label": "increasesSplicingOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:Transcript"
+            }
+        },
+        {
+            "@id": "bts:decreasesSplicingOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a molecular entity and an mRNA where the action or effect of the molecular entity decreases the proper splicing of the mRNA",
+            "rdfs:label": "decreasesSplicingOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:Transcript"
+            }
+        },
+        {
+            "@id": "bts:affectsStabilityOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one impacts the stability of the other within a system of interest",
+            "rdfs:label": "affectsStabilityOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesStabilityOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the stability of the other within a system of interest",
+            "rdfs:label": "increasesStabilityOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesStabilityOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the stability of the other within a system of interest",
+            "rdfs:label": "decreasesStabilityOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsTransportOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one impacts the rate of transport of the other across some boundary in a system of interest",
+            "rdfs:label": "affectsTransportOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesTransportOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the rate of transport of the other across some boundary in a system of interest",
+            "rdfs:label": "increasesTransportOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesTransportOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the rate of transport of the other across some boundary in a system of interest",
+            "rdfs:label": "decreasesTransportOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsSecretionOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one impacts the rate of secretion of the other out of a cell, gland, or organ",
+            "rdfs:label": "affectsSecretionOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesSecretionOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the rate of secretion of the other out of a cell, gland, or organ",
+            "rdfs:label": "increasesSecretionOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesSecretionOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the rate of secretion of the other out of a cell, gland, or organ",
+            "rdfs:label": "decreasesSecretionOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:affectsUptakeOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one impacts the rate of uptake of the other into of a cell, gland, or organ",
+            "rdfs:label": "affectsUptakeOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:increasesUptakeOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one increases the rate of uptake of the other into of a cell, gland, or organ",
+            "rdfs:label": "increasesUptakeOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:decreasesUptakeOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two molecular entities where the action or effect of one decreases the rate of uptake of the other into of a cell, gland, or organ",
+            "rdfs:label": "decreasesUptakeOf",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:regulates,ProcessToProcess",
+            "@type": "rdf:Property",
+            "rdfs:comment": null,
+            "rdfs:label": "regulates,ProcessToProcess",
+            "schema:domainIncludes": {
+                "@id": "bts:Occurrent"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:Occurrent"
+            }
+        },
+        {
+            "@id": "bts:regulates,EntityToEntity",
+            "@type": "rdf:Property",
+            "rdfs:comment": null,
+            "rdfs:label": "regulates,EntityToEntity",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:hasGeneProduct",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a gene and a transcribed and/or translated product generated from it",
+            "rdfs:label": "hasGeneProduct",
+            "schema:domainIncludes": {
+                "@id": "bts:Gene"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GeneProduct"
+            }
+        },
+        {
+            "@id": "bts:inPathwayWith",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two genes or gene products that are part of in the same biological pathway",
+            "rdfs:label": "inPathwayWith",
+            "schema:domainIncludes": {
+                "@id": "bts:GeneOrGeneProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GeneOrGeneProduct"
+            }
+        },
+        {
+            "@id": "bts:inComplexWith",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two genes or gene products that are part of (or code for products that are part of) in the same macromolecular complex",
+            "rdfs:label": "inComplexWith",
+            "schema:domainIncludes": {
+                "@id": "bts:GeneOrGeneProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GeneOrGeneProduct"
+            }
+        },
+        {
+            "@id": "bts:inCellPopulationWith",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two genes or gene products that are expressed in the same cell type or population ",
+            "rdfs:label": "inCellPopulationWith",
+            "schema:domainIncludes": {
+                "@id": "bts:GeneOrGeneProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GeneOrGeneProduct"
+            }
+        },
+        {
+            "@id": "bts:geneAssociatedWithCondition",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a gene and a disease or phenotypic feature that the gene or its alleles/products may influence, contribute to, or correlate with",
+            "rdfs:label": "geneAssociatedWithCondition",
+            "schema:domainIncludes": {
+                "@id": "bts:Gene"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:DiseaseOrPhenotypicFeature"
+            }
+        },
+        {
+            "@id": "bts:treats",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a therapeutic procedure or chemical substance and a disease or phenotypic feature that it is used to treat",
+            "rdfs:label": "treats",
+            "schema:domainIncludes": {
+                "@id": "bts:Treatment"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:DiseaseOrPhenotypicFeature"
+            }
+        },
+        {
+            "@id": "bts:correlatedWith",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a disease or phenotypic feature and a measurable molecular entity that is used as an indicator of the presence or state of the disease or feature.",
+            "rdfs:label": "correlatedWith",
+            "schema:domainIncludes": {
+                "@id": "bts:DiseaseOrPhenotypicFeature"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:hasBiomarker",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a disease or phenotypic feature and a measurable molecular entity that is used as an indicator of the presence or state of the disease or feature.",
+            "rdfs:label": "hasBiomarker",
+            "schema:domainIncludes": {
+                "@id": "bts:DiseaseOrPhenotypicFeature"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:MolecularEntity"
+            }
+        },
+        {
+            "@id": "bts:biomarkerFor",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a measurable molecular entity and a disease or phenotypic feature, where the entity is used as an indicator of the presence or state of the disease or feature.",
+            "rdfs:label": "biomarkerFor",
+            "schema:domainIncludes": {
+                "@id": "bts:MolecularEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:DiseaseOrPhenotypicFeature"
+            }
+        },
+        {
+            "@id": "bts:expressedIn",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a gene or gene product and an anatomical entity in which it is expressed",
+            "rdfs:label": "expressedIn",
+            "schema:domainIncludes": {
+                "@id": "bts:GeneOrGeneProduct"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:AnatomicalEntity"
+            }
+        },
+        {
+            "@id": "bts:expresses",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between an anatomical entity and gene or gene product that is expressed there",
+            "rdfs:label": "expresses",
+            "schema:domainIncludes": {
+                "@id": "bts:AnatomicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:GeneOrGeneProduct"
+            }
+        },
+        {
+            "@id": "bts:hasPhenotype",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between a biological entity and a phenotype, where a phenotype is construed broadly as any kind of quality of an organism part, a collection of these qualities, or a change in quality or qualities (e.g. abnormally increased temperature). ",
+            "rdfs:label": "hasPhenotype",
+            "schema:domainIncludes": {
+                "@id": "bts:BiologicalEntity"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:DiseaseOrPhenotypicFeature"
+            }
+        },
+        {
+            "@id": "bts:precedes",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two processes, where one completes before the other begins",
+            "rdfs:label": "precedes",
+            "schema:domainIncludes": {
+                "@id": "bts:Occurrent"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:Occurrent"
+            }
+        },
+        {
+            "@id": "bts:subclassOf",
+            "@type": "rdf:Property",
+            "rdfs:comment": "holds between two classes where the domain class is a specialization of the range class",
+            "rdfs:label": "subclassOf",
+            "schema:domainIncludes": {
+                "@id": "bts:OntologyClass"
+            },
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": {
+                "@id": "bts:OntologyClass"
+            }
+        },
+        {
+            "@id": "bts:Patient",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Patient",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Patient",
+            "sms:required": "sms:false",
+            "sms:requiresDependency": [
+                {
+                    "@id": "bts:PatientID"
+                },
+                {
+                    "@id": "bts:Sex"
+                },
+                {
+                    "@id": "bts:YearofBirth"
+                },
+                {
+                    "@id": "bts:Diagnosis"
+                },
+                {
+                    "@id": "bts:Component"
+                }
+            ],
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:PatientID",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "PatientID",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Patient ID",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Sex",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Sex",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:Female"
+                },
+                {
+                    "@id": "bts:Male"
+                },
+                {
+                    "@id": "bts:Other"
+                }
+            ],
+            "sms:displayName": "Sex",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:YearofBirth",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "YearofBirth",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Year of Birth",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Diagnosis",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Diagnosis",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:Healthy"
+                },
+                {
+                    "@id": "bts:Cancer"
+                }
+            ],
+            "sms:displayName": "Diagnosis",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Cancer",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Cancer",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:ValidValue"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Cancer",
+            "sms:required": "sms:false",
+            "sms:requiresDependency": [
+                {
+                    "@id": "bts:CancerType"
+                },
+                {
+                    "@id": "bts:FamilyHistory"
+                }
+            ],
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:CancerType",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CancerType",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:Breast"
+                },
+                {
+                    "@id": "bts:Colorectal"
+                },
+                {
+                    "@id": "bts:Lung"
+                },
+                {
+                    "@id": "bts:Prostate"
+                },
+                {
+                    "@id": "bts:Skin"
+                }
+            ],
+            "sms:displayName": "Cancer Type",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:FamilyHistory",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "FamilyHistory",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:Breast"
+                },
+                {
+                    "@id": "bts:Colorectal"
+                },
+                {
+                    "@id": "bts:Lung"
+                },
+                {
+                    "@id": "bts:Prostate"
+                },
+                {
+                    "@id": "bts:Skin"
+                }
+            ],
+            "sms:displayName": "Family History",
+            "sms:required": "sms:true",
+            "sms:validationRules": [
+                "list strict"
+            ]
+        },
+        {
+            "@id": "bts:Biospecimen",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Biospecimen",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Biospecimen",
+            "sms:required": "sms:false",
+            "sms:requiresComponent": [
+                {
+                    "@id": "bts:Patient"
+                }
+            ],
+            "sms:requiresDependency": [
+                {
+                    "@id": "bts:SampleID"
+                },
+                {
+                    "@id": "bts:PatientID"
+                },
+                {
+                    "@id": "bts:TissueStatus"
+                },
+                {
+                    "@id": "bts:Component"
+                }
+            ],
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:SampleID",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "SampleID",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Sample ID",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:TissueStatus",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "TissueStatus",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:Healthy"
+                },
+                {
+                    "@id": "bts:Malignant"
+                }
+            ],
+            "sms:displayName": "Tissue Status",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:BulkRNA-seqAssay",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "BulkRNA-seqAssay",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Bulk RNA-seq Assay",
+            "sms:required": "sms:false",
+            "sms:requiresComponent": [
+                {
+                    "@id": "bts:Biospecimen"
+                }
+            ],
+            "sms:requiresDependency": [
+                {
+                    "@id": "bts:Filename"
+                },
+                {
+                    "@id": "bts:SampleID"
+                },
+                {
+                    "@id": "bts:FileFormat"
+                },
+                {
+                    "@id": "bts:Component"
+                }
+            ],
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Filename",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Filename",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Filename",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:FileFormat",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "FileFormat",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:FASTQ"
+                },
+                {
+                    "@id": "bts:BAM"
+                },
+                {
+                    "@id": "bts:CRAM"
+                },
+                {
+                    "@id": "bts:CSV/TSV"
+                }
+            ],
+            "sms:displayName": "File Format",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:BAM",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "BAM",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:ValidValue"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "BAM",
+            "sms:required": "sms:false",
+            "sms:requiresDependency": [
+                {
+                    "@id": "bts:GenomeBuild"
+                }
+            ],
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:CRAM",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CRAM",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:ValidValue"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "CRAM",
+            "sms:required": "sms:false",
+            "sms:requiresDependency": [
+                {
+                    "@id": "bts:GenomeBuild"
+                },
+                {
+                    "@id": "bts:GenomeFASTA"
+                }
+            ],
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:CSV/TSV",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CSV/TSV",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:ValidValue"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "CSV/TSV",
+            "sms:required": "sms:false",
+            "sms:requiresDependency": [
+                {
+                    "@id": "bts:GenomeBuild"
+                }
+            ],
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:GenomeBuild",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "GenomeBuild",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:GRCh37"
+                },
+                {
+                    "@id": "bts:GRCh38"
+                },
+                {
+                    "@id": "bts:GRCm38"
+                },
+                {
+                    "@id": "bts:GRCm39"
+                }
+            ],
+            "sms:displayName": "Genome Build",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:GenomeFASTA",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "GenomeFASTA",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Genome FASTA",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:MockComponent",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "MockComponent",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "MockComponent",
+            "sms:required": "sms:false",
+            "sms:requiresDependency": [
+                {
+                    "@id": "bts:Component"
+                },
+                {
+                    "@id": "bts:CheckList"
+                },
+                {
+                    "@id": "bts:CheckRegexList"
+                },
+                {
+                    "@id": "bts:CheckRegexSingle"
+                },
+                {
+                    "@id": "bts:CheckRegexFormat"
+                },
+                {
+                    "@id": "bts:CheckNum"
+                },
+                {
+                    "@id": "bts:CheckFloat"
+                },
+                {
+                    "@id": "bts:CheckInt"
+                },
+                {
+                    "@id": "bts:CheckString"
+                },
+                {
+                    "@id": "bts:CheckURL"
+                },
+                {
+                    "@id": "bts:CheckMatchatLeast"
+                },
+                {
+                    "@id": "bts:CheckMatchatLeastvalues"
+                },
+                {
+                    "@id": "bts:CheckMatchExactly"
+                },
+                {
+                    "@id": "bts:CheckMatchExactlyvalues"
+                },
+                {
+                    "@id": "bts:CheckRecommended"
+                },
+                {
+                    "@id": "bts:CheckAges"
+                },
+                {
+                    "@id": "bts:CheckUnique"
+                },
+                {
+                    "@id": "bts:CheckRange"
+                },
+                {
+                    "@id": "bts:CheckDate"
+                }
+            ],
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:CheckList",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckList",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:Ab"
+                },
+                {
+                    "@id": "bts:Cd"
+                },
+                {
+                    "@id": "bts:Ef"
+                },
+                {
+                    "@id": "bts:Gh"
+                }
+            ],
+            "sms:displayName": "Check List",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "list strict error"
+            ]
+        },
+        {
+            "@id": "bts:CheckRegexList",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckRegexList",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Regex List",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "list strict error",
+                "regex match [a-f] error"
+            ]
+        },
+        {
+            "@id": "bts:CheckRegexSingle",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckRegexSingle",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Regex Single",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "regex search [a-f] error"
+            ]
+        },
+        {
+            "@id": "bts:CheckRegexFormat",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckRegexFormat",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Regex Format",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "regex match [a-f] error"
+            ]
+        },
+        {
+            "@id": "bts:CheckNum",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckNum",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Num",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "num error"
+            ]
+        },
+        {
+            "@id": "bts:CheckFloat",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckFloat",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Float",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "float error"
+            ]
+        },
+        {
+            "@id": "bts:CheckInt",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckInt",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Int",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "int error"
+            ]
+        },
+        {
+            "@id": "bts:CheckString",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckString",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check String",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "str error"
+            ]
+        },
+        {
+            "@id": "bts:CheckURL",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckURL",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check URL",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "url error"
+            ]
+        },
+        {
+            "@id": "bts:CheckMatchatLeast",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckMatchatLeast",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Match at Least",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "matchAtLeastOne Patient.PatientID set warning"
+            ]
+        },
+        {
+            "@id": "bts:CheckMatchExactly",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckMatchExactly",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Match Exactly",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "matchExactlyOne MockComponent.checkMatchExactly set warning"
+            ]
+        },
+        {
+            "@id": "bts:CheckMatchatLeastvalues",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckMatchatLeastvalues",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Match at Least values",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "matchAtLeastOne MockComponent.checkMatchatLeastvalues value warning"
+            ]
+        },
+        {
+            "@id": "bts:CheckMatchExactlyvalues",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckMatchExactlyvalues",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Match Exactly values",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "matchExactlyOne MockComponent.checkMatchExactlyvalues value warning"
+            ]
+        },
+        {
+            "@id": "bts:CheckRecommended",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckRecommended",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Recommended",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "recommended warning"
+            ]
+        },
+        {
+            "@id": "bts:CheckAges",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckAges",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Ages",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "protectAges warning"
+            ]
+        },
+        {
+            "@id": "bts:CheckUnique",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckUnique",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Unique",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "unique error"
+            ]
+        },
+        {
+            "@id": "bts:CheckRange",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckRange",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Range",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "inRange 50 100 error"
+            ]
+        },
+        {
+            "@id": "bts:CheckDate",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckDate",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Date",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "date error"
+            ]
+        },
+        {
+            "@id": "bts:MockRDB",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "MockRDB",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "MockRDB",
+            "sms:required": "sms:false",
+            "sms:requiresDependency": [
+                {
+                    "@id": "bts:Component"
+                },
+                {
+                    "@id": "bts:MockRDBId"
+                }
+            ],
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:MockRDBId",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "MockRDBId",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "MockRDB_id",
+            "sms:required": "sms:true",
+            "sms:validationRules": [
+                "int"
+            ]
+        },
+        {
+            "@id": "bts:Component",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Component",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Patient"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Component",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Female",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Female",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Sex"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Female",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Male",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Male",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Sex"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Male",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Other",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Other",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Sex"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Other",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Healthy",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Healthy",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Diagnosis"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Healthy",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Breast",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Breast",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CancerType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Breast",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Colorectal",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Colorectal",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CancerType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Colorectal",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Lung",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Lung",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CancerType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Lung",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Prostate",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Prostate",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CancerType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Prostate",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Skin",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Skin",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CancerType"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Skin",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Malignant",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Malignant",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:TissueStatus"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Malignant",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:FASTQ",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "FASTQ",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:FileFormat"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "FASTQ",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:GRCh37",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "GRCh37",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:GenomeBuild"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "GRCh37",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:GRCh38",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "GRCh38",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:GenomeBuild"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "GRCh38",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:GRCm38",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "GRCm38",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:GenomeBuild"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "GRCm38",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:GRCm39",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "GRCm39",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:GenomeBuild"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "GRCm39",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Ab",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Ab",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CheckList"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "ab",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Cd",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Cd",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CheckList"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "cd",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Ef",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Ef",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CheckList"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "ef",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Gh",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Gh",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CheckList"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "gh",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        }
+    ],
+    "@id": "http://schema.biothings.io/#0.1"
+}


### PR DESCRIPTION
Create example model with `MockComponent` attributes set to not required so that JSON schema validation only runs for the attribute being benchmarked. To be used for single rule benchmarking tests. Rules are explicitly set to their default behavior.