### PR TITLE
Id Column - fix bug where there would be two columns with `uuid` values

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1055,7 +1055,7 @@ class SynapseStorage(BaseStorage):
         Args:
             Manifest loaded as a pd.Dataframe
         Returns (pd.DataFrame):
-            Manifest df with new id and EntityId columns (and UUID values) if they were not already present.
+            Manifest df with new Id and EntityId columns (and UUID values) if they were not already present.
         """
         # Add Id for table updates and fill.
         if not "Id" in manifest.columns:

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1059,7 +1059,10 @@ class SynapseStorage(BaseStorage):
         """
         # Add Id for table updates and fill.
         if not "Id" in manifest.columns:
-            manifest["Id"] = ''
+            if 'Uuid' in manifest.columns:
+                manifest.rename(columns={'Uuid': 'Id'}, inplace=True)
+            else:
+                manifest["Id"] = ''
 
         for idx,row in manifest.iterrows():
             if not row["Id"]:

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -849,9 +849,9 @@ class SynapseStorage(BaseStorage):
         # Get the column schema
         col_schema = as_table_columns(table_manifest)
 
-        # Set id column length to 64 (for some reason not being auto set.)
+        # Set Id column length to 64 (for some reason not being auto set.)
         for i, col in enumerate(col_schema):
-            if col['name'] == 'id':
+            if col['name'] == 'Id':
                 col_schema[i]['maximumSize'] = 64
 
         return col_schema, table_manifest
@@ -1057,15 +1057,15 @@ class SynapseStorage(BaseStorage):
         Returns (pd.DataFrame):
             Manifest df with new id and EntityId columns (and UUID values) if they were not already present.
         """
-        # Add id for table updates and fill.
-        if not "id" in manifest.columns:
-            manifest["id"] = ''
+        # Add Id for table updates and fill.
+        if not "Id" in manifest.columns:
+            manifest["Id"] = ''
 
         for idx,row in manifest.iterrows():
-            if not row["id"]:
+            if not row["Id"]:
                 gen_uuid = str(uuid.uuid4())
-                row["id"] = gen_uuid
-                manifest.loc[idx, 'id'] = gen_uuid
+                row["Id"] = gen_uuid
+                manifest.loc[idx, 'Id'] = gen_uuid
 
         # add entityId as a column if not already there or
         # fill any blanks with an empty string.
@@ -1951,7 +1951,7 @@ class TableOperations:
 
         return existingTableId
 
-    def updateTable(synStore, tableToLoad: pd.DataFrame = None, existingTableId: str = None,  update_col: str = 'id',  restrict: bool = False):
+    def updateTable(synStore, tableToLoad: pd.DataFrame = None, existingTableId: str = None,  update_col: str = 'Id',  restrict: bool = False):
         """
         Method to update an existing table with a new column
         


### PR DESCRIPTION
Fixed a bug where after changing the name of the `Uuid` column to `Id`, both columns would be present in a manifest that previously had a `Uuid` column