### PR TITLE
Expose strict_validation option for manifest/generate endpoint

### DIFF
--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -86,6 +86,13 @@ paths:
             enum: ["excel", "google_sheet", "dataframe (only if getting existing manifests)"]
           description: If "excel" gets selected, this approach would avoid sending metadata to Google sheet APIs; if "google_sheet" gets selected, this would return a Google sheet URL. This parameter could potentially override sheet_url parameter. 
           required: false
+        - in: query
+          name: strict_validation
+          schema:
+            type: boolean
+            default: True
+          description: If using Google Sheets, can set the strictness of Google Sheets regex match validation. True (default) will block users from entering incorrect values, False will throw a warning to users.
+          required: false
       operationId: schematic_api.api.routes.get_manifest_route
       responses:
         "200":

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -207,7 +207,7 @@ def get_temp_jsonld(schema_url):
     return tmp_file.name
 
 # @before_request
-def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None, asset_view = None, output_format=None, title=None, access_token=None):
+def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None, asset_view = None, output_format=None, title=None, access_token=None, strict_validation:bool=True):
     """Get the immediate dependencies that are related to a given source node.
         Args:
             schema_url: link to data model in json ld format
@@ -217,6 +217,7 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
             use_annotations: Whether to use existing annotations during manifest generation
             asset_view: ID of view listing all project data assets. For example, for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.
             access_token: Token
+            strict: bool, strictness with which to apply validation rules to google sheets.
         Returns:
             Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
     """
@@ -231,7 +232,7 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
     all_args = connexion.request.args
     args_dict = dict(all_args.lists())
     data_type = args_dict['data_type']
-    
+
     # Gather all dataset_ids
     try:
         dataset_ids = args_dict['dataset_id']
@@ -262,7 +263,7 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
                 )
 
 
-    def create_single_manifest(data_type, title, dataset_id=None, output_format=None, access_token=None):
+    def create_single_manifest(data_type, title, dataset_id=None, output_format=None, access_token=None, strict=strict_validation):
         # create object of type ManifestGenerator
         manifest_generator = ManifestGenerator(
             path_to_json_ld=jsonld,
@@ -278,7 +279,7 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
                 output_format = "dataframe"
 
         result = manifest_generator.get_manifest(
-            dataset_id=dataset_id, sheet_url=True, output_format=output_format, access_token=access_token
+            dataset_id=dataset_id, sheet_url=True, output_format=output_format, access_token=access_token, strict=strict,
         )
 
         # return an excel file if output_format is set to "excel"


### PR DESCRIPTION
To address [FDS-538](https://sagebionetworks.jira.com/browse/FDS-538), update manifest generator and API to expose `strict_validation` parameter.

Was able to see it works for both Google Sheets and Excel.
Can check by typing nonsense into `Days to Birth` column.

- With [`strict_validation=true`](https://docs.google.com/spreadsheets/d/15oRi_qjHB0vmtYsJc1OnWkz89_OM-g16krm4Vj1BVKI/edit#gid=0).
- With [`strict_validation=false`](https://docs.google.com/spreadsheets/d/1RygED85XFRyUte-GUUqbXQ-7vX530mKtOsS8Id3QvxY/edit#gid=0).

To test`manifest/generate` endpoint with HTAN:

```
schema_url: https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld
data_type: Demographics
dataset_id: syn22677299
asset_view: syn22125563
output_format: excel or google_sheets
strict_validation: try both true and false

```



[FDS-538]: https://sagebionetworks.jira.com/browse/FDS-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ