### PR TITLE
Add API endpoint that returns the current version of schematic

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
           
+      - name: Set env variable for version tag
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Test variable assignment
+        run: |
+          echo $RELEASE_VERSION
+          echo ${{ env.RELEASE_VERSION }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -41,6 +49,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{raw}}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -57,3 +57,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            TAG=${{ env.RELEASE_VERSION }}
+            

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Set env variable for version tag
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - name: Test variable assignment
-        run: |
-          echo $RELEASE_VERSION
-          echo ${{ env.RELEASE_VERSION }}
-
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 # FROM python:3.10.6
 FROM python:3.10.8-slim-bullseye
 
+# add version as a build argument
+ARG tag
+
 ENV PYTHONFAULTHANDLER=1 \
   PYTHONUNBUFFERED=1 \
   PYTHONHASHSEED=random \
   PIP_NO_CACHE_DIR=off \
   PIP_DISABLE_PIP_VERSION_CHECK=on \
   PIP_DEFAULT_TIMEOUT=200 \
-  POETRY_VERSION=1.2.0
+  POETRY_VERSION=1.2.0 \
+  VERSION=$tag
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
 # FROM python:3.10.6
 FROM python:3.10.8-slim-bullseye
 
-# add version as a build argument
-ARG TAG
-
 ENV PYTHONFAULTHANDLER=1 \
   PYTHONUNBUFFERED=1 \
   PYTHONHASHSEED=random \
   PIP_NO_CACHE_DIR=off \
   PIP_DISABLE_PIP_VERSION_CHECK=on \
   PIP_DEFAULT_TIMEOUT=200 \
-  POETRY_VERSION=1.2.0 \
-  VERSION=$TAG
+  POETRY_VERSION=1.2.0
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.10.8-slim-bullseye
 
 # add version as a build argument
-ARG tag
+ARG TAG
 
 ENV PYTHONFAULTHANDLER=1 \
   PYTHONUNBUFFERED=1 \
@@ -11,7 +11,7 @@ ENV PYTHONFAULTHANDLER=1 \
   PIP_DISABLE_PIP_VERSION_CHECK=on \
   PIP_DEFAULT_TIMEOUT=200 \
   POETRY_VERSION=1.2.0 \
-  VERSION=$tag
+  VERSION=$TAG
 
 WORKDIR /usr/src/app
 

--- a/schematic_api/Dockerfile
+++ b/schematic_api/Dockerfile
@@ -1,5 +1,8 @@
 FROM tiangolo/uwsgi-nginx-flask:python3.10
 
+# add version tag as a build argument
+ARG tag
+
 # the environment variables defined here are the default
 # and can be overwritten by docker run -e VARIABLE = XX
 # or can be overwritten by .env when using docker compose
@@ -15,7 +18,8 @@ ENV PYTHONFAULTHANDLER=1 \
     APP_DIR=/app/app \
     ROOT=/ \
     UWSGI_INI=/app/uwsgi.ini \
-    NGINX_WORKER_PROCESSES=1
+    NGINX_WORKER_PROCESSES=1 \
+    VERSION=$tag
 
 # Note: 
 # The starting number of uWSGI processes is controlled by the variable UWSGI_CHEAPER, by default set to 2.

--- a/schematic_api/Dockerfile
+++ b/schematic_api/Dockerfile
@@ -1,7 +1,7 @@
 FROM tiangolo/uwsgi-nginx-flask:python3.10
 
 # add version tag as a build argument
-ARG tag
+ARG TAG
 
 # the environment variables defined here are the default
 # and can be overwritten by docker run -e VARIABLE = XX
@@ -19,7 +19,7 @@ ENV PYTHONFAULTHANDLER=1 \
     ROOT=/ \
     UWSGI_INI=/app/uwsgi.ini \
     NGINX_WORKER_PROCESSES=1 \
-    VERSION=$tag
+    VERSION=$TAG
 
 # Note: 
 # The starting number of uWSGI processes is controlled by the variable UWSGI_CHEAPER, by default set to 2.

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -1262,7 +1262,7 @@ paths:
                           Family History,FamilyHistory,TBD,False,True,," If Diagnosis is ""Cancer"" then ""Family History"" is required",Patient                  
       tags:
         - Visualization Operations
-        
+
   /version:
     get:
       summary: Get the version of schematic currently being used
@@ -1277,7 +1277,7 @@ paths:
               schema:
                 type: string
         "500":
-          description: Version not found.
+          description: Schematic version was not able to be identified.
           content:
             text/json:
               schema:

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -1262,4 +1262,19 @@ paths:
                           Family History,FamilyHistory,TBD,False,True,," If Diagnosis is ""Cancer"" then ""Family History"" is required",Patient                  
       tags:
         - Visualization Operations
+  /version:
+    get:
+      summary: Get the version of schematic currently being used
+      description: >-
+        Get the version of schematic that is currently deployed and being used
+      operationId: schematic_api.api.routes.get_schematic_version
+      responses:
+        "200":
+          description: Returns a JSON String containing the version of schematic.
+          content:
+            text/json:
+              schema:
+                type: string
+      tags:
+        - Version
         

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -1262,6 +1262,7 @@ paths:
                           Family History,FamilyHistory,TBD,False,True,," If Diagnosis is ""Cancer"" then ""Family History"" is required",Patient                  
       tags:
         - Visualization Operations
+        
   /version:
     get:
       summary: Get the version of schematic currently being used
@@ -1271,6 +1272,12 @@ paths:
       responses:
         "200":
           description: Returns a JSON String containing the version of schematic.
+          content:
+            text/json:
+              schema:
+                type: string
+        "500":
+          description: Version not found.
           content:
             text/json:
               schema:

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -1273,15 +1273,11 @@ paths:
         "200":
           description: Returns a JSON String containing the version of schematic.
           content:
-            text/json:
+            text/plain:
               schema:
                 type: string
         "500":
           description: Schematic version was not able to be identified.
-          content:
-            text/json:
-              schema:
-                type: string
       tags:
         - Version
         

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -821,4 +821,8 @@ def get_schematic_version() -> str:
     """
     if "VERSION" in os.environ:
         version = os.environ["VERSION"]
+    else:
+        raise NotImplementedError(
+            "Using this endpoint to check the version of schematic is only supported when the API is running in a docker container."
+        )
     return version

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -815,3 +815,8 @@ def get_nodes_display_names(schema_url: str, node_list: list[str]) -> list:
     node_display_names = gen.get_nodes_display_names(node_list, mm_graph)
     return node_display_names
 
+def get_schematic_version() -> str:
+    """
+    Return the current version of schematic
+    """
+    return json.dumps("v0.1.55-betaTEST")

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -821,4 +821,4 @@ def get_schematic_version() -> str:
     """
     if "VERSION" in os.environ:
         version = os.environ["VERSION"]
-    return json.dumps(version)
+    return version

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -819,4 +819,6 @@ def get_schematic_version() -> str:
     """
     Return the current version of schematic
     """
-    return json.dumps("v0.1.55-betaTEST")
+    if "VERSION" in os.environ:
+        version = os.environ["VERSION"]
+    return json.dumps(version)


### PR DESCRIPTION
This PR adds an endpoint `/version` to the API to be used when schematic is deployed to AWS or running in a docker container. The endpoint will return the version of schematic, as identified by the tag that triggered the creation of the docker image. The tag is extracted from GitHub and is assigned as an environment variable `VERSION` in the `DockerFile` this is then available when a container is run.

Currently not usable when running the API outside of a docker container, it will return a `500 SERVER ERROR` response.

The schematic version tag was also added as an environment variable to the non-api image as well.

## To Test

- Pull the latest test image based on this branch 
  - `docker pull ghcr.io/sage-bionetworks/schematic:0.1.58-beta`
- Run the API with a docker container
  - `docker run --rm -p 3001:3001 -v $(pwd):/schematic -w /schematic --name schematic -e GE_HOME=/usr/src/app/great_expectations/ ghcr.io/sage-bionetworks/schematic:0.1.58-beta python run_api.py`
- Use SwaggerUI to use the api and use the `/version` [endpoint](http://localhost:3001/v1/ui/#/Version/schematic_api.api.routes.get_schematic_version)
- verify that the endpoint returns the version os schematic used to create the image, in this case `v0.1.58-beta` 
