### PR TITLE
Downloaded manifests to temporary folders on AWS

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -45,6 +45,8 @@ from schematic_db.synapse.synapse import SynapseConfig
 from schematic_db.rdb.synapse_database import SynapseDatabase
 from schematic_db.schema.schema import get_key_attribute
 
+from synapseclient.entity import File
+
 from schematic.utils.df_utils import update_df, load_df
 from schematic.utils.general import create_temp_folder
 from schematic.utils.validate_utils import comma_separated_list_regex, rule_in_rule_list
@@ -67,15 +69,14 @@ class ManifestDownload(object):
     syn: synapseclient.Synapse
     manifest_id: str
 
-    def _download_manifest_to_folder(self):
+    def _download_manifest_to_folder(self) -> File:
         """
         try downloading a manifest to local cache or a given folder
         manifest
         Return: 
-            manifest_data: A new Synapse Entity object of the appropriate type
+            manifest_data: synapse file entity
         """
-         # TO DO: potentially deprecate the if else statement because "manifest_folder" key always exist in config
-
+        # TO DO: potentially deprecate the if else statement because "manifest_folder" key always exist in config
         # on AWS, to avoid overriding manifest, we download the manifest to a temporary folder
         if "SECRETS_MANAGER_SECRETS" in os.environ:
             temporary_manifest_storage = "/var/tmp/temp_manifest_download"
@@ -101,7 +102,7 @@ class ManifestDownload(object):
                     )
         return manifest_data 
 
-    def _entity_type_checking(self):
+    def _entity_type_checking(self) -> str:
         """
         check the entity type of the id that needs to be downloaded
         Return: 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -74,7 +74,7 @@ class ManifestDownload(object):
         try downloading a manifest to local cache or a given folder
         manifest
         Return: 
-            manifest_data: synapse file entity
+            manifest_data: A Synapse file entity of the downloaded manifest
         """
         # TO DO: potentially deprecate the if else statement because "manifest_folder" key always exist in config
         # on AWS, to avoid overriding manifest, we download the manifest to a temporary folder

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -76,7 +76,7 @@ class ManifestDownload(object):
         Return: 
             manifest_data: A Synapse file entity of the downloaded manifest
         """
-        # TO DO: potentially deprecate the if else statement because "manifest_folder" key always exist in config
+        # TO DO: potentially deprecate the if else statement because "manifest_folder" key always exist in config (See issue FDS-349 in Jira)
         # on AWS, to avoid overriding manifest, we download the manifest to a temporary folder
         if "SECRETS_MANAGER_SECRETS" in os.environ:
             temporary_manifest_storage = "/var/tmp/temp_manifest_download"

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -89,17 +89,18 @@ class ManifestDownload(object):
 
         else:
             download_location=None
-
-        if download_location: 
+        
+        if not download_location:
+            manifest_data = self.syn.get(
+                        self.manifest_id,
+                    )
+        # if download_location is provided and it is not an empty string
+        else:
             manifest_data = self.syn.get(
                     self.manifest_id,
                     downloadLocation=download_location,
                     ifcollision="overwrite.local",
                 )
-        else:
-            manifest_data = self.syn.get(
-                        self.manifest_id,
-                    )
         return manifest_data 
 
     def _entity_type_checking(self) -> str:

--- a/schematic/utils/general.py
+++ b/schematic/utils/general.py
@@ -7,6 +7,8 @@ import pstats
 from cProfile import Profile
 from functools import wraps
 
+import tempfile
+
 from synapseclient.core.exceptions import SynapseHTTPError
 from synapseclient.table import EntityViewSchema
 from synapseclient.entity import File, Folder, Project
@@ -114,7 +116,21 @@ def entity_type_mapping(syn, entity_id):
     else:
         # if there's no matching type, return concreteType
         return entity.concreteType
-        
+
+def create_temp_folder(path):
+    """This function creates a temporary directory in the specified directory 
+    Args:
+        path: a directory path where all the temporary files will live
+    Returns: returns the absolute pathname of the new directory.
+    """
+    # Create a temporary directory in the specified directory
+    try:
+        path = tempfile.mkdtemp(dir=path)
+        return path
+    except FileNotFoundError:
+        raise FileNotFoundError(f'Folder path not found: {path}')
+
+
 def profile(output_file=None, sort_by='cumulative', lines_to_print=None, strip_dirs=False):
     """
     The function was initially taken from: https://towardsdatascience.com/how-to-profile-your-code-in-python-e70c834fad89

--- a/schematic/utils/general.py
+++ b/schematic/utils/general.py
@@ -124,11 +124,8 @@ def create_temp_folder(path: str) -> str:
     Returns: returns the absolute pathname of the new directory.
     """
     # Create a temporary directory in the specified directory
-    try:
-        path = tempfile.mkdtemp(dir=path)
-        return path
-    except FileNotFoundError:
-        raise FileNotFoundError(f'Folder path not found: {path}')
+    path = tempfile.mkdtemp(dir=path)
+    return path
 
 
 def profile(output_file=None, sort_by='cumulative', lines_to_print=None, strip_dirs=False):

--- a/schematic/utils/general.py
+++ b/schematic/utils/general.py
@@ -117,10 +117,10 @@ def entity_type_mapping(syn, entity_id):
         # if there's no matching type, return concreteType
         return entity.concreteType
 
-def create_temp_folder(path):
+def create_temp_folder(path: str) -> str:
     """This function creates a temporary directory in the specified directory 
     Args:
-        path: a directory path where all the temporary files will live
+        path(str): a directory path where all the temporary files will live
     Returns: returns the absolute pathname of the new directory.
     """
     # Create a temporary directory in the specified directory

--- a/schematic_api/Dockerfile
+++ b/schematic_api/Dockerfile
@@ -61,7 +61,10 @@ COPY schematic  ./schematic
 
 # change permission 
 WORKDIR /var/www/
-RUN chown www-data:www-data /var/www/
+#The -R option: make the command recursive, so it will change the owner of all files and subdirectories within a given folder.
+RUN chown -R www-data:www-data /var/www/
+
+RUN chown -R www-data:www-data /var/tmp/
 
 WORKDIR /
 COPY schematic_api/docker-entrypoint.sh ./

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -516,6 +516,15 @@ class TestDownloadManifest:
         # clean up 
         os.remove(manifest_data['path'])
 
+    def test_download_manifest_on_aws(self, mock_manifest_download, monkeypatch):
+        # mock AWS environment by providing SECRETS_MANAGER_SECRETS environment variable and attempt to download a manifest
+        monkeypatch.setenv('SECRETS_MANAGER_SECRETS', 'mock_value')
+        manifest_data = mock_manifest_download.download_manifest(mock_manifest_download)
+
+        assert os.path.exists(manifest_data['path'])
+        # clean up 
+        os.remove(manifest_data['path'])       
+
     @pytest.mark.parametrize("entity_id", ["syn27600053", "syn29862078"])
     def test_entity_type_checking(self, synapse_store, entity_id, caplog):
         md = ManifestDownload(synapse_store.syn, entity_id)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,12 @@
 import logging
 import json
 import os
-import shutil
 
 import pandas as pd
 import numpy as np
 import pytest
+
+import tempfile
 
 from pandas.testing import assert_frame_equal
 from synapseclient.core.exceptions import SynapseHTTPError
@@ -79,18 +80,9 @@ class TestGeneral:
             entity_type_mapping(syn, "syn123456")
 
     def test_download_manifest_to_temp_folder(self):
-        # define temporary folder path
-        current_dir = os.getcwd()
-        temp_path = os.path.join(current_dir, 'temp_folder')
-
-        # create a temporary folder to test out
-        if not os.path.exists(temp_path):
-            os.mkdir(temp_path)
-
-        path_dir = general.create_temp_folder(temp_path)
-        assert os.path.exists(path_dir)
-        shutil.rmtree(path_dir)
-        shutil.rmtree(temp_path)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path_dir = general.create_temp_folder(tmpdir)
+            assert os.path.exists(path_dir)
 
 class TestCliUtils:
     def test_query_dict(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import os
+import shutil
 
 import pandas as pd
 import numpy as np
@@ -76,6 +77,20 @@ class TestGeneral:
         # test with an invalid entity id
         with pytest.raises(SynapseHTTPError) as exception_info:
             entity_type_mapping(syn, "syn123456")
+
+    def test_download_manifest_to_temp_folder(self):
+        # define temporary folder path
+        current_dir = os.getcwd()
+        temp_path = os.path.join(current_dir, 'temp_folder')
+
+        # create a temporary folder to test out
+        if not os.path.exists(temp_path):
+            os.mkdir(temp_path)
+
+        path_dir = general.create_temp_folder(temp_path)
+        assert os.path.exists(path_dir)
+        shutil.rmtree(path_dir)
+        shutil.rmtree(temp_path)
 
 class TestCliUtils:
     def test_query_dict(self):


### PR DESCRIPTION
Related to the bug reported by @andrewelamb here: https://sagebionetworks.jira.com/browse/FDS-299

Highlights: 
* Added function in general.py that could create temporary folders in specified directory. 
* when downloading a manifest on AWS, downloading the manifests to a temporary location.
* Updated permission in Dockerfile to make sure that the user that we defined in uWSGI.ini could create folders on AWS. 

Will merge to develop after #1142 