### PR TITLE
Installed schematic in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,3 +28,5 @@ RUN poetry config virtualenvs.create false
 RUN poetry install --no-interaction --no-ansi --no-root
 
 COPY . ./
+
+RUN poetry install --only-root


### PR DESCRIPTION
## Changelog
Added a line to install schematic in Dockerfile

Related to: [FDS-497 Install schematic in Dockerfile](https://sagebionetworks.jira.com/browse/FDS-497?atlOrigin=eyJpIjoiZTY2MTZkZjIwZWYxNDI0Yjg4MWExN2U3ZTI2NDI0NjQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## To test this PR
1. docker build -t schematic-external .
2. Launch docker container based on the docker image that just built 
3. install vim inside the container: `apt install vim`
4. run `vim .synapseConfig` and copy and paste your content of `.synapseConfig`
5. run a schematic cli command: `schematic init --config config.yml`
which proves that schematic cli is working as expected 