### PR TITLE
add Component as a required attribute to the example data model

### DIFF
--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -1,4 +1,5 @@
 Attribute,Description,Valid Values,DependsOn,Properties,Required,Parent,DependsOn Component,Source,Validation Rules
+Component,,,,,TRUE,,,,
 Patient,,,"Patient ID, Sex, Year of Birth, Diagnosis, Component",,FALSE,DataType,,,
 Patient ID,,,,,TRUE,DataProperty,,,
 Sex,,"Female, Male, Other",,,TRUE,DataProperty,,,

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -1973,6 +1973,23 @@
             }
         },
         {
+            "@id": "bts:Component",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "Component",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "schema:Thing"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Component",
+            "sms:required": "sms:true",
+            "sms:validationRules": []
+        },
+        {
             "@id": "bts:Patient",
             "@type": "rdfs:Class",
             "rdfs:comment": "TBD",
@@ -2985,23 +3002,6 @@
             },
             "sms:displayName": "SourceManifest",
             "sms:required": "sms:true",
-            "sms:validationRules": []
-        },
-        {
-            "@id": "bts:Component",
-            "@type": "rdfs:Class",
-            "rdfs:comment": "TBD",
-            "rdfs:label": "Component",
-            "rdfs:subClassOf": [
-                {
-                    "@id": "bts:Patient"
-                }
-            ],
-            "schema:isPartOf": {
-                "@id": "http://schema.biothings.io"
-            },
-            "sms:displayName": "Component",
-            "sms:required": "sms:false",
             "sms:validationRules": []
         },
         {


### PR DESCRIPTION
This PR addresses the issue where the desired functionality is to have Component show up as a required column in Example manifests. The data model previously did not contain `Component` as an attribute. This change adds `Component` as a Required attribute. 

Test via CLI with:
```
schematic manifest -c config.yml get -dt Patient -p tests/data/example.model.jsonld -s
```