### PR TITLE
Avoided publishing minor releases to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ name: Build and publish container to Docker Hub
 
 on:
   push:
-    tags: ['v[0-9]*', '[0-9]+.[0-9]+*']  # Match tags that resemble a version
+    tags: ['^v\d+\.\d+\.\d+$']  # Match tags that resemble a version, but exclude minior releases. For example, v0.1.1-beta would not get included
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Avoided publishing minor releases to Docker Hub

## Context
Currently, we have two Dockerfile: one is for deploying schematic to aws, and the other one is for external users to use schematic. As a short-term solution, we should avoid publishing minor releases to DockerHub to avoid confusion since minor releases are not production ready (plus the dockerfile for deployment is not the one that we want users to use)