### PR TITLE
FDS-293 Fix column mismatch for Excel File Based Manifest Generation 

### DIFF
--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -142,16 +142,26 @@ def get_manifest(
         # if output_xlsx gets specified, output_format = "excel"
         if output_xlsx: 
             output_format = "excel"
-
             # if file name is in the path, and that file does not exist
             if not os.path.exists(output_xlsx):
+                breakpoint()
                 if ".xlsx" or ".xls" in output_xlsx:
                     path = Path(output_xlsx)
                     output_path = path.parent.absolute()
-                else: 
-                    logger.error(f"{output_xlsx} does not exists. Please try a valid file path")
-
-            else: 
+                    if not os.path.exists(output_path):
+                        raise ValueError(
+                            f"{output_path} does not exists. Please try a valid file path"
+                        )
+                else:
+                    raise ValueError(
+                            f"{output_xlsx} does not exists. Please try a valid file path"
+                        )
+            else:
+                # Check if base path itself exists.
+                if not os.path.exists(os.path.dirname(output_xlsx)):
+                    raise ValueError(
+                    f"{output_xlsx} does not exists. Please try a valid file path"
+                    )
                 output_path = output_xlsx
         else: 
             output_format = None

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1268,12 +1268,13 @@ class ManifestGenerator(object):
         return set(headers_1) - set(headers_2)
 
     def set_dataframe_by_url(
-        self, manifest_url: str, manifest_df: pd.DataFrame, out_of_schema_columns=None,
+        self, manifest_url: str, manifest_df: pd.DataFrame, out_of_schema_columns: set =None,
     ) -> ps.Spreadsheet:
         """Update Google Sheets using given pandas DataFrame.
         Args:
             manifest_url (str): Google Sheets URL.
             manifest_df (pd.DataFrame): Data frame to "upload".
+            out_of_schema_columns (set): Columns that are in downloaded manifest, but not in current schema.
         Returns:
             ps.Spreadsheet: A Google Sheet object.
         """
@@ -1425,7 +1426,7 @@ class ManifestGenerator(object):
         
         return output_excel_file_path
 
-    def _handle_output_format_logic(self, output_format: str = None, output_path: str = None, sheet_url: bool = None, empty_manifest_url: str = None, dataframe: pd.DataFrame = None, out_of_schema_columns=None):
+    def _handle_output_format_logic(self, output_format: str = None, output_path: str = None, sheet_url: bool = None, empty_manifest_url: str = None, dataframe: pd.DataFrame = None, out_of_schema_columns: set =None):
         """
         Handle the logic between sheet_url parameter and output_format parameter to determine the type of output to return
         Args: 
@@ -1434,6 +1435,7 @@ class ManifestGenerator(object):
             empty_manifest_url: Google sheet URL that leads to an empty manifest 
             dataframe: the pandas dataframe that contains the metadata that needs to be populated to an empty manifest
             output_path: Determines the output path of the exported manifest (only relevant if returning an excel spreadsheet)
+            out_of_schema_columns (set): Columns that are in downloaded manifest, but not in current schema.
         Return: 
             a pandas dataframe, file path of an excel spreadsheet, or a google sheet URL 
         TODO:
@@ -1442,10 +1444,6 @@ class ManifestGenerator(object):
 
         # if the output type gets set to "dataframe", return a data frame 
         if output_format == "dataframe":
-            """
-            TODO: for backwards compatibility may need to return downloaded CSV only with no updates wrt to the schema. 
-            Probably use a different function and endpoint for this bc could just wrap a synapse client funtion instead of going through all the prior steps.
-            """
             return dataframe
         
         # if the output type gets set to "excel", return an excel spreadsheet
@@ -1582,6 +1580,7 @@ class ManifestGenerator(object):
 
         Returns:
             updated_df (Pd.DataFrame): existing_df with new_columns added.
+            out_of_schema_columns (set): Columns that are in downloaded manifest, but not in current schema.
         """
 
         # Get headers for the current schema and existing manifest df.

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1454,9 +1454,6 @@ class ManifestGenerator(object):
                                                           output_location = output_path,
                                                           )
             
-            if not os.path.exists(output_file_path): 
-                logger.error(f'Export to Excel spreadsheet fail. Please make sure that file path {output_file_path} is valid')
-
             # populate an excel spreadsheet with the existing dataframe
             self.populate_existing_excel_spreadsheet(output_file_path, dataframe)
 

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1242,7 +1242,7 @@ class ManifestGenerator(object):
         Returns:
             manifest_url (str): url of the google sheet manifest.
         TODO:
-        In future
+            Refactor to not be dependent on GS.
         """
         spreadsheet_id = self._create_empty_manifest_spreadsheet(self.title)
         json_schema = self._get_json_schema(json_schema_filepath)

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1256,7 +1256,7 @@ class ManifestGenerator(object):
         )
         return manifest_url
 
-    def _get_mismatched_columns(self, headers_1:list , headers_2:list) -> list:
+    def _get_missing_columns(self, headers_1:list , headers_2:list) -> list:
         """Compare two colunm sets and get cols that are in headers_1, but not headers_2
         Args:
             headers_1 (list): list of column headers
@@ -1266,7 +1266,6 @@ class ManifestGenerator(object):
 
         """
         return set(headers_1) - set(headers_2)
-
 
     def set_dataframe_by_url(
         self, manifest_url: str, manifest_df: pd.DataFrame, out_of_schema_columns=None,
@@ -1590,10 +1589,10 @@ class ManifestGenerator(object):
         existing_manfiest_headers = list(existing_df.columns)
 
         # Find columns that exist in the current schema, but are not in the manifest being downloaded.
-        new_columns = self._get_mismatched_columns(current_schema_headers, existing_manfiest_headers)
+        new_columns = self._get_missing_columns(current_schema_headers, existing_manfiest_headers)
 
         # Find columns that exist in the manifest being downloaded, but not in the current schema.
-        out_of_schema_columns = self._get_mismatched_columns(existing_manfiest_headers, current_schema_headers)
+        out_of_schema_columns = self._get_missing_columns(existing_manfiest_headers, current_schema_headers)
 
         # clean empty columns if any are present (there should be none)
         # TODO: Remove this line once we start preventing empty column names


### PR DESCRIPTION
This PR addresses the issue brought up in [FDS-293](https://sagebionetworks.jira.com/browse/FDS-293).

**For Context:**
The crux of the issue that was happening relates to how manifests are generated when there is an issue between the columns in the manifest being downloaded from Synapse and the columns that are expected based on the Schema. For the CSV and excel downloads, the handling was conducted such that if there were columns in the schema that weren't in the downloaded manifest, these would be handled and these columns would be added to the manifest. But if there were columns in the downloaded manifest that weren't in the schema, the columns would be simply added, but the ordering of the data was not adjusted accordingly.

**Additionally**
The handling of the different outputs was being handled separately allowing this divergence to occur, where you could get the expected output when exporting a CSV but not if you were exporting to excel. A user would presumably expect all the data to be the same but simply the output type to be different.

**What this PR Does**
I moved the handling of the columns and data upstream of the data output in a new function called `ManifestGenerate._update_dataframe_with_existing_df`. This new function handles all the logic for updating manifest to have all the expected columns using Pandas. The pandas DF is then handed of to `_handle_output_format_logic` which figures out the proper format to export to and calls the necessary functions.

There are also differences in the handling of `output_format` and `sheet_url`. There is a small change that handles this difference in output type a bit more clearly, in the future though we would want to consider depreciating `sheet_url`.

All this works functionally right now, but is a less than ideal solution. Since we are going to be doing a larger refactor in the future I don't think this PR needs to perform an intermediate refactor, but I do think there is a lot of room for improvement in the structure of the Manifest Generator now that we are expecting outputs other than Google Sheet.

[FDS-293]: https://sagebionetworks.jira.com/browse/FDS-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ