### PR TITLE
Replaced synapse API calls with synapse Python client call 

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -2285,12 +2285,9 @@ class TableOperations:
                         "maximumListLength": 1,
                     }
 
-                    # Send POST /column request to define new column and get new column ID
-                    newColResponse = self.synStore.send_api_request(
-                        request_type = "restPOST",
-                        uri = "https://repo-prod.prod.sagebase.org/repo/v1/column",
-                        body = columnModelDict,
-                    )
+                    new_col = Column(name='Id', columnType='STRING', maximumSize=64, maximumListLength=1)
+                    newColResponse = self.synStore.syn.store(new_col)
+
 
                     # Define columnChange body
                     columnChangeDict = {
@@ -2304,19 +2301,7 @@ class TableOperations:
                         ]
                     }
 
-                    # Build body for POST request
-                    schemaChangeBody = {
-                        "entityId": self.existingTableId,
-                        "changes": [columnChangeDict],
-                    }
-
-                    # Send POST request to change column name
-                    schemaChangeResponse = self.synStore.send_api_request(
-                        request_type = "restPOST",
-                        uri = f"https://repo-prod.prod.sagebase.org/repo/v1/entity/{self.existingTableId}/table/transaction/async/start",
-                        body = schemaChangeBody,
-                    )
-                    # Exit iteration; only concerned with `Uuid` column
+                    self.synStore.syn._async_table_update(table=self.existingTableId, changes=[columnChangeDict], wait=False)
                 break
 
         return

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -2233,7 +2233,6 @@ class TableOperations:
         except(SynapseHTTPError) as ex:
             # If error is raised because Table has old `Uuid` column and not new `Id` column, then handle and re-attempt upload
             if 'Id is not a valid column name or id' in str(ex):
-                print('triggering this function call that I want to test')
                 self._update_table_uuid_column(sg)
                 synapseDB.upsert_table_rows(table_name=self.tableName, data=self.tableToLoad)
             # Raise if other error

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -2275,17 +2275,8 @@ class TableOperations:
                 else:
                     
                     # Build ColumnModel that will be used for new column
-                    columnModelDict = {
-                        "id": None,
-                        "name": "Id",
-                        "defaultValue": None,
-                        "columnType": "STRING",
-                        "maximumSize": 64,
-                        "maximumListLength": 1,
-                    }
-
-                    new_col = Column(name='Id', columnType='STRING', maximumSize=64, maximumListLength=1)
-                    newColResponse = self.synStore.syn.store(new_col)
+                    id_column = Column(name='Id', columnType='STRING', maximumSize=64, defaultValue=None, maximumListLength=1)
+                    new_col_response = self.synStore.syn.store(id_column)
 
 
                     # Define columnChange body
@@ -2295,7 +2286,7 @@ class TableOperations:
                         "changes": [
                             {                        
                                 "oldColumnId": col['id'],
-                                "newColumnId": newColResponse['id'],
+                                "newColumnId": new_col_response['id'],
                             }
                         ]
                     }

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -54,7 +54,7 @@ from schematic.exceptions import MissingConfigValueError, AccessCredentialsError
 
 from schematic import CONFIG
 
-from schematic.utils.general import Profile
+from schematic.utils.general import profile
 
 logger = logging.getLogger("Synapse storage")
 
@@ -2242,7 +2242,7 @@ class TableOperations:
 
         return self.existingTableId
     
-    @Profile
+    @profile(sort_by='cumulative', strip_dirs=True)
     def _update_table_uuid_column(self, sg: SchemaGenerator,) -> None:
         """Removes the `Uuid` column when present, and relpaces with an `Id` column
         Used to enable backwards compatability for manifests using the old `Uuid` convention

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -54,6 +54,8 @@ from schematic.exceptions import MissingConfigValueError, AccessCredentialsError
 
 from schematic import CONFIG
 
+from schematic.utils.general import Profile
+
 logger = logging.getLogger("Synapse storage")
 
 @dataclass
@@ -2231,6 +2233,7 @@ class TableOperations:
         except(SynapseHTTPError) as ex:
             # If error is raised because Table has old `Uuid` column and not new `Id` column, then handle and re-attempt upload
             if 'Id is not a valid column name or id' in str(ex):
+                print('triggering this function call that I want to test')
                 self._update_table_uuid_column(sg)
                 synapseDB.upsert_table_rows(table_name=self.tableName, data=self.tableToLoad)
             # Raise if other error
@@ -2238,7 +2241,8 @@ class TableOperations:
                 raise ex
 
         return self.existingTableId
-
+    
+    @Profile
     def _update_table_uuid_column(self, sg: SchemaGenerator,) -> None:
         """Removes the `Uuid` column when present, and relpaces with an `Id` column
         Used to enable backwards compatability for manifests using the old `Uuid` convention


### PR DESCRIPTION
## Changelog
* Replaced synapse API call with synapse python client call to reduce complexity

## Context
Based on previous discussion with @GiaJordan and @milen-sage, it seems like making direct synapse API calls improve performance of the `table upsert` functionality. Initially, I was hoping to see if I could borrow similar approach to improve performance of `manifest/download`. 

But based on @thomasyu888 's comment in PR here: https://github.com/Sage-Bionetworks/schematic/pull/1229, the synapse python client already includes some functionalities that Gianna implemented. It seems like we just need to find the right synapse python client functions to call. I then investigated by replacing direct synapase API calls with functions in synapse python client and tested out the performance. It turns out that we could maintain the same (or even slightly better performance) by calling synapse python client. 

## Steps that I took: 
* I started by testing the performance of the `_update_table_uuid_column` function in the `develop` branch by using `profile` function in `utils.general.py`. It seems like the function took 11.695 seconds to finish See the report here: [_update_table_uuid_column_develop.txt](https://github.com/Sage-Bionetworks/schematic/files/11691407/_update_table_uuid_column_develop.txt)
* I then used Gianna's branch `develop-Uuid-API-calls-FDS-493` and tested out the function of `_update_table_uuid_column`, and it seems like the function finish much faster. See the report here: 
[_update_table_uuid_column_gianna_pr.txt](https://github.com/Sage-Bionetworks/schematic/files/11691447/_update_table_uuid_column_gianna_pr.txt)
* Based on Gianna's PR, I then replaced the direct API calls with synapse python client functions that Tom mentioned and tested again, this time function finished slightly faster than above[_update_table_uuid_column.txt](https://github.com/Sage-Bionetworks/schematic/files/11691458/_update_table_uuid_column.txt)

## To reproduce test results above: 
* Launch schematic API by using `poetry run python3 run_api.py`
* Manually update the table schema here: https://www.synapse.org/#!Synapse:syn51512388/tables/ and change the `Id` to `Uuid`. (Since the goal is to test out the performance of renaming column from `Uuid` to `Id`, we have to ensure the table is using `Uuid` before upsert) 
* In swagger UI interface, try submitting manifest by using the following parameter: 
  * schema_url: https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld
  * data_type: MockRDB
  * dataset_id: syn51680230
  * manifest_record_type: table_and_file
  * access_token: your synapse token
  * asset_view: syn51680311
  * table_manipulation: `upsert`
  * use_schema_label: false
  * file_name: `schematic/tests/data/mock_manifests/rdb_table_manifest_upsert.csv`

