### PR TITLE
Revert "Feat: allowed production tag, staging tag, and manual run on existing tags to trigger building docker images for AWS deployment"

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -7,13 +7,7 @@ name: Create and publish a Docker image
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-  workflow_dispatch:
-    inputs:
-      tags:
-        description: 'Please only use existing tags'
-        required: true
-
+      - '*beta*'
 
 env:
   REGISTRY: ghcr.io
@@ -45,7 +39,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{raw}},value=${{ env.TAG || github.event.inputs.tags }}
+            type=semver,pattern={{raw}}
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:


### PR DESCRIPTION
Reverts Sage-Bionetworks/schematic#1241

It seems like there's something wrong with the docker image being built and the API deployment didn't really work on AWS. Let me revert the workflow changes for now. 