### PR TITLE
Fix df_utils/load_df so it more accurately captures integers to prevent Regex Errors.

### DIFF
--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -60,6 +60,9 @@ def load_df(file_path, preserve_raw_input=True, data_model=False, **load_args):
             pandarallel.initialize(verbose = 1)
             ints = org_df.parallel_applymap(lambda x: np.int64(x) if str.isdigit(x) else False, na_action='ignore').fillna(False)
 
+        # Identify cells converted to intergers
+        ints_tf_df = ints.applymap(pd.api.types.is_integer)
+
         # convert strings to numerical dtype (float) if possible, preserve non-numerical strings
         for col in org_df.columns:
             float_df[col]=pd.to_numeric(float_df[col], errors='coerce')
@@ -68,9 +71,9 @@ def load_df(file_path, preserve_raw_input=True, data_model=False, **load_args):
         
         # Trim nans and empty rows and columns
         processed_df = trim_commas_df(float_df)
-        
+
         # Store values that were converted to type int in the final dataframe
-        processed_df=processed_df.mask(ints != False, other = ints)  
+        processed_df=processed_df.mask(ints_tf_df, other = ints)
         
         # log manifest load and processing time
         logger.debug(f"Load Elapsed time {perf_counter()-t_load_df}")

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -18,11 +18,12 @@ CRAM,,,"Genome Build, Genome FASTA",,FALSE,ValidValue,,,
 CSV/TSV,,,Genome Build,,FALSE,ValidValue,,,
 Genome Build,,"GRCh37, GRCh38, GRCm38, GRCm39",,,TRUE,DataProperty,,,
 Genome FASTA,,,,,TRUE,DataProperty,,,
-MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range, Check Date, Check NA",,FALSE,DataType,,,
+MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Regex Integer, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range, Check Date, Check NA",,FALSE,DataType,,,
 Check List,,"ab, cd, ef, gh",,,TRUE,DataProperty,,,list strict 
 Check Regex List,,,,,TRUE,DataProperty,,,list strict::regex match [a-f]
 Check Regex Single,,,,,TRUE,DataProperty,,,regex search [a-f]
 Check Regex Format,,,,,TRUE,DataProperty,,,regex match [a-f]
+Check Regex Integer,,,,,TRUE,DataProperty,,,regex search ^\d+$
 Check Num,,,,,TRUE,DataProperty,,,num
 Check Float,,,,,TRUE,DataProperty,,,float
 Check Int,,,,,TRUE,DataProperty,,,int

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -2499,6 +2499,9 @@
                     "@id": "bts:CheckRegexFormat"
                 },
                 {
+                    "@id": "bts:CheckRegexInteger"
+                },
+                {
                     "@id": "bts:CheckNum"
                 },
                 {
@@ -2635,6 +2638,25 @@
             "sms:required": "sms:true",
             "sms:validationRules": [
                 "regex match [a-f]"
+            ]
+        },
+        {
+            "@id": "bts:CheckRegexInteger",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckRegexInteger",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Regex Integer",
+            "sms:required": "sms:true",
+            "sms:validationRules": [
+                "regex search ^\\d+$"
             ]
         },
         {

--- a/tests/data/mock_manifests/Invalid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Invalid_Test_Manifest.csv
@@ -1,4 +1,4 @@
-Component,Check List,Check Regex List,Check Regex Format,Check Regex Single,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
-MockComponent,"ab,cd","ab,cd,ef",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,,6549,str1,70,32-984,7
-MockComponent,invalid list values,ab cd ef,m,q,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,,32851,str1,30,notADate,9.5
-MockComponent,"ab,cd","ab,cd,ef",b,b,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,210065,,6550,str1,90,84-43-094,Not Applicable
+Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Regex Integer,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
+MockComponent,"ab,cd","ab,cd,ef",a,a,5.4,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,,6549,str1,70,32-984,7
+MockComponent,invalid list values,ab cd ef,q,m,0,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,,32851,str1,30,notADate,9.5
+MockComponent,"ab,cd","ab,cd,ef",b,b,683902,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,210065,,6550,str1,90,84-43-094,Not Applicable

--- a/tests/data/mock_manifests/Valid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Valid_Test_Manifest.csv
@@ -1,5 +1,5 @@
-Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
-MockComponent,"ab,cd","a,c,f",a,a,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,,6571,str1,75,10/21/2022,Not Applicable
-MockComponent,"ab,cd","a,c,f",e,b,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80,October 21 2022,8
-MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,present,32849,str3,95,10/21/2022,Not Applicable
-MockComponent,"ab,cd","b,d,f",b,c,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,32849,str4,55,21/10/2022,695
+Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Regex Integer,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
+MockComponent,"ab,cd","a,c,f",a,a,0,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,,6571,str1,75,10/21/2022,Not Applicable
+MockComponent,"ab,cd","a,c,f",e,b,1234,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80,October 21 2022,8
+MockComponent,"ab,cd","b,d,f",b,c,683902,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,present,32849,str3,95,10/21/2022,Not Applicable
+MockComponent,"ab,cd","b,d,f",b,c,0,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,32849,str4,55,21/10/2022,695

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -128,7 +128,17 @@ class TestManifestValidation:
             module_to_call = 'search',
             invalid_entry = 'q',
             sg = sg,
-            )[0] in errors   
+            )[0] in errors
+
+        assert GenerateError.generate_regex_error(
+            val_rule = 'regex',
+            reg_expression = '^\d+$',
+            row_num = '2',
+            attribute_name = 'Check Regex Integer',
+            module_to_call = 'search',
+            invalid_entry = '5.4',
+            sg = sg,
+            )[0] in errors 
 
         assert GenerateError.generate_url_error(
             val_rule = 'url',


### PR DESCRIPTION
**Background**
In issue [FDS-547](https://sagebionetworks.jira.com/browse/FDS-547) HTAN reported an interesting error where their regex validation rule was not evaluating properly `re.match("\d+$|Not\sApplicable$|unknown$")`. The regex  is looking for either a string of digits of arbitrary length or "Not Applicable" or "unknown".

The problem was the 0's in their validation column were being converted to "0.0" even through they were entered as "0". This conversion was causing them to fail the validation .

The problem was specific to when "0"s were submitted in the same column as longer digits. For manifests with only "0"s in the column a quirk of pandas was allowing them to not be converted to float and thus to pass validation. 

**Solution**
The essence of this issue boils down to how "0"s can be treated either like numbers or bool (`false`). The func `load_df` is doing a lot of processing of imported manifests to make sure the import of values into schematic is accurate to the users intent (rather than just converting everything to str in bulk). 

In short:

1. The manifest is read as a table where all the values are strings.
2. `ints`: `load_df` attempts to find all the strings that should be integers and stores them in a data frame (`ints`) where each cell records the integer (if it can be converted to an int) or the boolean value `false` if it cannot.
3. `floats`: `load_df` then attempts to convert all the cells it can to float. If it cant it keeps those values as string. This df is a mix of strings and floats.
4. `processed_df`: after some string processing, `load_df` then attempts to layer the ints back into the `floats` df (that already contains the floats and strs). This should ensure that all the values we need as `ints` are preserved as integers. The problem arises bc the way the masking was applied, it look at the `ints` data frame, and looked for if `ints!=False`. In this case all of the 0's that were recorded then evaluated as a boolean false. So none of the 0 integers were layered back over the floats and strings they were expected to replace. Thus the 0's were converted to 0.0. This caused them to fail validation when the regex was applied.
5.  An interesting case: when the entire column to be converted to Float is composed of 0's they are not converted to 0.0...rather they were retained as integers. In this case, it didn't matter that they were not overlaid later as ints bc they were never converted to float in the first place. This is how this error got through.

To get ensure this error does not happen in the future I replaced the check for if an integer was present with a more explicit type check rather than using the boolean check: `ints!=False`. 

The type check is very simply: `ints.applymap(pd.api.types.is_integer)`.

I am additionally adding to the validation test suite to make sure this is checked for in the future.

**To Test**
Via CLI:
Validate against the test manifest `tests/data/example.model.csv`
```
schematic model --config config.yml validate -dt MockComponent -mp tests/data/mock_manifests/Valid_Test_Manifest.csv 
```
[FDS-547]: https://sagebionetworks.jira.com/browse/FDS-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ