### PR TITLE
[Bug fix]: Fix regex in docker build workflow 

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -7,7 +7,7 @@ name: Create and publish a Docker image
 on:
   push:
     tags:
-      - 'v[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z]+)?'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Related to: https://github.com/Sage-Bionetworks/schematic/pull/1246

The previous pattern didn't work because the tag only matched single digit number after `v`. I used the exact tag that I would need and make sure that works: https://github.com/linglp/testworkflow/tree/v23.6.3