### PR TITLE
[bug fix] Updated parameters being used when generating existing manifests in test_api.py

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -401,8 +401,7 @@ class TestManifestOperation:
 
     #@pytest.mark.parametrize("output_format", [None, "excel", "google_sheet", "dataframe (only if getting existing manifests)"])
     @pytest.mark.parametrize("output_format", ["excel"])
-    @pytest.mark.parametrize("data_type", ["Biospecimen"])
-    # @pytest.mark.parametrize("data_type", ["Biospecimen", "Patient", "all manifests", ["Biospecimen", "Patient"]])
+    @pytest.mark.parametrize("data_type", ["Biospecimen", "Patient", "all manifests", ["Biospecimen", "Patient"]])
     def test_generate_existing_manifest(self, client, data_model_jsonld, data_type, output_format, caplog):
         # set dataset
         if data_type == "Patient":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -401,15 +401,16 @@ class TestManifestOperation:
 
     #@pytest.mark.parametrize("output_format", [None, "excel", "google_sheet", "dataframe (only if getting existing manifests)"])
     @pytest.mark.parametrize("output_format", ["excel"])
-    @pytest.mark.parametrize("data_type", ["Biospecimen", "Patient", "all manifests", ["Biospecimen", "Patient"]])
+    @pytest.mark.parametrize("data_type", ["Biospecimen"])
+    # @pytest.mark.parametrize("data_type", ["Biospecimen", "Patient", "all manifests", ["Biospecimen", "Patient"]])
     def test_generate_existing_manifest(self, client, data_model_jsonld, data_type, output_format, caplog):
         # set dataset
         if data_type == "Patient":
-            dataset_id = ["syn42171373"] #Mock Patient Manifest folder on synapse
+            dataset_id = ["syn51730545"] #Mock Patient Manifest folder on synapse
         elif data_type == "Biospecimen":
-            dataset_id = ["syn42171508"] #Mock biospecimen manifest folder
+            dataset_id = ["syn51730547"] #Mock biospecimen manifest folder
         elif data_type == ["Biospecimen", "Patient"]:
-            dataset_id = ["syn42171508", "syn42171373"]
+            dataset_id = ["syn51730547", "syn51730545"]
         else: 
             dataset_id = None #if "all manifests", dataset id is None
 


### PR DESCRIPTION
## Changelog: 
Updated parameters being used in test_api.py so that we are actually getting existing manifest. 
Also related to: https://sagebionetworks.jira.com/browse/FDS-712


Have to merge 1260 before fixing the issue in test_api.py
depends on: https://github.com/Sage-Bionetworks/schematic/pull/1260