### PR TITLE
fix: fixed tests in test_api.py

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -4,11 +4,14 @@
 name: Test schematic API
 
 on:
+  push:
+    branches: ['main', 'develop']
   workflow_dispatch:
     inputs:
       perform_benchmarking:
         required: true
         type: boolean
+        default: False
         description: perform benchmarking test (True) or skip (False)
 
 jobs:
@@ -82,7 +85,7 @@ jobs:
         env:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
-        if: ${{ false == inputs.perform_benchmarking }}
+        if: ${{ false == inputs.perform_benchmarking }} || ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
         run: >
           source .venv/bin/activate;
           pytest -m "schematic_api and not rule_benchmark"

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -49,7 +49,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
       #----------------------------------------------
       #          install & configure poetry
       #----------------------------------------------

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -14,6 +14,19 @@ on:
         default: False
         description: perform benchmarking test (True) or skip (False)
 
+concurrency:
+  # cancel the current running workflow from the same branch, PR when a new workflow is triggered
+  # when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group
+  # {{ github.workflow }}: the workflow name is used to generate the concurrency group. This allows you to have more than one workflows
+  # {{ github.ref_type }}: the type of Git ref object created in the repository. Can be either branch or tag
+  # {{ github.event.pull_request.number}}: get PR number
+  # {{ github.sha }}: full commit sha
+  # credit: https://github.com/Sage-Bionetworks-Workflows/sagetasks/blob/main/.github/workflows/ci.yml
+  group: >-
+    ${{ github.workflow }}-${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -89,4 +102,3 @@ jobs:
         run: >
           source .venv/bin/activate;
           pytest -m "schematic_api and not rule_benchmark"
-          

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -4,28 +4,12 @@
 name: Test schematic API
 
 on:
-  pull_request_review:
-    types: [submitted]
   workflow_dispatch:
     inputs:
       perform_benchmarking:
         required: true
         type: boolean
-        default: False
         description: perform benchmarking test (True) or skip (False)
-
-concurrency:
-  # cancel the current running workflow from the same branch, PR when a new workflow is triggered
-  # when the trigger is not a PR but a push, it will use the commit sha to generate the concurrency group
-  # {{ github.workflow }}: the workflow name is used to generate the concurrency group. This allows you to have more than one workflows
-  # {{ github.ref_type }}: the type of Git ref object created in the repository. Can be either branch or tag
-  # {{ github.event.pull_request.number}}: get PR number
-  # {{ github.sha }}: full commit sha
-  # credit: https://github.com/Sage-Bionetworks-Workflows/sagetasks/blob/main/.github/workflows/ci.yml
-  group: >-
-    ${{ github.workflow }}-${{ github.ref_type }}-
-    ${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
 
 jobs:
   test:
@@ -49,6 +33,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       #----------------------------------------------
       #          install & configure poetry
       #----------------------------------------------

--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -4,8 +4,8 @@
 name: Test schematic API
 
 on:
-  push:
-    branches: ['main', 'develop']
+  pull_request_review:
+    types: [submitted]
   workflow_dispatch:
     inputs:
       perform_benchmarking:
@@ -85,7 +85,7 @@ jobs:
         env:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
-        if: ${{ false == inputs.perform_benchmarking }} || ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
+        if: ${{ false == inputs.perform_benchmarking }}
         run: >
           source .venv/bin/activate;
           pytest -m "schematic_api and not rule_benchmark"

--- a/tests/data/mock_manifests/example_biospecimen_test.csv
+++ b/tests/data/mock_manifests/example_biospecimen_test.csv
@@ -1,0 +1,2 @@
+Sample ID,Patient ID,Tissue Status,Component
+123,1,Healthy,Biospecimen

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,15 +1,20 @@
 
-import pytest
-from schematic_api.api import create_app
 import configparser
 import json
+import logging
 import os
 import re
+import time
 from math import ceil
-import logging
 from time import perf_counter
-import pandas as pd # third party library import
-from schematic.schemas.generator import SchemaGenerator #Local application/library specific imports.
+
+import numpy as np
+import pandas as pd  # third party library import
+import pytest
+
+from schematic.schemas.generator import \
+    SchemaGenerator  # Local application/library specific imports.
+from schematic_api.api import create_app
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -39,7 +44,7 @@ def test_invalid_manifest(helpers):
 
 @pytest.fixture(scope="class")
 def test_upsert_manifest_csv(helpers):
-    test_upsert_manifest_path = helpers.get_data_path("mock_manifests/rdb_table_manifest.csv")
+    test_upsert_manifest_path = helpers.get_data_path("mock_manifests/rdb_table_manifest_upsert.csv")
     yield test_upsert_manifest_path
 
 @pytest.fixture(scope="class")
@@ -656,7 +661,10 @@ class TestManifestOperation:
 
         if as_json: 
             response_json = json.loads(response_dt)
-            assert response_json == [{'Component': 'BulkRNA-seqAssay', 'File Format': 'CSV/TSV', 'Filename': 'Sample_A', 'Genome Build': 'GRCm38', 'Genome FASTA': None, 'Sample ID': 2022, 'entityId': 'syn28278954'}]
+            assert response_json[0]["Component"] == "BulkRNA-seqAssay"
+            assert response_json[0]["File Format"] == "CSV/TSV"
+            assert response_json[0]["Sample ID"] == 2022
+            assert response_json[0]["entityId"] == "syn28278954"
         else:
             # return a file path
             response_path = response_dt.decode('utf-8')
@@ -664,96 +672,94 @@ class TestManifestOperation:
             assert isinstance(response_path, str)
             assert response_path.endswith(".csv")
 
-    @pytest.mark.parametrize("json_str", [None, '[{ "Patient ID": 123, "Sex": "Female", "Year of Birth": "", "Diagnosis": "Healthy", "Component": "Patient", "Cancer Type": "Breast", "Family History": "Breast, Lung", }]'])
-    @pytest.mark.parametrize("use_schema_label", ['true','false'])
-    @pytest.mark.parametrize("manifest_record_type", ['table_and_file', 'file_only'])
-    def test_submit_manifest(self, client, syn_token, data_model_jsonld, json_str, test_manifest_csv, use_schema_label, manifest_record_type):
+    def test_submit_manifest_table_and_file_replace(self, client, syn_token, data_model_jsonld, test_manifest_csv):
+        """Testing submit manifest in a csv format as a table and a file. Only replace the table
+        """
         params = {
             "access_token": syn_token,
             "schema_url": data_model_jsonld,
-            "data_type": "Patient",
+            "data_type": "MockComponent",
             "restrict_rules": False, 
-            "manifest_record_type": manifest_record_type,
-            "asset_view": "syn44259375",
-            "dataset_id": "syn44259313",
-            "table_manipulation": 'replace',
-            "use_schema_label": use_schema_label
-        }
-
-        if json_str:
-            params["json_str"] = json_str
-            response = client.post('http://localhost:3001/v1/model/submit', query_string = params, data={"file_name":''})
-            assert response.status_code == 200
-        else: 
-            headers = {
-            'Content-Type': "multipart/form-data",
-            'Accept': "application/json"
-            }
-            params["data_type"] = "MockComponent"
-
-            # test uploading a csv file
-            response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")}, headers=headers)
-            assert response_csv.status_code == 200
-
-    @pytest.mark.parametrize("json_str", [None, '[{ "Patient ID": 123, "Sex": "Female", "Year of Birth": "", "Diagnosis": "Healthy", "Component": "Patient", "Cancer Type": "Breast", "Family History": "Breast, Lung", }]'])
-    @pytest.mark.parametrize("manifest_record_type", ['file_and_entities', 'table_file_and_entities'])
-    def test_submit_manifest_w_entities(self, client, syn_token, data_model_jsonld, json_str, test_manifest_csv, manifest_record_type):
-        params = {
-            "access_token": syn_token,
-            "schema_url": data_model_jsonld,
-            "data_type": "Patient",
-            "restrict_rules": False, 
-            "manifest_record_type": manifest_record_type,
-            "asset_view": "syn44259375",
-            "dataset_id": "syn44259313",
+            "manifest_record_type": "table_and_file",
+            "asset_view": "syn51514344",
+            "dataset_id": "syn51514345",
             "table_manipulation": 'replace',
             "use_schema_label": True
         }
 
-        if json_str:
-            params["json_str"] = json_str
-            response = client.post('http://localhost:3001/v1/model/submit', query_string = params, data={"file_name":''})
-            assert response.status_code == 200
-        else: 
-            headers = {
-            'Content-Type': "multipart/form-data",
-            'Accept': "application/json"
-            }
-            params["data_type"] = "MockComponent"
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")})
+        assert response_csv.status_code == 200
 
-            # test uploading a csv file
-            response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")}, headers=headers)
-            assert response_csv.status_code == 200  
-
+    def test_submit_manifest_file_only_replace(self, client, syn_token, data_model_jsonld, test_manifest_csv):
+        """Testing submit manifest in a csv format as a file
+        """
+        params = {
+            "access_token": syn_token,
+            "schema_url": data_model_jsonld,
+            "data_type": "MockComponent",
+            "restrict_rules": False, 
+            "manifest_record_type": "file_only",
+            "asset_view": "syn51514344",
+            "dataset_id": "syn51514345",
+            "table_manipulation": 'replace',
+            "use_schema_label": True
+        }
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")})
+        assert response_csv.status_code == 200 
     
-    @pytest.mark.parametrize("json_str", [None, '[{ "Component": "MockRDB", "MockRDB_id": 5 }]'])
-    def test_submit_manifest_upsert(self, client, syn_token, data_model_jsonld, json_str, test_upsert_manifest_csv, ):
+    def test_submit_manifest_json_str_replace(self, client, syn_token, data_model_jsonld):
+        """Submit json str as a file
+        """
+        json_str = '[{ "Patient ID": 123, "Sex": "Female", "Year of Birth": "", "Diagnosis": "Healthy", "Component": "Patient", "Cancer Type": "Breast", "Family History": "Breast, Lung", }]'
+        params = {
+            "access_token": syn_token,
+            "schema_url": data_model_jsonld,
+            "data_type": "Patient",
+            "json_str": json_str,
+            "restrict_rules": False, 
+            "manifest_record_type": "file_only",
+            "asset_view": "syn51514344",
+            "dataset_id": "syn51514345",
+            "table_manipulation": 'replace',
+            "use_schema_label": True
+        }
+        params["json_str"] = json_str
+        response = client.post('http://localhost:3001/v1/model/submit', query_string = params, data={"file_name":''})
+        assert response.status_code == 200
+
+    def test_submit_manifest_w_file_and_entities(self, client, syn_token, data_model_jsonld, test_manifest_csv):
+        params = {
+            "access_token": syn_token,
+            "schema_url": data_model_jsonld,
+            "data_type": "MockComponent",
+            "restrict_rules": False, 
+            "manifest_record_type": "file_and_entities",
+            "asset_view": "syn51514501",
+            "dataset_id": "syn51514523",
+            "table_manipulation": 'replace',
+            "use_schema_label": True
+        }
+
+        # test uploading a csv file
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")})
+        assert response_csv.status_code == 200
+
+    def test_submit_manifest_table_and_file_upsert(self, client, syn_token, data_model_jsonld, test_upsert_manifest_csv, ):
         params = {
             "access_token": syn_token,
             "schema_url": data_model_jsonld,
             "data_type": "MockRDB",
             "restrict_rules": False, 
-            "manifest_record_type": "table",
-            "asset_view": "syn44259375",
-            "dataset_id": "syn44259313",
+            "manifest_record_type": "table_and_file",
+            "asset_view": "syn51514557",
+            "dataset_id": "syn51514551",
             "table_manipulation": 'upsert',
-            "use_schema_label": False
+            "use_schema_label": False # have to set use_schema_label to false to ensure upsert feature works
         }
 
-        if json_str:
-            params["json_str"] = json_str
-            response = client.post('http://localhost:3001/v1/model/submit', query_string = params, data={"file_name":''})
-            assert response.status_code == 200
-        else: 
-            headers = {
-            'Content-Type': "multipart/form-data",
-            'Accept': "application/json"
-            }
-            params["data_type"] = "MockRDB"
-
-            # test uploading a csv file
-            response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_upsert_manifest_csv, 'rb'), "test.csv")}, headers=headers)            
-            assert response_csv.status_code == 200     
+        # test uploading a csv file
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_upsert_manifest_csv, 'rb'), "test.csv")},)            
+        assert response_csv.status_code == 200     
 
 @pytest.mark.schematic_api
 class TestSchemaVisualization:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,6 +38,11 @@ def test_manifest_csv(helpers):
     yield test_manifest_path
 
 @pytest.fixture(scope="class")
+def test_manifest_submit(helpers):
+    test_manifest_path = helpers.get_data_path("mock_manifests/example_biospecimen_test.csv")
+    yield test_manifest_path   
+
+@pytest.fixture(scope="class")
 def test_invalid_manifest(helpers):
     test_invalid_manifest = helpers.get_data_frame("mock_manifests/Invalid_Test_Manifest.csv", preserve_raw_input=False)
     yield test_invalid_manifest
@@ -672,13 +677,13 @@ class TestManifestOperation:
             assert isinstance(response_path, str)
             assert response_path.endswith(".csv")
 
-    def test_submit_manifest_table_and_file_replace(self, client, syn_token, data_model_jsonld, test_manifest_csv):
+    def test_submit_manifest_table_and_file_replace(self, client, syn_token, data_model_jsonld, test_manifest_submit):
         """Testing submit manifest in a csv format as a table and a file. Only replace the table
         """
         params = {
             "access_token": syn_token,
             "schema_url": data_model_jsonld,
-            "data_type": "MockComponent",
+            "data_type": "Biospecimen",
             "restrict_rules": False, 
             "manifest_record_type": "table_and_file",
             "asset_view": "syn51514344",
@@ -687,16 +692,16 @@ class TestManifestOperation:
             "use_schema_label": True
         }
 
-        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")})
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_submit, 'rb'), "test.csv")})
         assert response_csv.status_code == 200
 
-    def test_submit_manifest_file_only_replace(self, client, syn_token, data_model_jsonld, test_manifest_csv):
+    def test_submit_manifest_file_only_replace(self, client, syn_token, data_model_jsonld, test_manifest_submit):
         """Testing submit manifest in a csv format as a file
         """
         params = {
             "access_token": syn_token,
             "schema_url": data_model_jsonld,
-            "data_type": "MockComponent",
+            "data_type": "Biospecimen",
             "restrict_rules": False, 
             "manifest_record_type": "file_only",
             "asset_view": "syn51514344",
@@ -704,17 +709,17 @@ class TestManifestOperation:
             "table_manipulation": 'replace',
             "use_schema_label": True
         }
-        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")})
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_submit, 'rb'), "test.csv")})
         assert response_csv.status_code == 200 
     
     def test_submit_manifest_json_str_replace(self, client, syn_token, data_model_jsonld):
         """Submit json str as a file
         """
-        json_str = '[{ "Patient ID": 123, "Sex": "Female", "Year of Birth": "", "Diagnosis": "Healthy", "Component": "Patient", "Cancer Type": "Breast", "Family History": "Breast, Lung", }]'
+        json_str = '[{"Sample ID": 123, "Patient ID": 1,"Tissue Status": "Healthy","Component": "Biospecimen"}]'
         params = {
             "access_token": syn_token,
             "schema_url": data_model_jsonld,
-            "data_type": "Patient",
+            "data_type": "Biospecimen",
             "json_str": json_str,
             "restrict_rules": False, 
             "manifest_record_type": "file_only",
@@ -727,11 +732,11 @@ class TestManifestOperation:
         response = client.post('http://localhost:3001/v1/model/submit', query_string = params, data={"file_name":''})
         assert response.status_code == 200
 
-    def test_submit_manifest_w_file_and_entities(self, client, syn_token, data_model_jsonld, test_manifest_csv):
+    def test_submit_manifest_w_file_and_entities(self, client, syn_token, data_model_jsonld, test_manifest_submit):
         params = {
             "access_token": syn_token,
             "schema_url": data_model_jsonld,
-            "data_type": "MockComponent",
+            "data_type": "Biospecimen",
             "restrict_rules": False, 
             "manifest_record_type": "file_and_entities",
             "asset_view": "syn51514501",
@@ -741,7 +746,7 @@ class TestManifestOperation:
         }
 
         # test uploading a csv file
-        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")})
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_submit, 'rb'), "test.csv")})
         assert response_csv.status_code == 200
 
     def test_submit_manifest_table_and_file_upsert(self, client, syn_token, data_model_jsonld, test_upsert_manifest_csv, ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,7 +49,7 @@ def test_invalid_manifest(helpers):
 
 @pytest.fixture(scope="class")
 def test_upsert_manifest_csv(helpers):
-    test_upsert_manifest_path = helpers.get_data_path("mock_manifests/rdb_table_manifest_upsert.csv")
+    test_upsert_manifest_path = helpers.get_data_path("mock_manifests/rdb_table_manifest.csv")
     yield test_upsert_manifest_path
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
## Chagelog:  
* Broken downn tests related to `test_submit_manifest`, so that it is easier to track what tests failed
* Since DCA and DFA are using csv file to submit instead of json str, I modified the tests so that the majority of the tests focused on testing using the CSV instead of json. 
* Modified the github workflow so that the API tests (except those related to benchmarking performance) get run when pushing to develop or main branch

## To test this PR
Run all the tests in test_api.py locally. All the tests should pass except some in TestValidationBenchmark

Related to Jira issue: https://sagebionetworks.jira.com/jira/software/c/projects/FDS/issues/FDS-318?jql=project%20%3D%20%22FDS%22%20AND%20text%20~%20%22test%22%20AND%20status%20IN%20%28Open%2C%22Ready%20for%20Dev%20Triage%22%2C%22Ready%20for%20Team%22%29%20ORDER%20BY%20created%20DESC

