### PR TITLE
Feat: allowed production tag and staging tag to run docker build for aws deployment

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -51,5 +51,5 @@ jobs:
         with:
           file: schematic_api/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }} || ${{ github.event.inputs.tags }}
+          tags: ${{ steps.meta.outputs.tags || github.event.inputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -7,7 +7,13 @@ name: Create and publish a Docker image
 on:
   push:
     tags:
-      - '*beta*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'tag version number'
+        required: true
+
 
 env:
   REGISTRY: ghcr.io
@@ -45,5 +51,5 @@ jobs:
         with:
           file: schematic_api/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }} || ${{ github.event.inputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Related to [FDS-600 Update schematic dev instance to use the latest develop branch](https://sagebionetworks.jira.com/browse/FDS-600?atlOrigin=eyJpIjoiOTAxOGY5Nzg0Zjc1NDI1OGEzYWVjZDQ1MTkxNDE2NTQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

Features: 
* Allowed production tag and staging tag to trigger docker build
* For tags that have been published, allow developers to manually publish the docker images. 