### PR TITLE
Allow storage/project/datasets to take in parent_id and benefactor_id

### DIFF
--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -549,7 +549,7 @@ paths:
   /storage/project/datasets:
     get:
       summary: Gets all datasets in folder under a given storage project that the current user has access to.
-      description: Gets all datasets in folder under a given storage project that the current user has access to.
+      description: Gets all datasets in folder under a given storage project that the current user has access to, will further check that dataset is part of a specific parent or benefactor folder. Only provide a single parent or benefactor.
       operationId: schematic_api.api.routes.get_storage_projects_datasets
       parameters:
         - in: query
@@ -576,6 +576,20 @@ paths:
           description: synapse ID of a storage project.
           example: syn26251192
           required: true
+        - in: query
+          name: parent_id
+          schema:
+            type: string
+            nullable: false
+          description: synapse ID of a parent folder.
+          required: false
+        - in: query
+          name: benefactor_id
+          schema:
+            type: string
+            nullable: false
+          description: synapse ID of a benefactor folder.
+          required: false
       responses:
         "200":
           description: A list of tuples

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -450,7 +450,7 @@ def get_storage_projects(access_token, asset_view):
     
     return lst_storage_projects
 
-def get_storage_projects_datasets(access_token, asset_view, project_id):
+def get_storage_projects_datasets(access_token, asset_view, project_id, parent_id=None, benefactor_id=None):
     # call config handler
     config_handler(asset_view=asset_view)
 
@@ -458,7 +458,7 @@ def get_storage_projects_datasets(access_token, asset_view, project_id):
     store = SynapseStorage(access_token=access_token)
 
     # call getStorageDatasetsInProject function
-    sorted_dataset_lst = store.getStorageDatasetsInProject(projectId = project_id)
+    sorted_dataset_lst = store.getStorageDatasetsInProject(projectId = project_id, parentId=parent_id, benefactorId=benefactor_id)
     
     return sorted_dataset_lst
 


### PR DESCRIPTION
Addresses [FDS-542](https://sagebionetworks.jira.com/browse/FDS-542).

**Background:**

This PR addresses an issue in the AD knowledge portal where they were unable to view datasets within their 'project'. 

What was being attempted is as follows:

**Figure 1:** Benefactor Folder to the dataset folder.
![Screen Shot 2023-06-13 at 2 01 33 PM](https://github.com/Sage-Bionetworks/schematic/assets/85905780/361cda6f-6df1-4430-9621-310577a17ddd)
**Figure 2:** Parent Folder to the dataset folder.
![Screen Shot 2023-06-13 at 2 01 51 PM](https://github.com/Sage-Bionetworks/schematic/assets/85905780/b0ccd7a8-dd40-481c-a11e-ccbc3cab2233)
**Figure 3:** View of the asset view showing projectId, parentId, and benefactorId for the dataset.
![Screen Shot 2023-06-13 at 2 02 25 PM](https://github.com/Sage-Bionetworks/schematic/assets/85905780/001e780b-28f8-414e-a95c-9baa95b9557e)
**Figure 4:** View of the REST API endpoint being used.
![Screen Shot 2023-06-13 at 2 03 06 PM](https://github.com/Sage-Bionetworks/schematic/assets/85905780/e4181402-dedb-41bd-8fe4-f9c41df96b38)

The AD Knowledge Portal is the overarching “Project” with a ProjectId SynId = `syn2580853`. This is the immutable projectID no matter what is submitted through the schematic REST API (see figure 3). 

For the DCA they want the study that is surfaced to the user to be “ABC-DS”. Within that folder wanted to find the dataset Genomic Variants (SNP array). To do this they added the annotation `contentType=dataset` to the Genomic Varients folder (`syn38195237`). 

In the API the following was provided:

`asset_view :  syn51324810`

`project_id : syn38190930`

Within schematic when looking at the fileview it can see that the folder Genomic Varients folder (`syn38195237`) is annotated as a dataset, however when trying to check that its in the correct project_id folder, it cant validate that. This is because the `project_id` provided in the API is not its true `project_id`, rather it is the `benefactorId` (again see the third figure).

 After discussing with Anthony, I will expose some new arguments to the current function and endpoint. I can allow users to submit a parentId or a benefactorId. If one of these options is provided I can check that there is a folder with `contentType=dataset` in the given benefactor or parentfolder.

This change will allow users to search the project, parent, or benefactor folders for datasets.

**This PR**
Implements the change discussed above. Users can optionally pass a `parentId` or a `benefactorId`. Cannot provide both parent and benefactor Ids.  If one of these folder IDs is provided a further check will be done to see if the dataset resides in the given folder, within the overall project.

**NOTE**
Designed to throw an error if both a benefactor ID and parent ID are supplied.

**To test**
In the API _for AMPAD_, provide the following to the REST API (must have sufficient permissions):
`V1/storage/project/datasets`
- `Asset View: syn51324810`
- `ProjectId: syn2580853`
- `BenefactorId: syn38190930`

Should return:
```
[
  [
    "syn38195237",
    "Genomic Variants (SNP array)"
  ]
]
```

In the API with standard Schematic Testing Permissions:
`V1/storage/project/datasets`

- `Asset View: syn51707141 `
- `ProjectId: syn23643250`
- `ParentId: syn51707122 `

Should return: 
```
[
  [
    "syn51707123",
    "TestDatasetFolder"
  ]
]
```

Note: BenefactorID seems to be often the same as the ProjectId and seems to do largely with inheritance of permissions...





[FDS-542]: https://sagebionetworks.jira.com/browse/FDS-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ