### PR TITLE
Raise a helpful error when a datatype cannot be found in a schema

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -80,22 +80,22 @@ class ManifestGenerator(object):
         # additional metadata to add to manifest
         self.additional_metadata = additional_metadata
 
+        # Raise an error if no DataType has been provided
+        if not self.root:
+            raise ValueError("No DataType has been provided.")
+   
+        # Check if the class is in the schema
+        root_in_schema = self.sg.se.is_class_in_schema(self.root)
+        
+        # If the class could not be found, give a notification
+        if not root_in_schema:
+            exception_message = f"The DataType entered ({self.root}) could not be found in the data model schema. " + \
+                                "Please confirm that the datatype is in the data model and that the spelling matches the class label in the .jsonld file."
+            raise LookupError(exception_message) 
+
         # Determine whether current data type is file-based
-        is_file_based = False
+        self.is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
 
-        if self.root:    
-            # Check if the class is in the schema
-            root_in_schema = self.sg.se.is_class_in_schema(self.root)
-            
-            # If the class could not be found, give a notification
-            if not root_in_schema:
-                exception_message = f"The DataType entered ({self.root}) could not be found in the data model schema. " + \
-                                    "Please confirm that the datatype is in the data model and that the spelling matches the class label in the .jsonld file."
-                raise LookupError(exception_message) 
-            
-            is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
-
-        self.is_file_based = is_file_based
 
     def _attribute_to_letter(self, attribute, manifest_fields):
         """Map attribute to column letter in a google sheet"""

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -54,7 +54,11 @@ class ManifestGenerator(object):
         self.creds = services_creds["creds"]
 
         # schema root
-        self.root = root
+        if root:
+            self.root = root
+        # Raise an error if no DataType has been provided
+        else:
+            raise ValueError("No DataType has been provided.")
 
         # alphabetize valid values
         self.alphabetize = alphabetize_valid_values
@@ -79,10 +83,6 @@ class ManifestGenerator(object):
 
         # additional metadata to add to manifest
         self.additional_metadata = additional_metadata
-
-        # Raise an error if no DataType has been provided
-        if not self.root:
-            raise ValueError("No DataType has been provided.")
    
         # Check if the class is in the schema
         root_in_schema = self.sg.se.is_class_in_schema(self.root)

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -87,7 +87,9 @@ class ManifestGenerator(object):
                 is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
             except KeyError as e:
                if self.root in str(e):
-                   raise LookupError(f"The DataType entered ({self.root}) could not be found in the data model schema. Please confirm that the datatype is in the data model and that the spelling matches what is in the .jsonld file.") from e
+                   exception_message = f"The DataType entered ({self.root}) could not be found in the data model schema. " + \
+                                     "Please confirm that the datatype is in the data model and that the spelling matches the class label in the .jsonld file."
+                   raise LookupError(exception_message) from e
                else:
                    raise(e)
 

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -83,7 +83,14 @@ class ManifestGenerator(object):
         # Determine whether current data type is file-based
         is_file_based = False
         if self.root:
-            is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
+            try:
+                is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
+            except KeyError as e:
+               if self.root in str(e):
+                   raise LookupError(f"The DataType entered ({self.root}) could not be found in the data model schema. Please confirm that the datatype is in the data model and that the spelling matches what is in the .jsonld file.") from e
+               else:
+                   raise(e)
+
         self.is_file_based = is_file_based
 
     def _attribute_to_letter(self, attribute, manifest_fields):

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -82,16 +82,18 @@ class ManifestGenerator(object):
 
         # Determine whether current data type is file-based
         is_file_based = False
-        if self.root:
-            try:
-                is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
-            except KeyError as e:
-               if self.root in str(e):
-                   exception_message = f"The DataType entered ({self.root}) could not be found in the data model schema. " + \
-                                     "Please confirm that the datatype is in the data model and that the spelling matches the class label in the .jsonld file."
-                   raise LookupError(exception_message) from e
-               else:
-                   raise(e)
+
+        if self.root:    
+            # Check if the class is in the schema
+            root_in_schema = self.sg.se.is_class_in_schema(self.root)
+            
+            # If the class could not be found, give a notification
+            if not root_in_schema:
+                exception_message = f"The DataType entered ({self.root}) could not be found in the data model schema. " + \
+                                    "Please confirm that the datatype is in the data model and that the spelling matches the class label in the .jsonld file."
+                raise LookupError(exception_message) 
+            
+            is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
 
         self.is_file_based = is_file_based
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -100,7 +100,7 @@ class TestManifestGenerator:
                                ids = ["DataType not found in Schema", "No DataType provided"])
     def test_missing_root_error(self, helpers, data_type, exc, exc_message):
         """
-        The ManifestGenerator should raise a LookupError during initialization if a data_type is passed in that can't be found in the schema.
+        Test for errors when either no DataType is provided or when a DataType is provided but not found in the schema
         """
 
         # A LookupError should be raised and include message when the component cannot be found

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -94,6 +94,24 @@ class TestManifestGenerator:
         assert generator.root is None
         assert type(generator.sg) is SchemaGenerator
 
+    def test_missing_root_error(self, helpers):
+        """
+        The ManifestGenerator should raise a LookupError during initialization if a data_type is passed in that can't be found in the schema.
+        """
+        # Choose a data type that is not in the schema
+        data_type = "MissingComponent"
+
+        # A LookupError should be raised and include message when the component cannot be found
+        with pytest.raises(LookupError) as e:
+            generator = ManifestGenerator(
+            path_to_json_ld=helpers.get_data_path("example.model.jsonld"),
+            root=data_type,
+            use_annotations=False,
+            )        
+
+        # Check message contents
+        assert f"({data_type}) could not be found in the data model schema" in str(e)
+
     @pytest.mark.google_credentials_needed
     def test_get_manifest_first_time(self, manifest):
 
@@ -145,7 +163,7 @@ class TestManifestGenerator:
         # An annotation merged with an attribute from the data model
         if use_annotations:
             assert output["File Format"].tolist() == ["txt", "csv", "fastq"]
-      
+
     @pytest.mark.parametrize("output_format", [None, "dataframe", "excel", "google_sheet"])
     @pytest.mark.parametrize("sheet_url", [None, True, False])
     @pytest.mark.parametrize("dataset_id", [None, "syn27600056"])
@@ -380,6 +398,4 @@ class TestManifestGenerator:
 
         # remove file
         os.remove(dummy_output_path)
-
-
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -87,11 +87,12 @@ class TestManifestGenerator:
         generator = ManifestGenerator(
             title="mock_title",
             path_to_json_ld=helpers.get_data_path("example.model.jsonld"),
+            root = "Patient"
         )
 
         assert type(generator.title) is str
         # assert generator.sheet_service == mock_creds["sheet_service"]
-        assert generator.root is None
+        assert generator.root is "Patient"
         assert type(generator.sg) is SchemaGenerator
 
     @pytest.mark.parametrize("data_type, exc, exc_message",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -94,15 +94,17 @@ class TestManifestGenerator:
         assert generator.root is None
         assert type(generator.sg) is SchemaGenerator
 
-    def test_missing_root_error(self, helpers):
+    @pytest.mark.parametrize("data_type, exc, exc_message",
+                              [("MissingComponent", LookupError, "could not be found in the data model schema"),
+                               (None, ValueError, "No DataType has been provided.")],
+                               ids = ["DataType not found in Schema", "No DataType provided"])
+    def test_missing_root_error(self, helpers, data_type, exc, exc_message):
         """
         The ManifestGenerator should raise a LookupError during initialization if a data_type is passed in that can't be found in the schema.
         """
-        # Choose a data type that is not in the schema
-        data_type = "MissingComponent"
 
         # A LookupError should be raised and include message when the component cannot be found
-        with pytest.raises(LookupError) as e:
+        with pytest.raises(exc) as e:
             generator = ManifestGenerator(
             path_to_json_ld=helpers.get_data_path("example.model.jsonld"),
             root=data_type,
@@ -110,7 +112,7 @@ class TestManifestGenerator:
             )        
 
         # Check message contents
-        assert f"({data_type}) could not be found in the data model schema" in str(e)
+        assert exc_message in str(e)
 
     @pytest.mark.google_credentials_needed
     def test_get_manifest_first_time(self, manifest):


### PR DESCRIPTION
For the linked issue, the error arose because the data type was not spelled according to the conventions of the class label in the schema. The error raised by `networkx`: `return self._nodes[n] \ KeyError: 'AssayRNASeqMetadataTemplate'` was not very good at communicating what was going wrong. I've wrapped another error around this message for the case of generating a manifest that should be more explanatory and offers suggestions for remedying.

Depends on: #1287 