### PR TITLE
Introduce workflow for API tests

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -1,0 +1,110 @@
+# Built from:
+# https://docs.github.com/en/actions/guides/building-and-testing-python
+# https://github.com/Sage-Bionetworks/challengeutils/blob/master/.github/workflows/pythonapp.yml
+# https://github.com/snok/install-poetry#workflows-and-tips
+
+name: Test schematic
+
+on:
+  workflow_dispatch:  # Allow manually triggering the workflow
+  inputs:
+    perform_benchmarking:
+      type: boolean
+      description: perform benchmarking test (True) or skip (False)
+concurrency:
+  # do not cancel the current running workflow from the same branch, PR when a new workflow is triggered
+  # when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group
+  # {{ github.workflow }}: the workflow name is used to generate the concurrency group. This allows you to have more than one workflows
+  # {{ github.ref_type }}: the type of Git ref object created in the repository. Can be either branch or tag
+  # {{ github.event.pull_request.number}}: get PR number
+  # {{ github.sha }}: full commit sha
+  # credit: https://github.com/Sage-Bionetworks-Workflows/sagetasks/blob/main/.github/workflows/ci.yml
+  group: >-
+    ${{ github.workflow }}-${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: false
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      POETRY_VERSION:  1.2.0rc1
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
+
+    steps:
+
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      #----------------------------------------------
+      #          install & configure poetry
+      #----------------------------------------------
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org \
+            | python3 - --version ${{ env.POETRY_VERSION }};
+          poetry config virtualenvs.create true;
+          poetry config virtualenvs.in-project true;
+      #----------------------------------------------
+      #       load cached venv if cache exists
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      #----------------------------------------------
+      # install dependencies if cache does not exist
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root --all-extras
+
+      #----------------------------------------------
+      #    install your root project, if required
+      #----------------------------------------------
+      - name: Install library
+        run: poetry install --no-interaction
+
+      #----------------------------------------------
+      #              run API test suite
+      #----------------------------------------------
+      - name: Run all API tests
+        env:
+          SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
+          SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
+        if: ${{ inputs.perform_benchmarking }}
+        run: >
+          source .venv/bin/activate;
+          pytest --cov-report=term --cov-report=html:htmlcov --cov=schematic/
+          -m "schematic_api"
+
+      - name: Run API tests + Exclude Benchmarks
+        env:
+          SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
+          SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
+        if: ${{ false == inputs.perform_benchmarking }}
+        run: >
+          source .venv/bin/activate;
+          pytest --cov-report=term --cov-report=html:htmlcov --cov=schematic/
+          -m "schematic_api and not rule_benchmark"
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: pytest-results-${{ matrix.python-version }}
+          path: htmlcov
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -11,18 +11,6 @@ on:
         type: boolean
         description: perform benchmarking test (True) or skip (False)
 
-concurrency:
-  # do not cancel the current running workflow from the same branch, PR when a new workflow is triggered
-  # when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group
-  # {{ github.workflow }}: the workflow name is used to generate the concurrency group. This allows you to have more than one workflows
-  # {{ github.ref_type }}: the type of Git ref object created in the repository. Can be either branch or tag
-  # {{ github.event.pull_request.number}}: get PR number
-  # {{ github.sha }}: full commit sha
-  # credit: https://github.com/Sage-Bionetworks-Workflows/sagetasks/blob/main/.github/workflows/ci.yml
-  group: >-
-    ${{ github.workflow }}-${{ github.ref_type }}-
-    ${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: false
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -1,5 +1,6 @@
 # Built from:
 # https://github.com/Sage-Bionetworks/schematic/blob/develop/.github/workflows/test.yml
+
 name: Test schematic API
 
 on:

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -3,7 +3,7 @@
 # https://github.com/Sage-Bionetworks/challengeutils/blob/master/.github/workflows/pythonapp.yml
 # https://github.com/snok/install-poetry#workflows-and-tips
 
-name: Test schematic
+name: Test schematic API
 
 on:
   workflow_dispatch:  # Allow manually triggering the workflow

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -39,7 +39,7 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -1,16 +1,15 @@
 # Built from:
-# https://docs.github.com/en/actions/guides/building-and-testing-python
-# https://github.com/Sage-Bionetworks/challengeutils/blob/master/.github/workflows/pythonapp.yml
-# https://github.com/snok/install-poetry#workflows-and-tips
-
+# https://github.com/Sage-Bionetworks/schematic/blob/develop/.github/workflows/test.yml
 name: Test schematic API
 
 on:
-  workflow_dispatch:  # Allow manually triggering the workflow
-  inputs:
-    perform_benchmarking:
-      type: boolean
-      description: perform benchmarking test (True) or skip (False)
+  workflow_dispatch:
+    inputs:
+      perform_benchmarking:
+        required: true
+        type: boolean
+        description: perform benchmarking test (True) or skip (False)
+
 concurrency:
   # do not cancel the current running workflow from the same branch, PR when a new workflow is triggered
   # when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -76,8 +76,7 @@ jobs:
         if: ${{ inputs.perform_benchmarking }}
         run: >
           source .venv/bin/activate;
-          pytest --cov-report=term --cov-report=html:htmlcov --cov=schematic/
-          -m "schematic_api"
+          pytest -m "schematic_api"
 
       - name: Run API tests + Exclude Benchmarks
         env:
@@ -86,13 +85,5 @@ jobs:
         if: ${{ false == inputs.perform_benchmarking }}
         run: >
           source .venv/bin/activate;
-          pytest --cov-report=term --cov-report=html:htmlcov --cov=schematic/
-          -m "schematic_api and not rule_benchmark"
-
-      - name: Upload pytest test results
-        uses: actions/upload-artifact@v2
-        with:
-          name: pytest-results-${{ matrix.python-version }}
-          path: htmlcov
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
+          pytest -m "schematic_api and not rule_benchmark"
+          

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -27,7 +27,7 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ markers = [
     table_operations: marks tests covering \
     table operations that pass locally \
     but fail on CI due to interactions with Synapse (skipped on GitHub CI)   
-    """    
+    """,    
     """\
     rule_benchmark: marks tests covering \
     validation rule benchmarking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,4 +132,8 @@ markers = [
     table operations that pass locally \
     but fail on CI due to interactions with Synapse (skipped on GitHub CI)   
     """    
+    """\
+    rule_benchmark: marks tests covering \
+    validation rule benchmarking
+    """    
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,8 +119,8 @@ markers = [
     Google credentials (skipped on GitHub CI) \
     """,
     """\
-    schematic_api: marks tests requiring \
-    running API locally (skipped on GitHub CI)   
+    schematic_api: marks tests covering \
+    API functionality (skipped on regular GitHub CI test suite)   
     """,
     """\
     rule_combos: marks tests covering \

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -76,7 +76,8 @@ def syn_token(config):
     # try using synapse access token
     if "SYNAPSE_ACCESS_TOKEN" in os.environ:
         token=os.environ["SYNAPSE_ACCESS_TOKEN"]
-    token = config_parser["authentication"]["authtoken"]
+    else:
+        token = config_parser["authentication"]["authtoken"]
     yield token
 
 @pytest.mark.schematic_api

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -730,6 +730,7 @@ class TestSchemaVisualization:
         assert response_text in response.text
 
 @pytest.mark.schematic_api
+@pytest.mark.rule_benchmark
 class TestValidationBenchmark():
     @pytest.mark.parametrize('MockComponent_attribute', get_MockComponent_attribute())
     def test_validation_performance(self, helpers, benchmark_data_model_jsonld, client, test_invalid_manifest, MockComponent_attribute ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,10 +14,6 @@ from schematic.schemas.generator import SchemaGenerator #Local application/libra
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-'''
-To run the tests, you have to keep API running locally first by doing `python3 run_api.py`
-'''
-
 @pytest.fixture(scope="class")
 def app():
     app = create_app()


### PR DESCRIPTION
Added workflow separate from regular unit test suite to run API tests when manually triggered.

This would allow me to test the function of the API without encountering the timeout issues of codespace or issues on windows.
Others can use as well when necessary as it can be triggered for any branch.

Note: it appears that the UI to manually trigger a run [won't be available through GH](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) until this branch is merged with our default branch 
> Note: This event will only trigger a workflow run if the workflow file is on the default branch.

[Test runs](https://github.com/Sage-Bionetworks/schematic/actions/workflows/api_test.yml) of the workflow were triggered manually through the GitHub CLI to verify correct performance

Failing tests seem to be  the ones identified previously in #1195, with the addition of the case `[table_and_file-false-[*** "Patient ID": 123, "Sex": "Female", "Year of Birth": "", "Diagnosis": "Healthy", "Component": "Patient", "Cancer Type": "Breast", "Family History": "Breast, Lung", ***]]` for `test_submit_manifest` that was already failing with other cases