### PR TITLE
Added hide-blanks parameter when submitting manifest through API

### DIFF
--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -330,6 +330,13 @@ paths:
           description: If True, validation suite will only run with in-house validation rule. If False, the Great Expectations suite will be utilized and all rules will be available.
           required: true
         - in: query
+          name: hide_blanks
+          schema:
+            type: boolean
+          description: If true, annotations with blank values will be hidden from a dataset's annotation list in Synaspe. If false, annotations with blank values will be displayed. Default to false
+          required: false
+          example: false
+        - in: query
           name: access_token
           schema:
             type: string

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -370,7 +370,7 @@ def validate_manifest_route(schema_url, data_type, restrict_rules=None, json_str
 
 #####profile validate manifest route function 
 #@profile(sort_by='cumulative', strip_dirs=True)
-def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None, json_str=None, table_manipulation=None, data_type=None):
+def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None, json_str=None, table_manipulation=None, data_type=None, hide_blanks=False):
     # call config_handler()
     config_handler(asset_view = asset_view)
 
@@ -415,6 +415,7 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
         access_token=access_token, 
         manifest_record_type = manifest_record_type, 
         restrict_rules = restrict_rules, 
+        hide_blanks=hide_blanks,
         table_manipulation = table_manipulation, 
         use_schema_label=use_schema_label)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -685,6 +685,7 @@ class TestManifestOperation:
             "schema_url": data_model_jsonld,
             "data_type": "Biospecimen",
             "restrict_rules": False, 
+            "hide_blanks": False, 
             "manifest_record_type": "table_and_file",
             "asset_view": "syn51514344",
             "dataset_id": "syn51514345",


### PR DESCRIPTION
Related to: https://sagebionetworks.jira.com/browse/FDS-503

## Changelog
* Added `hide-blanks` parameter. This is an optional parameter that defaults to False. 
* Updated test and added `hide-blanks` parameter

## To test the PR
1. Run schematic APIs locally by doing `poetry run python3 run_api.py`
2. Submit a manifest by using the example data model. Try setting `hide-blanks` to True, False, or None