### PR TITLE
Add `IsNA` rule to validation suite | FDS-81 FDS-232

### DIFF
--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -134,7 +134,8 @@ class GreatExpectationsHelpers(object):
             "protectAges": "expect_column_values_to_be_between",
             "unique": "expect_column_values_to_be_unique",
             "inRange": "expect_column_values_to_be_between",
-            
+            "IsNA": "expect_column_values_to_match_regex_list",
+
             # To be implemented rules with possible expectations
             #"list": "expect_column_values_to_not_match_regex_list",
             #"regex": "expect_column_values_to_match_regex",
@@ -282,6 +283,17 @@ class GreatExpectationsHelpers(object):
                             "notes": {
                                 "format": "markdown",
                                 "content": "Expect column values to be within a specified range. **Markdown** `Supported`",
+                            },
+                            "validation_rule": rule
+                        }
+                        
+                    elif base_rule==("IsNA"):
+                        args["mostly"]=1.0
+                        args["regex_list"]=['Not Applicable']
+                        meta={
+                            "notes": {
+                                "format": "markdown",
+                                "content": "Expect column values to be marked Not Applicable. **Markdown** `Supported`",
                             },
                             "validation_rule": rule
                         }

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -482,20 +482,17 @@ class GenerateError:
             content_error_str = (
                 f"{attribute_name} values in rows {row_num} are not parsable as dates."
             )  
-        elif val_rule.startswith('IsNA'):
-            content_error_str = (
-                f"{attribute_name} values in rows {row_num} are not marked as 'Not Applicable'."
-            )  
-        logLevel(content_error_str)
-        error_row = row_num 
-        error_message = content_error_str
 
-        #return error and empty list for warnings
-        if raises == 'error':
-            error_list = [error_row, error_col, error_message, error_val]
-        #return warning and empty list for errors
-        elif raises == 'warning':
-            warning_list = [error_row, error_col, error_message, error_val]
+        if val_rule != "IsNA":
+            logLevel(content_error_str)
+            error_row = row_num 
+            error_message = content_error_str
+            #return error and empty list for warnings
+            if raises == 'error':
+                error_list = [error_row, error_col, error_message, error_val]
+            #return warning and empty list for errors
+            elif raises == 'warning':
+                warning_list = [error_row, error_col, error_message, error_val]
         
         return error_list, warning_list
 

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -24,6 +24,7 @@ from schematic.utils.validate_utils import (comma_separated_list_regex,
                                             parse_str_series_to_list,
                                             np_array_to_str_list,
                                             iterable_to_str_list,
+                                            rule_in_rule_list,
                                             )
 
 
@@ -225,19 +226,22 @@ class GenerateError:
             f"On row {row_num} the attribute {attribute_name} "
             f"does not contain the proper value type {val_rule}."
         )
-        logLevel(type_error_str)
         error_row = row_num  # index row of the manifest where the error presented.
         error_col = attribute_name  # Attribute name
         error_message = type_error_str
         error_val = invalid_entry
 
-
-        #return error and empty list for warnings
-        if raises == 'error':
-            error_list = [error_row, error_col, error_message, error_val]
-        #return warning and empty list for errors
-        elif raises == 'warning':
-            warning_list = [error_row, error_col, error_message, error_val]
+        # If IsNA rule is being used to allow `Not Applicable` entries, do not log a message
+        if error_val.lower() == 'not applicable' and rule_in_rule_list('IsNA', sg.get_node_validation_rules(sg.get_node_label(attribute_name))):
+          pass  
+        else:
+            logLevel(type_error_str)
+            #return error and empty list for warnings
+            if raises == 'error':
+                error_list = [error_row, error_col, error_message, error_val]
+            #return warning and empty list for errors
+            elif raises == 'warning':
+                warning_list = [error_row, error_col, error_message, error_val]
         
         return error_list, warning_list              
 

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -486,6 +486,10 @@ class GenerateError:
             content_error_str = (
                 f"{attribute_name} values in rows {row_num} are not parsable as dates."
             )  
+        elif val_rule.startswith('IsNA'):
+            content_error_str = (
+                f"{attribute_name} values in rows {row_num} are not marked as 'Not Applicable'."
+            )  
 
         if val_rule != "IsNA":
             logLevel(content_error_str)

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -482,6 +482,10 @@ class GenerateError:
             content_error_str = (
                 f"{attribute_name} values in rows {row_num} are not parsable as dates."
             )  
+        elif val_rule.startswith('IsNA'):
+            content_error_str = (
+                f"{attribute_name} values in rows {row_num} are not marked as 'Not Applicable'."
+            )  
         logLevel(content_error_str)
         error_row = row_num 
         error_message = content_error_str

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -107,7 +107,7 @@ def validation_rule_info():
             "IsNA":     {
                 'arguments':(0, 1), 
                 'type': "content_validation",
-                'complementary_rules': ['int', 'float', 'num', 'str'],
+                'complementary_rules': None,
                 'default_message_level': 'warning'},            
             }
 

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -105,7 +105,7 @@ def validation_rule_info():
                 'complementary_rules': ['int','float','num','protectAges'],
                 'default_message_level': 'error'},
             "IsNA":     {
-                'arguments':(0, 1), 
+                'arguments':(1, 0), 
                 'type': "content_validation",
                 'complementary_rules': None,
                 'default_message_level': 'warning'},            

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -104,6 +104,11 @@ def validation_rule_info():
                 'type': "content_validation",
                 'complementary_rules': ['int','float','num','protectAges'],
                 'default_message_level': 'error'},
+            "IsNA":     {
+                'arguments':(0, 1), 
+                'type': "content_validation",
+                'complementary_rules': ['int', 'float', 'num', 'str'],
+                'default_message_level': 'warning'},            
             }
 
     return rule_dict

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -22,19 +22,19 @@ def validation_rule_info():
             "int": {
                 'arguments':(1, 0),
                 'type': "type_validation",
-                'complementary_rules': ['inRange',],
+                'complementary_rules': ['inRange', 'IsNA'],
                 'default_message_level': 'error'},
 
             "float": {
                 'arguments':(1, 0),
                 'type': "type_validation",
-                'complementary_rules': ['inRange',],
+                'complementary_rules': ['inRange', 'IsNA'],
                 'default_message_level': 'error'},
 
             "num": {
                 'arguments':(1, 0),
                 'type': "type_validation",
-                'complementary_rules': ['inRange',],
+                'complementary_rules': ['inRange', 'IsNA'],
                 'default_message_level': 'error'},
 
             "str": {
@@ -104,10 +104,11 @@ def validation_rule_info():
                 'type': "content_validation",
                 'complementary_rules': ['int','float','num','protectAges'],
                 'default_message_level': 'error'},
+            
             "IsNA":     {
                 'arguments':(1, 0), 
                 'type': "content_validation",
-                'complementary_rules': None,
+                'complementary_rules': ['int', 'float', 'num', ],
                 'default_message_level': 'warning'},            
             }
 

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -18,7 +18,7 @@ CRAM,,,"Genome Build, Genome FASTA",,FALSE,ValidValue,,,
 CSV/TSV,,,Genome Build,,FALSE,ValidValue,,,
 Genome Build,,"GRCh37, GRCh38, GRCm38, GRCm39",,,TRUE,DataProperty,,,
 Genome FASTA,,,,,TRUE,DataProperty,,,
-MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range, Check Date",,FALSE,DataType,,,
+MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range, Check Date, Check NA",,FALSE,DataType,,,
 Check List,,"ab, cd, ef, gh",,,TRUE,DataProperty,,,list strict 
 Check Regex List,,,,,TRUE,DataProperty,,,list strict::regex match [a-f]
 Check Regex Single,,,,,TRUE,DataProperty,,,regex search [a-f]
@@ -37,5 +37,6 @@ Check Ages,,,,,TRUE,DataProperty,,,protectAges
 Check Unique,,,,,TRUE,DataProperty,,,unique error
 Check Range,,,,,TRUE,DataProperty,,,inRange 50 100 error
 Check Date,,,,,TRUE,DataProperty,,,date
+Check NA,,,,,TRUE,DataProperty,,,IsNA
 MockRDB,,,"Component, MockRDB_id",,FALSE,DataType,,,
 MockRDB_id,,,,,TRUE,DataProperty,,,int

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -37,6 +37,6 @@ Check Ages,,,,,TRUE,DataProperty,,,protectAges
 Check Unique,,,,,TRUE,DataProperty,,,unique error
 Check Range,,,,,TRUE,DataProperty,,,inRange 50 100 error
 Check Date,,,,,TRUE,DataProperty,,,date
-Check NA,,,,,TRUE,DataProperty,,,IsNA
+Check NA,,,,,TRUE,DataProperty,,,int::IsNA
 MockRDB,,,"Component, MockRDB_id",,FALSE,DataType,,,
 MockRDB_id,,,,,TRUE,DataProperty,,,int

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2539,6 +2539,9 @@
                 },
                 {
                     "@id": "bts:CheckDate"
+                },
+                {
+                    "@id": "bts:CheckNA"
                 }
             ],
             "sms:validationRules": []
@@ -2898,6 +2901,25 @@
             "sms:required": "sms:true",
             "sms:validationRules": [
                 "date"
+            ]
+        },
+        {
+            "@id": "bts:CheckNA",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckNA",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check NA",
+            "sms:required": "sms:true",
+            "sms:validationRules": [
+                "IsNA"
             ]
         },
         {

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2919,6 +2919,7 @@
             "sms:displayName": "Check NA",
             "sms:required": "sms:true",
             "sms:validationRules": [
+                "int",
                 "IsNA"
             ]
         },

--- a/tests/data/example.single_rule.model.jsonld
+++ b/tests/data/example.single_rule.model.jsonld
@@ -2539,6 +2539,9 @@
                 },
                 {
                     "@id": "bts:CheckDate"
+                },
+                {
+                    "@id": "bts:CheckNA"
                 }
             ],
             "sms:validationRules": []
@@ -2898,6 +2901,26 @@
             "sms:required": "sms:false",
             "sms:validationRules": [
                 "date error"
+            ]
+        },
+        {
+            "@id": "bts:CheckNA",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckNA",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check NA",
+            "sms:required": "sms:false",
+            "sms:validationRules": [
+                "int error",
+                "IsNA"
             ]
         },
         {

--- a/tests/data/mock_manifests/Invalid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Invalid_Test_Manifest.csv
@@ -1,4 +1,4 @@
 Component,Check List,Check Regex List,Check Regex Format,Check Regex Single,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
-MockComponent,"ab,cd","ab,cd,ef",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,,6549,str1,70,32-984,Not Applicable
-MockComponent,invalid list values,ab cd ef,m,q,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,,32851,str1,30,notADate,3489249023
+MockComponent,"ab,cd","ab,cd,ef",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,,6549,str1,70,32-984,7
+MockComponent,invalid list values,ab cd ef,m,q,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,,32851,str1,30,notADate,9.5
 MockComponent,"ab,cd","ab,cd,ef",b,b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,210065,,6550,str1,90,84-43-094,Not Applicable

--- a/tests/data/mock_manifests/Invalid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Invalid_Test_Manifest.csv
@@ -1,4 +1,4 @@
-Component,Check List,Check Regex List,Check Regex Format,Check Regex Single,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date
-MockComponent,"ab,cd","ab,cd,ef",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,,6549,str1,70,32-984
-MockComponent,invalid list values,ab cd ef,m,q,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,,32851,str1,30,notADate
-MockComponent,"ab,cd","ab,cd,ef",b,b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,210065,,6550,str1,90,84-43-094
+Component,Check List,Check Regex List,Check Regex Format,Check Regex Single,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
+MockComponent,"ab,cd","ab,cd,ef",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,,6549,str1,70,32-984,Not Applicable
+MockComponent,invalid list values,ab cd ef,m,q,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,,32851,str1,30,notADate,3489249023
+MockComponent,"ab,cd","ab,cd,ef",b,b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,210065,,6550,str1,90,84-43-094,Not Applicable

--- a/tests/data/mock_manifests/Rule_Combo_Manifest.csv
+++ b/tests/data/mock_manifests/Rule_Combo_Manifest.csv
@@ -1,5 +1,5 @@
-Component,Check List,Check Regex List,Check Regex Single,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match Exactly,Check Recommended,Check Ages,Check Unique,Check Range
-MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,https://www.google.com/,https://github.com/Sage-Bionetworks/schematic,,6571,1,75
-MockComponent,"valid,list,values","a,c,f",e,71,58.4,3,valid,https://www.google.com/,https://www.google.com/,https://github.com/Sage-Bionetworks/schematic,,6571,2,80
-MockComponent,"valid,list,values","b,d,f",b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,https://github.com/Sage-Bionetworks/schematic,https://www.google.com/,present,32849,3,95
-MockComponent,"valid,list,values","b,d,f",b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,https://github.com/Sage-Bionetworks/schematic,https://www.google.com/,,32849,4,55
+Component,Check List,Check Regex List,Check Regex Single,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match Exactly,Check Recommended,Check Ages,Check Unique,Check Range,Check NA
+MockComponent,"valid,list,values","a,c,f",a,6,99.65,7,valid,https://www.google.com/,https://www.google.com/,https://github.com/Sage-Bionetworks/schematic,,6571,1,75,9.5
+MockComponent,"valid,list,values","a,c,f",e,71,58.4,3,valid,https://www.google.com/,https://www.google.com/,https://github.com/Sage-Bionetworks/schematic,,6571,2,80,9
+MockComponent,"valid,list,values","b,d,f",b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,https://github.com/Sage-Bionetworks/schematic,https://www.google.com/,present,32849,3,95,Not Applicable
+MockComponent,"valid,list,values","b,d,f",b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,https://github.com/Sage-Bionetworks/schematic,https://www.google.com/,,32849,4,55,Not Applicable

--- a/tests/data/mock_manifests/Valid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Valid_Test_Manifest.csv
@@ -1,5 +1,5 @@
-Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date
-MockComponent,"ab,cd","a,c,f",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,,6571,str1,75,2022-10-21
-MockComponent,"ab,cd","a,c,f",e,b,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80,October 21 2022
-MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,present,32849,str3,95,10/21/2022
-MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,32849,str4,55,21/10/2022
+Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
+MockComponent,"ab,cd","a,c,f",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,,6571,str1,75,10/21/2022,Not Applicable
+MockComponent,"ab,cd","a,c,f",e,b,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80,October 21 2022,Not Applicable
+MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,present,32849,str3,95,10/21/2022,Not Applicable
+MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,32849,str4,55,21/10/2022,Not Applicable

--- a/tests/data/mock_manifests/Valid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Valid_Test_Manifest.csv
@@ -1,5 +1,5 @@
 Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
 MockComponent,"ab,cd","a,c,f",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,,6571,str1,75,10/21/2022,Not Applicable
-MockComponent,"ab,cd","a,c,f",e,b,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80,October 21 2022,Not Applicable
+MockComponent,"ab,cd","a,c,f",e,b,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80,October 21 2022,8
 MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,present,32849,str3,95,10/21/2022,Not Applicable
-MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,32849,str4,55,21/10/2022,Not Applicable
+MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,32849,str4,55,21/10/2022,695

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -263,6 +263,14 @@ class TestManifestValidation:
             invalid_entry = '94',
             sg = sg,
             )[0] in errors
+        
+        assert GenerateError.generate_type_error(
+            val_rule = 'int',
+            row_num = '3',
+            attribute_name = 'Check NA', 
+            invalid_entry = '9.5',
+            sg = sg,
+            )[0] in errors
             
         assert GenerateError.generate_list_error(
             val_rule = 'list strict',

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -381,6 +381,10 @@ class TestManifestValidation:
                 # remove default combination for attribute's reules
                 if attribute['sms:displayName'] == 'Check NA':
                     attribute['sms:validationRules'].remove('int')
+                    
+                    # update class 
+                    sg.se.edit_class(attribute)
+                    break
 
                 # Add rule args if necessary
                 if base_rule in attribute['sms:validationRules'] or re.match(rule_regex, attribute['sms:validationRules'][0]):
@@ -394,9 +398,10 @@ class TestManifestValidation:
                         rule_args = ''
             
                     attribute['sms:validationRules'].append(second_rule + rule_args)
-                
-                sg.se.edit_class(attribute)
-                break
+                    
+                    # update class 
+                    sg.se.edit_class(attribute)
+                    break
 
         target_column=attribute['sms:displayName']
         for col in manifest.columns:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -375,11 +375,15 @@ class TestManifestValidation:
         manifestPath = helpers.get_data_path("mock_manifests/Rule_Combo_Manifest.csv")
         manifest = helpers.get_data_frame(manifestPath)
 
+        # adjust rules and arguments as necessary for testing combinations
         for attribute in sg.se.schema['@graph']: #Doing it in a loop becasue of sg.se.edit_class design
             if 'sms:validationRules' in attribute and attribute['sms:validationRules']: 
+                # remove default combination for attribute's reules
+                if attribute['sms:displayName'] == 'Check NA':
+                    attribute['sms:validationRules'].remove('int')
+
+                # Add rule args if necessary
                 if base_rule in attribute['sms:validationRules'] or re.match(rule_regex, attribute['sms:validationRules'][0]):
-                    
-                    #Add rule args if necessary
                     if second_rule.startswith('matchAtLeastOne') or second_rule.startswith('matchExactlyOne'):
                         rule_args = f" MockComponent.{attribute['rdfs:label']} Patient.PatientID"
                     elif second_rule.startswith('inRange'):
@@ -390,8 +394,9 @@ class TestManifestValidation:
                         rule_args = ''
             
                     attribute['sms:validationRules'].append(second_rule + rule_args)
-                    sg.se.edit_class(attribute)
-                    break
+                
+                sg.se.edit_class(attribute)
+                break
 
         target_column=attribute['sms:displayName']
         for col in manifest.columns:


### PR DESCRIPTION
Add `IsNA` rule to check if manifest entries are marked as `Not Applicable`, to be used only in conjunction with other rules ~~using the `OR` operator to be implemented in #/1201~~.

This PR adds support for the combination of the new `IsNA` rule with `type` validation type rules `int`, `float`, and `num`, but not `str`. Implementation of rule combination functionality is intended to be temporary until after the refactor of the validation suite when general support for rule disjunction is implemented.

Tests are also included for the new rule. The data model attribute `Check NA` will test the behavior of the `int::IsNA` combo during the valid and invalid manifest tests. All combinations will be tested when `test_rule_combinations` is run.

The rule in its current form is only intended to be used by @andrewelamb for iAtlas, as such the addition of this rule **will not be documented** until rule disjunctions are officially supported and this rule is refactored.