### PR TITLE
Id Column - fix bug preventing upserts

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -874,7 +874,7 @@ class SynapseStorage(BaseStorage):
             datasetId: synID of the dataset for the manifest
             table_name: name of the table to be uploaded
             col_schema: schema for table columns: type, size, etc from `formatDB`
-            table_manifest: formatted manifest taht can be uploaded as a table
+            table_manifest: formatted manifest that can be uploaded as a table
             table_manipulation: str, 'replace' or 'upsert', in the case where a manifest already exists, should the new metadata replace the existing (replace) or be added to it (upsert)
             restrict: bool, whether or not the manifest contains sensitive data that will need additional access restrictions 
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -2031,7 +2031,7 @@ class TableOperations:
         try:
             synapseDB.upsert_table_rows(table_name=tableName, data=tableToLoad)
         except(SynapseHTTPError) as ex:
-            if 'header' in str(ex):
+            if 'Id is not a valid column name or id' in str(ex):
                 TableOperations._update_table_uuid_column(synStore, existingTableId)
             else:
                 raise ex


### PR DESCRIPTION
Fix bug where trying to upload a manifest with the `Id` column and upsert to a table where the column was named `Uuid` would error out