### PR TITLE
[bug fix] Added includesType parameter when using walk function 

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -35,7 +35,7 @@ from synapseclient.entity import File
 from synapseclient.table import CsvFileTable, build_table, Schema
 from synapseclient.annotations import from_synapse_annotations
 from synapseclient.core.exceptions import SynapseHTTPError, SynapseAuthenticationError, SynapseUnmetAccessRestrictions
-from synapseutils import walk
+import synapseutils
 from synapseutils.copy_functions import changeFileMetaData
 
 import uuid
@@ -413,7 +413,7 @@ class SynapseStorage(BaseStorage):
         """
 
         # select all files within a given storage dataset folder (top level folder in a Synapse storage project or folder marked with contentType = 'dataset')
-        walked_path = walk(self.syn, datasetId, includeTypes=["folder", "file"])
+        walked_path = synapseutils.walk(self.syn, datasetId, includeTypes=["folder", "file"])
 
         file_list = []
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -413,7 +413,7 @@ class SynapseStorage(BaseStorage):
         """
 
         # select all files within a given storage dataset folder (top level folder in a Synapse storage project or folder marked with contentType = 'dataset')
-        walked_path = walk(self.syn, datasetId)
+        walked_path = walk(self.syn, datasetId, includeTypes=["folder", "file"])
 
         file_list = []
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -237,7 +237,8 @@ class TestSynapseStorage:
         with pytest.raises(PermissionError):
             synapse_store.getDatasetProject("syn12345678")
     
-    def test_getFilesInStorageDataset(self, synapse_store):
+    @pytest.mark.parametrize("full_path", [True, False])
+    def test_getFilesInStorageDataset(self, synapse_store, full_path):
         mock_return = [
         (
             ("parent_folder", "syn123"),
@@ -250,11 +251,14 @@ class TestSynapseStorage:
             [("test_file_2", "syn125")],
         ),
         ]
-        expected_return = [('syn126', 'parent_folder/test_file'), ('syn125', 'parent_folder/test_folder/test_file_2')]
+        expected_return_full_path = [('syn126', 'parent_folder/test_file'), ('syn125', 'parent_folder/test_folder/test_file_2')]
+        expected_return_not_full_path = [('syn126', 'test_file'), ('syn125', 'test_file_2')]
         with patch('synapseutils.walk_functions._helpWalk', return_value=mock_return):
-            file_list = synapse_store.getFilesInStorageDataset(datasetId="syn_mock", fileNames=None, fullpath=True)
-            assert file_list == expected_return
-
+            file_list = synapse_store.getFilesInStorageDataset(datasetId="syn_mock", fileNames=None, fullpath=full_path)
+            if full_path:
+                assert file_list == expected_return_full_path
+            else:
+                assert file_list == expected_return_not_full_path
 
     @pytest.mark.parametrize("downloadFile", [True, False])
     def test_getDatasetManifest(self, synapse_store, downloadFile):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -237,8 +237,8 @@ class TestSynapseStorage:
         with pytest.raises(PermissionError):
             synapse_store.getDatasetProject("syn12345678")
     
-    @pytest.mark.parametrize("full_path", [True, False])
-    def test_getFilesInStorageDataset(self, synapse_store, full_path):
+    @pytest.mark.parametrize("full_path,expected", [(True, [('syn126', 'parent_folder/test_file'), ('syn125', 'parent_folder/test_folder/test_file_2')]),(False, [('syn126', 'test_file'), ('syn125', 'test_file_2')])])
+    def test_getFilesInStorageDataset(self, synapse_store, full_path, expected):
         mock_return = [
         (
             ("parent_folder", "syn123"),
@@ -251,14 +251,9 @@ class TestSynapseStorage:
             [("test_file_2", "syn125")],
         ),
         ]
-        expected_return_full_path = [('syn126', 'parent_folder/test_file'), ('syn125', 'parent_folder/test_folder/test_file_2')]
-        expected_return_not_full_path = [('syn126', 'test_file'), ('syn125', 'test_file_2')]
         with patch('synapseutils.walk_functions._helpWalk', return_value=mock_return):
             file_list = synapse_store.getFilesInStorageDataset(datasetId="syn_mock", fileNames=None, fullpath=full_path)
-            if full_path:
-                assert file_list == expected_return_full_path
-            else:
-                assert file_list == expected_return_not_full_path
+            assert file_list == expected
 
     @pytest.mark.parametrize("downloadFile", [True, False])
     def test_getDatasetManifest(self, synapse_store, downloadFile):


### PR DESCRIPTION
Related to Jira: https://sagebionetworks.jira.com/browse/FDS-883

## Changelog
* added IncludeTypes parameter when calling `getFilesInStorageDataset`
* added unit test for `getFilesInStorageDataset` function 
* re-order import statement 

Note: when writing unit test, I noticed that we are not catching cases where `fileNames` is not None in `getFilesInStorageDataset` function. See jira issue FDS 889 for details