### PR TITLE
Fix Google Sheet column info mismatch FDS-675

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1581,8 +1581,13 @@ class ManifestGenerator(object):
         # Identify columns to add to the end of the manifest
         end_columns = list(out_of_schema_columns)
         
-        # Make sure entityId is at the end of the list
-        if 'entityId' in end_columns and end_columns[-1] != 'entityId':
+        # Make sure want Uuids at the end before entityId is at the end of the list
+        for id_name in ['Uuid', 'Id']:
+            if id_name in end_columns:
+                end_columns.remove(id_name)
+                end_columns.append(id_name)
+
+        if 'entityId' in end_columns:
             end_columns.remove('entityId')
             end_columns.append('entityId')
         

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1462,7 +1462,7 @@ class ManifestGenerator(object):
             return output_file_path
         
         # Return google sheet if sheet_url flag is raised.
-        elif sheet_url: 
+        elif sheet_url:
             manifest_sh = self.set_dataframe_by_url(manifest_url=empty_manifest_url, manifest_df=dataframe, out_of_schema_columns=out_of_schema_columns)
             return manifest_sh.url
         
@@ -1520,7 +1520,7 @@ class ManifestGenerator(object):
         if manifest_record:
             # TODO: Update or remove the warning in self.__init__() if
             # you change the behavior here based on self.use_annotations
-
+            breakpoint()
             # Update df with existing manifest. Agnostic to output format
             updated_df, out_of_schema_columns = self._update_dataframe_with_existing_df(empty_manifest_url=empty_manifest_url, existing_df=manifest_record[1])
 
@@ -1554,7 +1554,7 @@ class ManifestGenerator(object):
 
                 # Update `additional_metadata` and generate manifest
                 manifest_url, manifest_df = self.get_manifest_with_annotations(annotations)
-            
+            breakpoint()
             # Update df with existing manifest. Agnostic to output format
             updated_df, out_of_schema_columns = self._update_dataframe_with_existing_df(empty_manifest_url=empty_manifest_url, existing_df=manifest_df)
 
@@ -1564,6 +1564,7 @@ class ManifestGenerator(object):
                                                       sheet_url = sheet_url,
                                                       empty_manifest_url=empty_manifest_url,
                                                       dataframe = manifest_df,
+                                                      out_of_schema_columns = out_of_schema_columns,
                                                       )
             return result
 

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1588,7 +1588,7 @@ class ManifestGenerator(object):
                 end_columns.append(id_name)
         
         # Add entity_id to the end columns if it should be there but isn't
-        elif 'entityId' in (current_schema_headers or existing_manfiest_headers) and 'entityId' not in end_columns:
+        if 'entityId' in (current_schema_headers or existing_manfiest_headers) and 'entityId' not in end_columns:
             end_columns.append('entityId')
         return end_columns
 

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1522,7 +1522,6 @@ class ManifestGenerator(object):
         if manifest_record:
             # TODO: Update or remove the warning in self.__init__() if
             # you change the behavior here based on self.use_annotations
-            breakpoint()
             # Update df with existing manifest. Agnostic to output format
             updated_df, out_of_schema_columns = self._update_dataframe_with_existing_df(empty_manifest_url=empty_manifest_url, existing_df=manifest_record[1])
 

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1581,15 +1581,11 @@ class ManifestGenerator(object):
         # Identify columns to add to the end of the manifest
         end_columns = list(out_of_schema_columns)
         
-        # Make sure want Uuids at the end before entityId is at the end of the list
-        for id_name in ['Uuid', 'Id']:
+        # Make sure want Ids are placed at end of manifest, in given order.
+        for id_name in ['Uuid', 'Id', 'entityId']:
             if id_name in end_columns:
                 end_columns.remove(id_name)
                 end_columns.append(id_name)
-
-        if 'entityId' in end_columns:
-            end_columns.remove('entityId')
-            end_columns.append('entityId')
         
         # Add entity_id to the end columns if it should be there but isn't
         elif 'entityId' in (current_schema_headers or existing_manfiest_headers) and 'entityId' not in end_columns:

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1298,6 +1298,8 @@ class ManifestGenerator(object):
             start_col = self._column_to_letter(len(manifest_df.columns) - num_out_of_schema_columns) # find start of out of schema columns
             end_col = self._column_to_letter(len(manifest_df.columns) + 1) # find end of out of schema columns
             wb.set_data_validation(start = start_col, end = end_col, condition_type = None)
+        
+
         # set permissions so that anyone with the link can edit
         sh.share("", role="writer", type="anyone")
 
@@ -1554,7 +1556,6 @@ class ManifestGenerator(object):
 
                 # Update `additional_metadata` and generate manifest
                 manifest_url, manifest_df = self.get_manifest_with_annotations(annotations)
-            breakpoint()
             # Update df with existing manifest. Agnostic to output format
             updated_df, out_of_schema_columns = self._update_dataframe_with_existing_df(empty_manifest_url=empty_manifest_url, existing_df=manifest_df)
 
@@ -1563,10 +1564,33 @@ class ManifestGenerator(object):
                                                       output_path = output_path,
                                                       sheet_url = sheet_url,
                                                       empty_manifest_url=empty_manifest_url,
-                                                      dataframe = manifest_df,
+                                                      dataframe = updated_df,
                                                       out_of_schema_columns = out_of_schema_columns,
                                                       )
             return result
+
+    def _get_end_columns(self, current_schema_headers, existing_manifest_headers, out_of_schema_columns):
+        """
+        Gather columns to be added to the end of the manifest, and ensure entityId is at the end.
+        Args:
+            current_schema_headers: list, columns in the current manifest schema
+            existing_manifest_headers: list, columns in the existing manifest
+            out_of_schema_columns: set, columns that are in the existing manifest, but not the current schema
+        Returns:
+            end_columns: list of columns to be added to the end of the manifest.
+        """
+        # Identify columns to add to the end of the manifest
+        end_columns = list(out_of_schema_columns)
+        
+        # Make sure entityId is at the end of the list
+        if 'entityId' in end_columns and end_columns[-1] != 'entityId':
+            end_columns.remove('entityId')
+            end_columns.append('entityId')
+        
+        # Add entity_id to the end columns if it should be there but isn't
+        elif 'entityId' in (current_schema_headers or existing_manfiest_headers) and 'entityId' not in end_columns:
+            end_columns.append('entityId')
+        return end_columns
 
     def _update_dataframe_with_existing_df(self, empty_manifest_url: str, existing_df: pd.DataFrame) -> pd.DataFrame:
         """
@@ -1585,13 +1609,13 @@ class ManifestGenerator(object):
 
         # Get headers for the current schema and existing manifest df.
         current_schema_headers = list(self.get_dataframe_by_url(empty_manifest_url).columns)
-        existing_manfiest_headers = list(existing_df.columns)
+        existing_manifest_headers = list(existing_df.columns)
 
         # Find columns that exist in the current schema, but are not in the manifest being downloaded.
-        new_columns = self._get_missing_columns(current_schema_headers, existing_manfiest_headers)
+        new_columns = self._get_missing_columns(current_schema_headers, existing_manifest_headers)
 
         # Find columns that exist in the manifest being downloaded, but not in the current schema.
-        out_of_schema_columns = self._get_missing_columns(existing_manfiest_headers, current_schema_headers)
+        out_of_schema_columns = self._get_missing_columns(existing_manifest_headers, current_schema_headers)
 
         # clean empty columns if any are present (there should be none)
         # TODO: Remove this line once we start preventing empty column names
@@ -1607,12 +1631,17 @@ class ManifestGenerator(object):
                 **dict(zip(new_columns, len(new_columns) * [""]))
             )
 
+        end_columns = self._get_end_columns(current_schema_headers=current_schema_headers,
+                                           existing_manifest_headers=existing_manifest_headers,
+                                           out_of_schema_columns=out_of_schema_columns)
+        
         # sort columns in the updated manifest:
         # match latest schema order
         # move obsolete columns at the end
         updated_df = updated_df[self.sort_manifest_fields(updated_df.columns)]
-        updated_df = updated_df[[c for c in updated_df if c not in out_of_schema_columns] + list(out_of_schema_columns)]
 
+        # move obsolete columns at the end with entityId at the very end
+        updated_df = updated_df[[c for c in updated_df if c not in end_columns] + list(end_columns)]
         return updated_df, out_of_schema_columns
 
     def _format_new_excel_column(self, worksheet, new_column_index: int, col: str):


### PR DESCRIPTION
[FDS-675
](https://sagebionetworks.jira.com/browse/FDS-675)
@allaway observed that when using google sheets the comments at the tops of the columns were not matched up properly. Upon inspection it appeared as if columns that were outside the schema (being pulled from Synapse but not present in the data model) were not getting added to the end of the manifest as anticipated. These were being inserted within the schema columns and was throwing off the formatting. Since these columns are outside the model they do not have notes/formatting applied to them.

I found the error was in passing the wrong df to the output handler. I corrected this and also corrected an issue were the `entitityId` column was not being put at the very end of the manifest, after the out_of_schema_columns were moved. 

Note the full issue that Robert observed will not be fixed with this issue since `entityId` was accidentally added to the model. Once that is resolved, the columns will appear as anticipated.

Test with the following:

```
schematic manifest -c config.yml get -dt ScRNA-seqLevel1 -p tests/data/HTAN.model.jsonld -d syn23665337 -s -a
```
with `asset_view`: syn22125563

and Roberts case:
```
To reproduce

[dev schematic swagger UI](https://schematic-dev.api.sagebionetworks.org/v1/ui/#/Manifest%20Operations/schematic_api.api.routes.get_manifest_route) manifest/generate endpoint

schema_url: https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/v7.1.7/NF.jsonld

data_type: RNASeqTemplate

use_annotations: false or true (NF-OSI needs true)

dataset_id: syn51907743

asset_view: syn16858331

output_format: google_sheet (bug does not happen with excel)
```

Should see entityId at then end and the column notes matching throughout.
Here is a [copy of the incorrect manifest](https://docs.google.com/spreadsheets/d/1bmAAOYNzF5NyEm4FrkbAwR20CC59brtBUdIwTRYhvY0/edit?usp=sharing).

