### PR TITLE
[bug fix] Updated manifest download endpoint to avoid querying file view

### DIFF
--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -28,7 +28,6 @@ from schematic.schemas.explorer import SchemaExplorer
 from schematic.store.synapse import SynapseStorage, ManifestDownload
 from synapseclient.core.exceptions import SynapseHTTPError, SynapseAuthenticationError, SynapseUnmetAccessRestrictions, SynapseNoCredentialsError, SynapseTimeoutError
 from schematic.utils.general import entity_type_mapping
-from synapseclient.client import Synapse
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -28,6 +28,7 @@ from schematic.schemas.explorer import SchemaExplorer
 from schematic.store.synapse import SynapseStorage, ManifestDownload
 from synapseclient.core.exceptions import SynapseHTTPError, SynapseAuthenticationError, SynapseUnmetAccessRestrictions, SynapseNoCredentialsError, SynapseTimeoutError
 from schematic.utils.general import entity_type_mapping
+from synapseclient.client import Synapse
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
@@ -560,10 +561,8 @@ def download_manifest(access_token, manifest_id, new_manifest_name='', as_json=T
     # call config_handler()
     config_handler()
 
-    # use Synapse Storage
-    store = SynapseStorage(access_token=access_token)
-    # try logging in to asset store
-    syn = store.login(access_token=access_token)
+    # use login method in synapse storage
+    syn = SynapseStorage.login(access_token=access_token)
     try: 
         md = ManifestDownload(syn, manifest_id)
         manifest_data = ManifestDownload.download_manifest(md, new_manifest_name)


### PR DESCRIPTION
Related to the Jira issue here: https://sagebionetworks.jira.com/browse/FDS-776

## Changelog
Avoid instantiating file view before calling the login method. Since we could not cache file view, this change will allow manifest/download to be faster and avoid downloading the same file repeatedly. 