### PR TITLE
Remove requirement for `.synapseConfig` file to use `upsert` feature

### DIFF
--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -256,7 +256,7 @@ paths:
           schema:
             type: string
             nullable: true
-          description: Data Model Component
+          description: Data Model Component. Providing a data type will also validate the manfiest against the rules specified for the data type's attributes.
           example: Patient
           required: true
         - in: query

--- a/api/openapi/api.yaml
+++ b/api/openapi/api.yaml
@@ -24,7 +24,7 @@ paths:
             https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld
           required: true
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
           description: Token is needed if getting an existing manifest on AWS
@@ -105,7 +105,7 @@ paths:
       description: Endpoint to download an existing manifest
       parameters:
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
             nullable: false
@@ -281,7 +281,7 @@ paths:
           description: If True, validation suite will only run with in-house validation rule. If False, the Great Expectations suite will be utilized and all rules will be available.
           required: true
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
             nullable: false
@@ -438,7 +438,7 @@ paths:
       operationId: api.routes.get_manifest_datatype
       parameters:
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
             nullable: false
@@ -475,7 +475,7 @@ paths:
       operationId: api.routes.get_storage_projects
       parameters:
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
             nullable: false
@@ -504,7 +504,7 @@ paths:
       operationId: api.routes.get_storage_projects_datasets
       parameters:
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
             nullable: false
@@ -541,7 +541,7 @@ paths:
       operationId: api.routes.get_files_storage_dataset
       parameters:
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
             nullable: false
@@ -594,7 +594,7 @@ paths:
       operationId: api.routes.get_asset_view_table
       parameters:
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
             nullable: false
@@ -631,7 +631,7 @@ paths:
       operationId: api.routes.get_project_manifests
       parameters:
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
             nullable: false
@@ -679,7 +679,7 @@ paths:
       operationId: api.routes.check_entity_type
       parameters:
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
             nullable: false
@@ -717,7 +717,7 @@ paths:
       operationId: api.routes.check_if_files_in_assetview
       parameters:
         - in: query
-          name: input_token
+          name: access_token
           schema:
             type: string
             nullable: false

--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -255,12 +255,9 @@ def migrate_manifests(
     """
     jsonld = fill_in_from_config("jsonld", jsonld, ("model", "input", "location"))
 
-    access_token = os.getenv("SYNAPSE_ACCESS_TOKEN")
+    
     full_scope = project_scope + [archive_project]
-    if access_token:
-        synStore = SynapseStorage(access_token = access_token, project_scope = full_scope)
-    else:
-        synStore = SynapseStorage(project_scope = full_scope)  
+    synStore = SynapseStorage(project_scope = full_scope)  
 
     for project in project_scope:
         if not return_entities:

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1510,7 +1510,7 @@ class ManifestGenerator(object):
                 return manifest_sh.url
 
     def get_manifest(
-        self, dataset_id: str = None, sheet_url: bool = None, json_schema: str = None, output_format: str = None, output_path: str = None, input_token: str = None
+        self, dataset_id: str = None, sheet_url: bool = None, json_schema: str = None, output_format: str = None, output_path: str = None, access_token: str = None
     ) -> Union[str, pd.DataFrame]:
         """Gets manifest for a given dataset on Synapse.
            TODO: move this function to class MetadatModel (after MetadataModel is refactored)
@@ -1520,7 +1520,7 @@ class ManifestGenerator(object):
             sheet_url: Determines if googlesheet URL or pandas dataframe should be returned.
             output_format: Determines if Google sheet URL, pandas dataframe, or Excel spreadsheet gets returned.
             output_path: Determines the output path of the exported manifest
-            input_token: Token in .synapseConfig. Since we could not pre-load access_token as an environment variable on AWS, we have to add this variable. 
+            access_token: Token in .synapseConfig. Since we could not pre-load access_token as an environment variable on AWS, we have to add this variable. 
 
         Returns:
             Googlesheet URL, pandas dataframe, or an Excel spreadsheet 
@@ -1542,9 +1542,9 @@ class ManifestGenerator(object):
         #TODO: avoid explicitly exposing Synapse store functionality
         # just instantiate a Store class and let it decide at runtime/config
         # the store type
-        if input_token: 
+        if access_token: 
             # for getting an existing manifest on AWS
-            store = SynapseStorage(input_token=input_token)
+            store = SynapseStorage(access_token=access_token)
         else: 
             store = SynapseStorage()
 

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -343,6 +343,7 @@ class MetadataModel(object):
                         useSchemaLabel = use_schema_label,
                         hideBlanks = hide_blanks,
                         table_manipulation=table_manipulation,
+                        access_token = access_token,
                     )
                     restrict_maniest = True
                 
@@ -355,6 +356,7 @@ class MetadataModel(object):
                     hideBlanks = hide_blanks,
                     restrict_manifest=restrict_maniest,
                     table_manipulation=table_manipulation,
+                    access_token = access_token,
                 )
 
                 logger.info(f"No validation errors occured during validation.")

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -343,7 +343,6 @@ class MetadataModel(object):
                         useSchemaLabel = use_schema_label,
                         hideBlanks = hide_blanks,
                         table_manipulation=table_manipulation,
-                        access_token = access_token,
                     )
                     restrict_maniest = True
                 
@@ -356,7 +355,6 @@ class MetadataModel(object):
                     hideBlanks = hide_blanks,
                     restrict_manifest=restrict_maniest,
                     table_manipulation=table_manipulation,
-                    access_token = access_token,
                 )
 
                 logger.info(f"No validation errors occured during validation.")

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -286,7 +286,7 @@ class MetadataModel(object):
         validate_component: str = None,
         use_schema_label: bool = True,
         hide_blanks: bool = False,
-        input_token: str = None,
+        access_token: str = None,
         project_scope: List = None,
         table_manipulation: str = 'replace'
     ) -> string:
@@ -306,7 +306,7 @@ class MetadataModel(object):
         #TODO: avoid explicitly exposing Synapse store functionality
         # just instantiate a Store class and let it decide at runtime/config
         # the store type
-        syn_store = SynapseStorage(input_token = input_token, project_scope = project_scope)
+        syn_store = SynapseStorage(access_token = access_token, project_scope = project_scope)
         manifest_id=None
         censored_manifest_id=None
         restrict_maniest=False

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -570,11 +570,7 @@ class ValidateAttribute(object):
         target_dataset_IDs=[]
         
         #login
-        access_token = getenv("SYNAPSE_ACCESS_TOKEN")
-        if access_token:
-            synStore = SynapseStorage(access_token=access_token,project_scope=project_scope)
-        else:
-            synStore = SynapseStorage(project_scope=project_scope)        
+        synStore = SynapseStorage(project_scope=project_scope)        
 
         #Get list of all projects user has access to
         projects = synStore.getStorageProjects(project_scope=project_scope)

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1726,6 +1726,15 @@ class SynapseStorage(BaseStorage):
         dataset_index = self.storageFileviewTable["id"] == datasetId
         dataset_row = self.storageFileviewTable[dataset_index]
 
+        # re-query if nothing found
+        if len(dataset_row) == 0:
+            sleep(5)
+            self._query_fileview()
+            # Subset main file view
+            dataset_index = self.storageFileviewTable["id"] == datasetId
+            dataset_row = self.storageFileviewTable[dataset_index]
+
+
         # Return `projectId` for given row if only one found
         if len(dataset_row) == 1:
             dataset_project = dataset_row["projectId"].values[0]

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1953,6 +1953,10 @@ class TableOperations:
         if env_access_token:
             authtoken = env_access_token
 
+        # Get token from authorization header
+        if 'Authorization' in synStore.syn.default_headers:
+            authtoken = synStore.syn.default_headers['Authorization'].split('Bearer ')[-1]
+
         # retrive credentials from synapse object
         synapse_object_creds = synStore.syn.credentials
         if hasattr(synapse_object_creds, 'username'):
@@ -1970,7 +1974,6 @@ class TableOperations:
             if config.has_option('authentication', 'authtoken'):
                 authtoken = config.get('authentication', 'authtoken')
         
-        # raise error if required credentials are not found
         if not (username and authtoken):
             raise NameError(
                 "Username or authtoken credentials could not be found in the environment, synapse object, or the .synapseConfig file"

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -81,7 +81,7 @@ class SynapseStorage(BaseStorage):
             syn_store = SynapseStorage()
         """
 
-        self.syn = self.login(token, access_token, input_token)
+        self.syn = self.login(token, access_token)
         self.project_scope = project_scope
 
 
@@ -137,9 +137,9 @@ class SynapseStorage(BaseStorage):
             raise AccessCredentialsError(self.storageFileview)        
 
     @staticmethod
-    def login(token=None, access_token=None, input_token=None):
+    def login(token=None, access_token=None):
         # If no token is provided, try retrieving access token from environment
-        if not token and not access_token and not input_token:
+        if not token and not access_token:
             access_token = os.getenv("SYNAPSE_ACCESS_TOKEN")
 
         # login using a token

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1974,15 +1974,12 @@ class TableOperations:
             if config.has_option('authentication', 'authtoken'):
                 authtoken = config.get('authentication', 'authtoken')
         
-        if not (username and authtoken):
+        # raise error if required credentials are not found
+        if not username and not authtoken:
             raise NameError(
                 "Username or authtoken credentials could not be found in the environment, synapse object, or the .synapseConfig file"
             )
-        if not username:
-            raise NameError(
-                "Username credentials could not be found in the environment, synapse object, or the .synapseConfig file"
-            )
-        if not username:
+        if not authtoken:
             raise NameError(
                 "authtoken credentials could not be found in the environment, synapse object, or the .synapseConfig file"
             )

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -64,7 +64,6 @@ class SynapseStorage(BaseStorage):
         self,
         token: str = None,  # optional parameter retrieved from browser cookie
         access_token: str = None,
-        input_token: str = None,
         project_scope: List = None,
     ) -> None:
         """Initializes a SynapseStorage object.
@@ -152,12 +151,9 @@ class SynapseStorage(BaseStorage):
             except synapseclient.core.exceptions.SynapseHTTPError:
                 raise ValueError("Please make sure you are logged into synapse.org.")
         elif access_token:
-            syn = synapseclient.Synapse()
-            syn.default_headers["Authorization"] = f"Bearer {access_token}"
-        elif input_token: 
-            try: 
+            try:
                 syn = synapseclient.Synapse()
-                syn.default_headers["Authorization"] = f"Bearer {input_token}"
+                syn.default_headers["Authorization"] = f"Bearer {access_token}"
             except synapseclient.core.exceptions.SynapseHTTPError:
                 raise ValueError("No access to resources. Please make sure that your token is correct")
         else:

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -154,6 +154,7 @@ class SynapseStorage(BaseStorage):
             try:
                 syn = synapseclient.Synapse()
                 syn.default_headers["Authorization"] = f"Bearer {access_token}"
+                syn.login(authToken=access_token, silent = True)
             except synapseclient.core.exceptions.SynapseHTTPError:
                 raise ValueError("No access to resources. Please make sure that your token is correct")
         else:

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -154,7 +154,6 @@ class SynapseStorage(BaseStorage):
             try:
                 syn = synapseclient.Synapse()
                 syn.default_headers["Authorization"] = f"Bearer {access_token}"
-                syn.login(authToken=access_token, silent = True)
             except synapseclient.core.exceptions.SynapseHTTPError:
                 raise ValueError("No access to resources. Please make sure that your token is correct")
         else:

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1956,15 +1956,18 @@ class TableOperations:
 
 
         # Get access token from environment variable if available
+        # Primarily useful for testing environments, with other possible usefulness for containers
         env_access_token = os.getenv("SYNAPSE_ACCESS_TOKEN")
         if env_access_token:
             authtoken = env_access_token
 
         # Get token from authorization header
+        # Primarily useful for API endpoint functionality
         if 'Authorization' in synStore.syn.default_headers:
             authtoken = synStore.syn.default_headers['Authorization'].split('Bearer ')[-1]
 
         # retrive credentials from synapse object
+        # Primarily useful for local users, could only be stored here when a .synapseConfig file is used, but including to be safe
         synapse_object_creds = synStore.syn.credentials
         if hasattr(synapse_object_creds, 'username'):
             username = synapse_object_creds.username
@@ -1972,6 +1975,7 @@ class TableOperations:
             authtoken = synapse_object_creds.secret
 
         # Try getting creds from .synapseConfig file if it exists
+        # Primarily useful for local users. Seems to correlate with credentials stored in synaspe object when logged in
         if os.path.exists(CONFIG.SYNAPSE_CONFIG_PATH):
             config = synStore.syn.getConfigFile(CONFIG.SYNAPSE_CONFIG_PATH)
 
@@ -1982,9 +1986,11 @@ class TableOperations:
                 authtoken = config.get('authentication', 'authtoken')
         
         # raise error if required credentials are not found
+        # providing an authtoken without a username did not prohibit upsert functionality, 
+        # but including username gathering for completeness for schematic_db
         if not username and not authtoken:
             raise NameError(
-                "Username or authtoken credentials could not be found in the environment, synapse object, or the .synapseConfig file"
+                "Username and authtoken credentials could not be found in the environment, synapse object, or the .synapseConfig file"
             )
         if not authtoken:
             raise NameError(

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1725,7 +1725,7 @@ class SynapseStorage(BaseStorage):
         dataset_row = self.storageFileviewTable[dataset_index]
 
         # re-query if no datasets found
-        if len(dataset_row) == 0:
+        if dataset_row.empty:
             sleep(5)
             self._query_fileview()
             # Subset main file view

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -781,6 +781,7 @@ class SynapseStorage(BaseStorage):
         restrict: bool = False, 
         useSchemaLabel: bool = True, 
         table_manipulation: str = 'replace',
+        access_token: str = None,
         ):
         """
         Method to upload a database to an asset store. In synapse, this will upload a metadata table
@@ -805,7 +806,7 @@ class SynapseStorage(BaseStorage):
 
         col_schema, table_manifest = self.formatDB(se, manifest, useSchemaLabel)
 
-        manifest_table_id = self.buildDB(datasetId, table_name, col_schema, table_manifest, table_manipulation, restrict)
+        manifest_table_id = self.buildDB(datasetId, table_name, col_schema, table_manifest, table_manipulation, restrict, access_token)
 
         return manifest_table_id, manifest, table_manifest
 
@@ -865,6 +866,7 @@ class SynapseStorage(BaseStorage):
         table_manifest: pd.DataFrame,
         table_manipulation: str,
         restrict: bool = False, 
+        access_token: str = None,
         ):
         """
         Method to construct the table appropriately: create new table, replace existing, or upsert new into existing
@@ -894,7 +896,7 @@ class SynapseStorage(BaseStorage):
             if table_manipulation.lower() == 'replace':
                 manifest_table_id = TableOperations.replaceTable(self, tableToLoad=table_manifest, tableName=table_name, existingTableId=table_info[table_name], specifySchema = True, datasetId = datasetId, columnTypeDict=col_schema, restrict=restrict)
             elif table_manipulation.lower() == 'upsert':
-                manifest_table_id = TableOperations.upsertTable(self, tableToLoad = table_manifest, tableName=table_name, existingTableId=table_info[table_name], datasetId=datasetId)
+                manifest_table_id = TableOperations.upsertTable(self, tableToLoad = table_manifest, tableName=table_name, existingTableId=table_info[table_name], datasetId=datasetId, access_token=access_token)
             elif table_manipulation.lower() == 'update':
                 manifest_table_id = TableOperations.updateTable(self, tableToLoad=table_manifest, existingTableId=table_info[table_name], restrict=restrict)
 
@@ -1267,6 +1269,7 @@ class SynapseStorage(BaseStorage):
                             useSchemaLabel,
                             hideBlanks,
                             table_manipulation,
+                            access_token,
                             ):
         """Upload manifest to Synapse as a table and csv.
         Args:
@@ -1293,7 +1296,8 @@ class SynapseStorage(BaseStorage):
                                                     table_name,
                                                     restrict,
                                                     useSchemaLabel,
-                                                    table_manipulation)
+                                                    table_manipulation,
+                                                    access_token)
 
         manifest = self.add_entities(se, schemaGenerator, manifest, manifest_record_type, datasetId, useSchemaLabel, hideBlanks, manifest_synapse_table_id)
         # Load manifest to synapse as a CSV File
@@ -1312,7 +1316,9 @@ class SynapseStorage(BaseStorage):
                                                     table_name,  
                                                     restrict,
                                                     useSchemaLabel=useSchemaLabel,
-                                                    table_manipulation='update',)
+                                                    table_manipulation='update',
+                                                    access_token=access_token,
+                                                    )
 
         # Set annotations for the table manifest
         manifest_annotations = self.format_manifest_annotations(manifest, manifest_synapse_table_id)
@@ -1377,6 +1383,7 @@ class SynapseStorage(BaseStorage):
                             useSchemaLabel,
                             hideBlanks,
                             table_manipulation,
+                            access_token
                             ):
         """Upload manifest to Synapse as a table and CSV with entities.
         Args:
@@ -1402,7 +1409,9 @@ class SynapseStorage(BaseStorage):
                                                     table_name,
                                                     restrict,
                                                     useSchemaLabel=useSchemaLabel,
-                                                    table_manipulation=table_manipulation,)
+                                                    table_manipulation=table_manipulation,
+                                                    access_token=access_token,
+                                                    )
 
         manifest = self.add_entities(se, schemaGenerator, manifest, manifest_record_type, datasetId, useSchemaLabel, hideBlanks, manifest_synapse_table_id)
         
@@ -1422,7 +1431,9 @@ class SynapseStorage(BaseStorage):
                                                                 table_name,
                                                                 restrict,
                                                                 useSchemaLabel=useSchemaLabel,
-                                                                table_manipulation='update',)
+                                                                table_manipulation='update',
+                                                                access_token=access_token,
+                                                                )
 
         # Set annotations for the table manifest
         manifest_annotations = self.format_manifest_annotations(manifest, manifest_synapse_table_id)
@@ -1431,7 +1442,7 @@ class SynapseStorage(BaseStorage):
 
     def associateMetadataWithFiles(
         self, schemaGenerator: SchemaGenerator, metadataManifestPath: str, datasetId: str, manifest_record_type: str = 'table_file_and_entities', 
-        useSchemaLabel: bool = True, hideBlanks: bool = False, restrict_manifest = False, table_manipulation: str = 'replace',
+        useSchemaLabel: bool = True, hideBlanks: bool = False, restrict_manifest = False, table_manipulation: str = 'replace', access_token: str = None,
     ) -> str:
         """Associate metadata with files in a storage dataset already on Synapse.
         Upload metadataManifest in the storage dataset folder on Synapse as well. Return synapseId of the uploaded manifest file.
@@ -1499,6 +1510,7 @@ class SynapseStorage(BaseStorage):
                                         hideBlanks=hideBlanks,
                                         manifest_record_type=manifest_record_type,
                                         table_manipulation=table_manipulation,
+                                        access_token=access_token,
                                         )
         elif manifest_record_type == "file_and_entities":
             manifest_synapse_file_id = self.upload_manifest_as_csv( 
@@ -1528,6 +1540,7 @@ class SynapseStorage(BaseStorage):
                                         hideBlanks=hideBlanks,
                                         manifest_record_type=manifest_record_type,
                                         table_manipulation=table_manipulation,
+                                        access_token=access_token,
                                         )
         else:
             raise ValueError("Please enter a valid manifest_record_type.")
@@ -1950,7 +1963,7 @@ class TableOperations:
         return existingTableId
     
 
-    def _get_schematic_db_creds(synStore):
+    def _get_schematic_db_creds(synStore, access_token):
         username = None
         authtoken = None
 
@@ -1961,10 +1974,10 @@ class TableOperations:
         if env_access_token:
             authtoken = env_access_token
 
-        # Get token from authorization header
+        # Get token passed in from api endpoint
         # Primarily useful for API endpoint functionality
-        if 'Authorization' in synStore.syn.default_headers:
-            authtoken = synStore.syn.default_headers['Authorization'].split('Bearer ')[-1]
+        if access_token:
+            authtoken = access_token
 
         # retrive credentials from synapse object
         # Primarily useful for local users, could only be stored here when a .synapseConfig file is used, but including to be safe
@@ -1999,7 +2012,7 @@ class TableOperations:
         
         return username, authtoken
 
-    def upsertTable(synStore, tableToLoad: pd.DataFrame = None, tableName: str = None, existingTableId: str = None,  datasetId: str = None):
+    def upsertTable(synStore, tableToLoad: pd.DataFrame = None, tableName: str = None, existingTableId: str = None,  datasetId: str = None, access_token: str = None):
         """
         Method to upsert rows from a new manifest into an existing table on synapse
         For upsert functionality to work, primary keys must follow the naming convention of <componenet>_id        
@@ -2019,7 +2032,7 @@ class TableOperations:
            existingTableId: synID of the already existing table that had its metadata replaced
         """            
 
-        username, authtoken = TableOperations._get_schematic_db_creds(synStore)
+        username, authtoken = TableOperations._get_schematic_db_creds(synStore, access_token)
 
         synConfig = SynapseConfig(username, authtoken, synStore.getDatasetProject(datasetId))
         synapseDB = SynapseDatabase(synConfig)

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1720,13 +1720,11 @@ class SynapseStorage(BaseStorage):
             str: The Synapse ID for the parent project.
         """
 
-        self._query_fileview()
-
         # Subset main file view
         dataset_index = self.storageFileviewTable["id"] == datasetId
         dataset_row = self.storageFileviewTable[dataset_index]
 
-        # re-query if nothing found
+        # re-query if no datasets found
         if len(dataset_row) == 0:
             sleep(5)
             self._query_fileview()

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1960,11 +1960,13 @@ class TableOperations:
         env_access_token = os.getenv("SYNAPSE_ACCESS_TOKEN")
         if env_access_token:
             authtoken = env_access_token
+            return username, authtoken
 
         # Get token from authorization header
         # Primarily useful for API endpoint functionality
         if 'Authorization' in synStore.syn.default_headers:
             authtoken = synStore.syn.default_headers['Authorization'].split('Bearer ')[-1]
+            return username, authtoken
 
         # retrive credentials from synapse object
         # Primarily useful for local users, could only be stored here when a .synapseConfig file is used, but including to be safe

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -40,4 +40,4 @@ Check Date,,,,,TRUE,DataProperty,,,date
 Check NA,,,,,TRUE,DataProperty,,,int::IsNA
 MockRDB,,,"Component, MockRDB_id",,FALSE,DataType,,,
 MockRDB_id,,,,,TRUE,DataProperty,,,int
-Mock Attribute,,,,,TRUE,DataProperty,,,
+MockAttribute,,,,,TRUE,DataProperty,,,

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -40,3 +40,4 @@ Check Date,,,,,TRUE,DataProperty,,,date
 Check NA,,,,,TRUE,DataProperty,,,int::IsNA
 MockRDB,,,"Component, MockRDB_id",,FALSE,DataType,,,
 MockRDB_id,,,,,TRUE,DataProperty,,,int
+Mock Attribute,,,,,TRUE,DataProperty,,,

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -38,6 +38,6 @@ Check Unique,,,,,TRUE,DataProperty,,,unique error
 Check Range,,,,,TRUE,DataProperty,,,inRange 50 100 error
 Check Date,,,,,TRUE,DataProperty,,,date
 Check NA,,,,,TRUE,DataProperty,,,int::IsNA
-MockRDB,,,"Component, MockRDB_id",,FALSE,DataType,,,
+MockRDB,,,"Component, MockRDB_id, SourceManifest",,FALSE,DataType,,,
 MockRDB_id,,,,,TRUE,DataProperty,,,int
-MockAttribute,,,,,TRUE,DataProperty,,,
+SourceManifest,,,,,TRUE,DataProperty,,,

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2944,6 +2944,9 @@
                 },
                 {
                     "@id": "bts:MockRDBId"
+                },
+                {
+                    "@id": "bts:SourceManifest"
                 }
             ],
             "sms:validationRules": []
@@ -2968,10 +2971,10 @@
             ]
         },
         {
-            "@id": "bts:MockAttribute",
+            "@id": "bts:SourceManifest",
             "@type": "rdfs:Class",
             "rdfs:comment": "TBD",
-            "rdfs:label": "MockAttribute",
+            "rdfs:label": "SourceManifest",
             "rdfs:subClassOf": [
                 {
                     "@id": "bts:DataProperty"
@@ -2980,7 +2983,7 @@
             "schema:isPartOf": {
                 "@id": "http://schema.biothings.io"
             },
-            "sms:displayName": "MockAttribute",
+            "sms:displayName": "SourceManifest",
             "sms:required": "sms:true",
             "sms:validationRules": []
         },

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2980,7 +2980,7 @@
             "schema:isPartOf": {
                 "@id": "http://schema.biothings.io"
             },
-            "sms:displayName": "Mock Attribute",
+            "sms:displayName": "MockAttribute",
             "sms:required": "sms:true",
             "sms:validationRules": []
         },

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2968,6 +2968,23 @@
             ]
         },
         {
+            "@id": "bts:MockAttribute",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "MockAttribute",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Mock Attribute",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
             "@id": "bts:Component",
             "@type": "rdfs:Class",
             "rdfs:comment": "TBD",

--- a/tests/data/example.single_rule.model.jsonld
+++ b/tests/data/example.single_rule.model.jsonld
@@ -2920,7 +2920,7 @@
             "sms:required": "sms:false",
             "sms:validationRules": [
                 "int error",
-                "IsNA"
+                "IsNA warning"
             ]
         },
         {
@@ -2944,6 +2944,9 @@
                 },
                 {
                     "@id": "bts:MockRDBId"
+                },
+                {
+                    "@id": "bts:SourceManifest"
                 }
             ],
             "sms:validationRules": []
@@ -2966,6 +2969,23 @@
             "sms:validationRules": [
                 "int"
             ]
+        },
+        {
+            "@id": "bts:SourceManifest",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "SourceManifest",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "SourceManifest",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
         },
         {
             "@id": "bts:Component",

--- a/tests/data/mock_manifests/rdb_table_manifest.csv
+++ b/tests/data/mock_manifests/rdb_table_manifest.csv
@@ -1,4 +1,4 @@
-Component,MockRDB_id,Mock Attribute
+Component,MockRDB_id,MockAttribute
 MockRDB,1,Manifest1
 MockRDB,2,Manifest1
 MockRDB,3,Manifest1

--- a/tests/data/mock_manifests/rdb_table_manifest.csv
+++ b/tests/data/mock_manifests/rdb_table_manifest.csv
@@ -1,4 +1,4 @@
-Component,MockRDB_id,MockAttribute
+Component,MockRDB_id,SourceManifest
 MockRDB,1,Manifest1
 MockRDB,2,Manifest1
 MockRDB,3,Manifest1

--- a/tests/data/mock_manifests/rdb_table_manifest.csv
+++ b/tests/data/mock_manifests/rdb_table_manifest.csv
@@ -1,5 +1,5 @@
-Component,MockRDB_id
-MockRDB,1
-MockRDB,2
-MockRDB,3
-MockRDB,4
+Component,MockRDB_id,Mock Attribute
+MockRDB,1,Manifest1
+MockRDB,2,Manifest1
+MockRDB,3,Manifest1
+MockRDB,4,Manifest1

--- a/tests/data/mock_manifests/rdb_table_manifest_upsert.csv
+++ b/tests/data/mock_manifests/rdb_table_manifest_upsert.csv
@@ -1,4 +1,4 @@
-Component,MockRDB_id,Mock Attribute
+Component,MockRDB_id,MockAttribute
 MockRDB,5,Manifest2
 MockRDB,6,Manifest2
 MockRDB,7,Manifest2

--- a/tests/data/mock_manifests/rdb_table_manifest_upsert.csv
+++ b/tests/data/mock_manifests/rdb_table_manifest_upsert.csv
@@ -1,5 +1,6 @@
-Component,MockRDB_id
-MockRDB,5
-MockRDB,6
-MockRDB,7
-MockRDB,8
+Component,MockRDB_id,Mock Attribute
+MockRDB,5,Manifest2
+MockRDB,6,Manifest2
+MockRDB,7,Manifest2
+MockRDB,8,Manifest2
+MockRDB,4,Manifest2

--- a/tests/data/mock_manifests/rdb_table_manifest_upsert.csv
+++ b/tests/data/mock_manifests/rdb_table_manifest_upsert.csv
@@ -1,4 +1,4 @@
-Component,MockRDB_id,MockAttribute
+Component,MockRDB_id,SourceManifest
 MockRDB,5,Manifest2
 MockRDB,6,Manifest2
 MockRDB,7,Manifest2

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,7 +88,7 @@ class TestSynapseStorage:
     @pytest.mark.parametrize("return_type", ["json", "csv"])
     def test_get_storage_assets_tables(self, client, syn_token, return_type):
         params = {
-            "input_token": syn_token,
+            "access_token": syn_token,
             "asset_view": "syn23643253",
             "return_type": return_type
         }
@@ -114,7 +114,7 @@ class TestSynapseStorage:
     @pytest.mark.parametrize("file_names", [None, "Sample_A.txt"])
     def test_get_dataset_files(self,full_path, file_names, syn_token, client):
         params = {
-            "input_token": syn_token,
+            "access_token": syn_token,
             "asset_view": "syn23643253",
             "dataset_id": "syn23643250",
             "full_path": full_path,
@@ -142,7 +142,7 @@ class TestSynapseStorage:
         
     def test_get_storage_project_dataset(self, syn_token, client):
         params = {
-        "input_token": syn_token,
+        "access_token": syn_token,
         "asset_view": "syn23643253",
         "project_id": "syn26251192"
         }
@@ -155,7 +155,7 @@ class TestSynapseStorage:
     def test_get_storage_project_manifests(self, syn_token, client):
 
         params = {
-        "input_token": syn_token,
+        "access_token": syn_token,
         "asset_view": "syn23643253",
         "project_id": "syn30988314"
         }
@@ -167,7 +167,7 @@ class TestSynapseStorage:
     def test_get_storage_projects(self, syn_token, client):
 
         params = {
-        "input_token": syn_token,
+        "access_token": syn_token,
         "asset_view": "syn23643253"
         }
 
@@ -178,7 +178,7 @@ class TestSynapseStorage:
     @pytest.mark.parametrize("entity_id", ["syn34640850", "syn23643253", "syn24992754"])
     def test_get_entity_type(self, syn_token, client, entity_id):
         params = {
-            "input_token": syn_token,
+            "access_token": syn_token,
             "asset_view": "syn23643253",
             "entity_id": entity_id
         }
@@ -196,7 +196,7 @@ class TestSynapseStorage:
     @pytest.mark.parametrize("entity_id", ["syn30988314", "syn27221721"])
     def test_if_in_assetview(self, syn_token, client, entity_id):
         params = {
-            "input_token": syn_token,
+            "access_token": syn_token,
             "asset_view": "syn23643253",
             "entity_id": entity_id
         }
@@ -409,7 +409,7 @@ class TestManifestOperation:
             "title": "Example",
             "data_type": data_type,
             "use_annotations": False, 
-            "input_token": None
+            "access_token": None
             }
         if dataset_id: 
             params['dataset_id'] = dataset_id
@@ -455,7 +455,7 @@ class TestManifestOperation:
             "data_type": data_type,
             "use_annotations": False,
             "dataset_id": None,
-            "input_token": None
+            "access_token": None
         }
 
         if output_format: 
@@ -557,7 +557,7 @@ class TestManifestOperation:
 
     def test_get_datatype_manifest(self, client, syn_token):
         params = {
-            "input_token": syn_token,
+            "access_token": syn_token,
             "asset_view": "syn23643253",
             "manifest_id": "syn27600110"
         }
@@ -580,7 +580,7 @@ class TestManifestOperation:
     @pytest.mark.parametrize("new_manifest_name", [None, "Test"])
     def test_manifest_download(self, client, as_json, syn_token, new_manifest_name):
         params = {
-            "input_token": syn_token,
+            "access_token": syn_token,
             "asset_view": "syn28559058",
             "dataset_id": "syn28268700",
             "as_json": as_json,
@@ -606,7 +606,7 @@ class TestManifestOperation:
     @pytest.mark.parametrize("manifest_record_type", ['table_and_file', 'file_only'])
     def test_submit_manifest(self, client, syn_token, data_model_jsonld, json_str, test_manifest_csv, use_schema_label, manifest_record_type):
         params = {
-            "input_token": syn_token,
+            "access_token": syn_token,
             "schema_url": data_model_jsonld,
             "data_type": "Patient",
             "restrict_rules": False, 
@@ -636,7 +636,7 @@ class TestManifestOperation:
     @pytest.mark.parametrize("manifest_record_type", ['file_and_entities', 'table_file_and_entities'])
     def test_submit_manifest_w_entities(self, client, syn_token, data_model_jsonld, json_str, test_manifest_csv, manifest_record_type):
         params = {
-            "input_token": syn_token,
+            "access_token": syn_token,
             "schema_url": data_model_jsonld,
             "data_type": "Patient",
             "restrict_rules": False, 
@@ -666,7 +666,7 @@ class TestManifestOperation:
     @pytest.mark.parametrize("json_str", [None, '[{ "Component": "MockRDB", "MockRDB_id": 5 }]'])
     def test_submit_manifest_upsert(self, client, syn_token, data_model_jsonld, json_str, test_upsert_manifest_csv, ):
         params = {
-            "input_token": syn_token,
+            "access_token": syn_token,
             "schema_url": data_model_jsonld,
             "data_type": "MockRDB",
             "restrict_rules": False, 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -380,7 +380,7 @@ class TestTableOperations:
         table_name="MockRDB_synapse_storage_manifest_table".lower()
         manifest_path = "mock_manifests/rdb_table_manifest.csv"
         replacement_manifest_path = "mock_manifests/rdb_table_manifest_upsert.csv"
-        column_of_interest="MockRDB_id"   
+        column_of_interest="MockRDB_id,MockAttribute"
         
         # Check if FollowUp table exists if so delete
         existing_tables = synapse_store.get_table_info(projectId = projectId)        
@@ -412,13 +412,14 @@ class TestTableOperations:
         tableId = existing_tables[table_name]
 
         # Query table for DaystoFollowUp column        
-        IDs = synapse_store.syn.tableQuery(
+        table_query = synapse_store.syn.tableQuery(
             f"SELECT {column_of_interest} FROM {tableId}"
         ).asDataFrame().squeeze()
 
         # assert max ID is '4' and that there are 4 entries
-        assert IDs.max() == 4
-        assert IDs.size == 4
+        assert table_query.MockRDB_id.max() == 4
+        assert table_query.MockRDB_id.size == 4
+        assert table_query['MockAttribute'][3] == 'Manifest1'
         
         # Associate new manifest with files
         manifestId = synapse_store.associateMetadataWithFiles(
@@ -435,12 +436,13 @@ class TestTableOperations:
         
         # Query table for DaystoFollowUp column        
         tableId = existing_tables[table_name]
-        IDs = synapse_store.syn.tableQuery(
+        table_query = synapse_store.syn.tableQuery(
             f"SELECT {column_of_interest} FROM {tableId}"
         ).asDataFrame().squeeze()
 
         # assert max ID is '4' and that there are 4 entries
-        assert IDs.max() == 8
-        assert IDs.size == 8
+        assert table_query.MockRDB_id.max() == 8
+        assert table_query.MockRDB_id.size == 8
+        assert table_query['MockAttribute'][3] == 'Manifest2'
         # delete table        
         synapse_store.syn.delete(tableId)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -380,7 +380,7 @@ class TestTableOperations:
         table_name="MockRDB_synapse_storage_manifest_table".lower()
         manifest_path = "mock_manifests/rdb_table_manifest.csv"
         replacement_manifest_path = "mock_manifests/rdb_table_manifest_upsert.csv"
-        column_of_interest="MockRDB_id,MockAttribute"
+        column_of_interest="MockRDB_id,SourceManifest"
         
         # Check if FollowUp table exists if so delete
         existing_tables = synapse_store.get_table_info(projectId = projectId)        
@@ -419,7 +419,7 @@ class TestTableOperations:
         # assert max ID is '4' and that there are 4 entries
         assert table_query.MockRDB_id.max() == 4
         assert table_query.MockRDB_id.size == 4
-        assert table_query['MockAttribute'][3] == 'Manifest1'
+        assert table_query['SourceManifest'][3] == 'Manifest1'
         
         # Associate new manifest with files
         manifestId = synapse_store.associateMetadataWithFiles(
@@ -443,6 +443,6 @@ class TestTableOperations:
         # assert max ID is '4' and that there are 4 entries
         assert table_query.MockRDB_id.max() == 8
         assert table_query.MockRDB_id.size == 8
-        assert table_query['MockAttribute'][3] == 'Manifest2'
+        assert table_query['SourceManifest'][3] == 'Manifest2'
         # delete table        
         synapse_store.syn.delete(tableId)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -68,7 +68,6 @@ def datasetId(synapse_store, projectId, helpers):
     datasetId = synapse_store.syn.store(dataset).id
     sleep(5)
     yield datasetId
-    synapse_store.syn.delete(datasetId)
 
 
 def raise_final_error(retry_state):


### PR DESCRIPTION
Update credential gathering process for support of `schematic_db` use so that other log in methods besides the `.synapseConfig` file are supported. 
The API endpoints and relevant functions were also simplified to remove a parameter that was a duplicate of another.
Table upsert tests were also updated to ensure "update" functionality works as expected