### PR TITLE
[Bug fix]: Fix regex in docker build workflow

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -7,7 +7,7 @@ name: Create and publish a Docker image
 on:
   push:
     tags:
-      - 'v[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z]+)?'
+      - 'v[0-9].[0-9].[0-9]*'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Based on the post [here](https://stackoverflow.com/questions/68078004/why-doesnt-my-github-action-trigger-on-a-regex-tag), it turns out that Github workflow regex works differently than normal regex. 

I tested this regex again using my testing repo: 
- This pattern triggers the build of `v1.2.10`: https://github.com/linglp/testworkflow/actions/runs/5357987745
- Also triggers the build of `v1.1.1-beta`: https://github.com/linglp/testworkflow/tree/v1.1.1-beta

Hopefully this fixes the issue 

Note: In the future, to match more than one patterns, it will be best to separate the pattern to be match. See discussion here: https://github.com/orgs/community/discussions/52493