### PR TITLE
[bug fix] Do not pull annotations when use_annotations set to False and there is no existing manifests

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -462,7 +462,6 @@ class ManifestGenerator(object):
                 )
             else:
                 self.additional_metadata["Component"] = [self.root]
-
         return
 
     def _get_additional_metadata(self, required_metadata_fields: dict) -> dict:
@@ -1527,7 +1526,7 @@ class ManifestGenerator(object):
         manifest_record = store.updateDatasetManifestFiles(self.sg, datasetId = dataset_id, store = False)
 
         # get URL of an empty manifest file created based on schema component
-        empty_manifest_url = self.get_empty_manifest(strict=strict, sheet_url=sheet_url)
+        empty_manifest_url = self.get_empty_manifest(strict=strict, sheet_url=True)
 
         # Populate empty template with existing manifest
         if manifest_record:
@@ -1547,35 +1546,45 @@ class ManifestGenerator(object):
             return result
 
         # Generate empty template and optionally fill in with annotations
+        # if there is no existing manifest and use annotations is set to True, 
+        # pull annotations (in reality, annotations should be empty when there is no existing manifest)
         else:
             # Using getDatasetAnnotations() to retrieve file names and subset
             # entities to files and folders (ignoring tables/views)
-
             annotations = pd.DataFrame()
-            if self.is_file_based:
-                annotations = store.getDatasetAnnotations(dataset_id)
+            if self.use_annotations:
+                if self.is_file_based:
+                    annotations = store.getDatasetAnnotations(dataset_id)
+                    # in the old code, we take a subset of columns if no interested in user-defined annotations and there are files present
 
-            # if there are no files with annotations just generate an empty manifest
-            if annotations.empty:
-                manifest_url = self.get_empty_manifest(strict=strict)
-                manifest_df = self.get_dataframe_by_url(manifest_url)
-            else:
+                # if there are no files with annotations just generate an empty manifest
+                if annotations.empty:
+                    #manifest_url = self.get_empty_manifest(strict=strict)
+                    manifest_df = self.get_dataframe_by_url(empty_manifest_url)
+
+            # else:
                 # Subset columns if no interested in user-defined annotations and there are files present
-                if self.is_file_based and not self.use_annotations:
-                    annotations = annotations[["Filename", "eTag", "entityId"]]
-
-                # Update `additional_metadata` and generate manifest
-                manifest_url, manifest_df = self.get_manifest_with_annotations(annotations, sheet_url=sheet_url, strict=strict)
+                # if self.is_file_based:
+                #     annotations = annotations[["Filename", "eTag", "entityId"]]
+        
+            # Update `additional_metadata` and generate manifest
+            manifest_url, manifest_df = self.get_manifest_with_annotations(annotations, sheet_url=sheet_url, strict=strict)
 
             # Update df with existing manifest. Agnostic to output format
             updated_df, out_of_schema_columns = self._update_dataframe_with_existing_df(empty_manifest_url=empty_manifest_url, existing_df=manifest_df)
+
+            # if dataset id is provided, try getting a list of filenames and fill in to manifest
+            if dataset_id:
+                dataset_files, updated_manifest = store.fill_in_entity_id_filename(dataset_id, updated_df)
+            else:
+                updated_manifest = updated_df
 
             # determine the format of manifest that gets return 
             result = self._handle_output_format_logic(output_format = output_format,
                                                       output_path = output_path,
                                                       sheet_url = sheet_url,
                                                       empty_manifest_url=empty_manifest_url,
-                                                      dataframe = updated_df,
+                                                      dataframe = updated_manifest,
                                                       out_of_schema_columns = out_of_schema_columns,
                                                       )
             return result


### PR DESCRIPTION
## Changelog
* When there is no existing manifests, only pull annotations when `use_annotations = True`.
* Currently, the logic of filling in Filename and `entityId` is in function `updateDatasetManifestFiles`, and it only pulls in `Filename` and `entityId` when there is an existing manifest. I changed the behavior so that when there is no existing manifests and `use_annotations = False`, filename and entityId in manifest still get filled. 

## Discussion 
In the old code, if there is no existing manifest, but a component is file-base, and there is annotation but users are not interested in annotations, there is this statement here that only give users `Filename`, `eTag`, and `entityId`
```
            else:
                #Subset columns if no interested in user-defined annotations and there are files present
                if self.is_file_based:
                    annotations = annotations[["Filename", "eTag", "entityId"]]
```
Can we just delete this part? Since if there is no existing manifest and `use_annotations = False`, we are no longer pulling annotations
