### PR TITLE
BugFix: `is_class_in_schema` no longer errors out when a class is not in schema

### DIFF
--- a/great_expectations/great_expectations.yml
+++ b/great_expectations/great_expectations.yml
@@ -1,109 +1,78 @@
-# Welcome to Great Expectations! Always know what to expect from your data.
-#
-# Here you can define datasources, batch kwargs generators, integrations and
-# more. This file is intended to be committed to your repo. For help with
-# configuration please:
-#   - Read our docs: https://docs.greatexpectations.io/en/latest/reference/spare_parts/data_context_reference.html#configuration
-#   - Join our slack channel: http://greatexpectations.io/slack
-
-# config_version refers to the syntactic version of this config file, and is used in maintaining backwards compatibility
-# It is auto-generated and usually does not need to be changed.
 config_version: 3.0
-
-# Datasources tell Great Expectations where your data lives and how to get it.
-# You can use the CLI command `great_expectations datasource new` to help you
-# add a new datasource. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource.html
 datasources:
-  Manifest:
-    module_name: great_expectations.datasource
-    execution_engine:
-      module_name: great_expectations.execution_engine
-      class_name: PandasExecutionEngine
-    data_connectors:
-      default_runtime_data_connector_name:
-        module_name: great_expectations.datasource.data_connector
-        class_name: RuntimeDataConnector
-        batch_identifiers:
-          - default_identifier
+  pandas:
     class_name: Datasource
-  example_datasource:
     module_name: great_expectations.datasource
     execution_engine:
-      module_name: great_expectations.execution_engine
       class_name: PandasExecutionEngine
     data_connectors:
       default_runtime_data_connector_name:
-        module_name: great_expectations.datasource.data_connector
         class_name: RuntimeDataConnector
         batch_identifiers:
           - default_identifier_name
+  example_datasource:
     class_name: Datasource
-config_variables_file_path: uncommitted/config_variables.yml
-
-# The plugins_directory will be added to your python path for custom modules
-# used to override and extend Great Expectations.
-plugins_directory: plugins/
-
+    module_name: great_expectations.datasource
+    execution_engine:
+      class_name: PandasExecutionEngine
+      module_name: great_expectations.execution_engine
+    data_connectors:
+      default_runtime_data_connector_name:
+        class_name: RuntimeDataConnector
+        module_name: great_expectations.datasource.data_connector
+        batch_identifiers:
+          - default_identifier_name
+expectations_store_name: expectations_store
+validations_store_name: validations_store
+evaluation_parameter_store_name: evaluation_parameter_store
+checkpoint_store_name: checkpoint_store
+profiler_store_name: profiler_store
+plugins_directory:
 stores:
-# Stores are configurable places to store things like Expectations, Validations
-# Data Docs, and more. These are for advanced users only - most users can simply
-# leave this section alone.
-#
-# Three stores are required: expectations, validations, and
-# evaluation_parameters, and must exist with a valid store entry. Additional
-# stores can be configured for uses such as data_docs, etc.
   expectations_store:
     class_name: ExpectationsStore
     store_backend:
       class_name: TupleFilesystemStoreBackend
       base_directory: expectations/
-
+      root_directory: C:\Users\gjordan\Documents\GitHub\schematic\great_expectations
   validations_store:
     class_name: ValidationsStore
     store_backend:
       class_name: TupleFilesystemStoreBackend
       base_directory: uncommitted/validations/
-
+      root_directory: C:\Users\gjordan\Documents\GitHub\schematic\great_expectations
   evaluation_parameter_store:
-    # Evaluation Parameters enable dynamic expectations. Read more here:
-    # https://docs.greatexpectations.io/en/latest/reference/core_concepts/evaluation_parameters.html
     class_name: EvaluationParameterStore
-
   checkpoint_store:
     class_name: CheckpointStore
     store_backend:
       class_name: TupleFilesystemStoreBackend
       suppress_store_backend_id: true
       base_directory: checkpoints/
-
+      root_directory: C:\Users\gjordan\Documents\GitHub\schematic\great_expectations
   profiler_store:
     class_name: ProfilerStore
     store_backend:
       class_name: TupleFilesystemStoreBackend
       suppress_store_backend_id: true
       base_directory: profilers/
-
-expectations_store_name: expectations_store
-validations_store_name: validations_store
-evaluation_parameter_store_name: evaluation_parameter_store
-checkpoint_store_name: checkpoint_store
-
+      root_directory: C:\Users\gjordan\Documents\GitHub\schematic\great_expectations
+notebooks:
 data_docs_sites:
-  # Data Docs make it simple to visualize data quality in your project. These
-  # include Expectations, Validations & Profiles. The are built for all
-  # Datasources from JSON artifacts in the local repo including validations &
-  # profiles from the uncommitted directory. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/data_docs.html
   local_site:
     class_name: SiteBuilder
-    # set to false to hide how-to buttons in Data Docs
     show_how_to_buttons: true
     store_backend:
       class_name: TupleFilesystemStoreBackend
       base_directory: uncommitted/data_docs/local_site/
+      root_directory: C:\Users\gjordan\Documents\GitHub\schematic\great_expectations
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
-
+config_variables_file_path:
 anonymous_usage_statistics:
   data_context_id: 1130ca8d-9731-45d9-bc05-2032535250c8
   enabled: true
-notebooks:
+include_rendered_content:
+  globally: false
+  expectation_suite: false
+  expectation_validation_result: false

--- a/great_expectations/great_expectations.yml
+++ b/great_expectations/great_expectations.yml
@@ -1,78 +1,109 @@
+# Welcome to Great Expectations! Always know what to expect from your data.
+#
+# Here you can define datasources, batch kwargs generators, integrations and
+# more. This file is intended to be committed to your repo. For help with
+# configuration please:
+#   - Read our docs: https://docs.greatexpectations.io/en/latest/reference/spare_parts/data_context_reference.html#configuration
+#   - Join our slack channel: http://greatexpectations.io/slack
+
+# config_version refers to the syntactic version of this config file, and is used in maintaining backwards compatibility
+# It is auto-generated and usually does not need to be changed.
 config_version: 3.0
+
+# Datasources tell Great Expectations where your data lives and how to get it.
+# You can use the CLI command `great_expectations datasource new` to help you
+# add a new datasource. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/datasource.html
 datasources:
-  pandas:
-    class_name: Datasource
+  Manifest:
     module_name: great_expectations.datasource
     execution_engine:
-      class_name: PandasExecutionEngine
-    data_connectors:
-      default_runtime_data_connector_name:
-        class_name: RuntimeDataConnector
-        batch_identifiers:
-          - default_identifier_name
-  example_datasource:
-    class_name: Datasource
-    module_name: great_expectations.datasource
-    execution_engine:
-      class_name: PandasExecutionEngine
       module_name: great_expectations.execution_engine
+      class_name: PandasExecutionEngine
     data_connectors:
       default_runtime_data_connector_name:
-        class_name: RuntimeDataConnector
         module_name: great_expectations.datasource.data_connector
+        class_name: RuntimeDataConnector
+        batch_identifiers:
+          - default_identifier
+    class_name: Datasource
+  example_datasource:
+    module_name: great_expectations.datasource
+    execution_engine:
+      module_name: great_expectations.execution_engine
+      class_name: PandasExecutionEngine
+    data_connectors:
+      default_runtime_data_connector_name:
+        module_name: great_expectations.datasource.data_connector
+        class_name: RuntimeDataConnector
         batch_identifiers:
           - default_identifier_name
-expectations_store_name: expectations_store
-validations_store_name: validations_store
-evaluation_parameter_store_name: evaluation_parameter_store
-checkpoint_store_name: checkpoint_store
-profiler_store_name: profiler_store
-plugins_directory:
+    class_name: Datasource
+config_variables_file_path: uncommitted/config_variables.yml
+
+# The plugins_directory will be added to your python path for custom modules
+# used to override and extend Great Expectations.
+plugins_directory: plugins/
+
 stores:
+# Stores are configurable places to store things like Expectations, Validations
+# Data Docs, and more. These are for advanced users only - most users can simply
+# leave this section alone.
+#
+# Three stores are required: expectations, validations, and
+# evaluation_parameters, and must exist with a valid store entry. Additional
+# stores can be configured for uses such as data_docs, etc.
   expectations_store:
     class_name: ExpectationsStore
     store_backend:
       class_name: TupleFilesystemStoreBackend
       base_directory: expectations/
-      root_directory: C:\Users\gjordan\Documents\GitHub\schematic\great_expectations
+
   validations_store:
     class_name: ValidationsStore
     store_backend:
       class_name: TupleFilesystemStoreBackend
       base_directory: uncommitted/validations/
-      root_directory: C:\Users\gjordan\Documents\GitHub\schematic\great_expectations
+
   evaluation_parameter_store:
+    # Evaluation Parameters enable dynamic expectations. Read more here:
+    # https://docs.greatexpectations.io/en/latest/reference/core_concepts/evaluation_parameters.html
     class_name: EvaluationParameterStore
+
   checkpoint_store:
     class_name: CheckpointStore
     store_backend:
       class_name: TupleFilesystemStoreBackend
       suppress_store_backend_id: true
       base_directory: checkpoints/
-      root_directory: C:\Users\gjordan\Documents\GitHub\schematic\great_expectations
+
   profiler_store:
     class_name: ProfilerStore
     store_backend:
       class_name: TupleFilesystemStoreBackend
       suppress_store_backend_id: true
       base_directory: profilers/
-      root_directory: C:\Users\gjordan\Documents\GitHub\schematic\great_expectations
-notebooks:
+
+expectations_store_name: expectations_store
+validations_store_name: validations_store
+evaluation_parameter_store_name: evaluation_parameter_store
+checkpoint_store_name: checkpoint_store
+
 data_docs_sites:
+  # Data Docs make it simple to visualize data quality in your project. These
+  # include Expectations, Validations & Profiles. The are built for all
+  # Datasources from JSON artifacts in the local repo including validations &
+  # profiles from the uncommitted directory. Read more at https://docs.greatexpectations.io/en/latest/reference/core_concepts/data_docs.html
   local_site:
     class_name: SiteBuilder
+    # set to false to hide how-to buttons in Data Docs
     show_how_to_buttons: true
     store_backend:
       class_name: TupleFilesystemStoreBackend
       base_directory: uncommitted/data_docs/local_site/
-      root_directory: C:\Users\gjordan\Documents\GitHub\schematic\great_expectations
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
-config_variables_file_path:
+
 anonymous_usage_statistics:
   data_context_id: 1130ca8d-9731-45d9-bc05-2032535250c8
   enabled: true
-include_rendered_content:
-  globally: false
-  expectation_suite: false
-  expectation_validation_result: false
+notebooks:

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -184,17 +184,7 @@ class SchemaExplorer:
         return list(nodes)
 
     def is_class_in_schema(self, class_label):
-        
-        # accessing the node in the dictionary will error out if the class is not in the schema
-        try:
-            node = self.schema_nx.nodes[class_label]
-        except(KeyError) as e:
-            if class_label in str(e):
-                node = None
-            else:
-                raise(e)
-        
-        if node:
+        if class_label in self.schema_nx.nodes():
             return True
         else:
             return False

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -184,7 +184,13 @@ class SchemaExplorer:
         return list(nodes)
 
     def is_class_in_schema(self, class_label):
-        if self.schema_nx.nodes[class_label]:
+        
+        try:
+            node = self.schema_nx.nodes[class_label]
+        except(KeyError):
+            node = None
+        
+        if node:
             return True
         else:
             return False

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -185,6 +185,7 @@ class SchemaExplorer:
 
     def is_class_in_schema(self, class_label):
         
+        # accessing the node in the dictionary will error out if the class is not in the schema
         try:
             node = self.schema_nx.nodes[class_label]
         except(KeyError):

--- a/schematic/schemas/explorer.py
+++ b/schematic/schemas/explorer.py
@@ -188,8 +188,11 @@ class SchemaExplorer:
         # accessing the node in the dictionary will error out if the class is not in the schema
         try:
             node = self.schema_nx.nodes[class_label]
-        except(KeyError):
-            node = None
+        except(KeyError) as e:
+            if class_label in str(e):
+                node = None
+            else:
+                raise(e)
         
         if node:
             return True

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -279,7 +279,7 @@ class TestDfParser:
         assert(se_obj.get_class_label_from_display_name("model of manifestation", strict_camel_case = True) == "ModelOfManifestation")
 
 class TestSchemaExplorer:
-    @pytest.mark.parametrize("class_name,expected_in_schema",[("Patient",True),("ptaient",False),("Biospecimen",True),("InvalidComponent",False)])
+    @pytest.mark.parametrize("class_name, expected_in_schema", [("Patient",True), ("ptaient",False), ("Biospecimen",True), ("InvalidComponent",False)])
     def test_is_class_in_schema(self, sg, class_name, expected_in_schema):
         """
         Test to cover checking if a given class is in a schema.

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -281,5 +281,10 @@ class TestDfParser:
 class TestSchemaExplorer:
     @pytest.mark.parametrize("class_name,expected_in_schema",[("Patient",True),("ptaient",False),("Biospecimen",True),("InvalidComponent",False)])
     def test_is_class_in_schema(self, sg, class_name, expected_in_schema):
+        """
+        Test to cover checking if a given class is in a schema.
+        `is_class_in_schema` should return `True` if the class is in the schema
+        and `False` if it is not.
+        """
 
         assert True

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -287,4 +287,8 @@ class TestSchemaExplorer:
         and `False` if it is not.
         """
 
-        assert True
+        # Check if class is in schema
+        class_in_schema = sg.se.is_class_in_schema(class_name)
+
+        # Assert value is as expected
+        assert class_in_schema == expected_in_schema

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -280,6 +280,6 @@ class TestDfParser:
 
 class TestSchemaExplorer:
     @pytest.mark.parametrize("class_name,expected_in_schema",[("Patient",True),("ptaient",False),("Biospecimen",True),("InvalidComponent",False)])
-    def test_is_class_in_schema(sg, class_name, expected_in_schema):
+    def test_is_class_in_schema(self, sg, class_name, expected_in_schema):
 
         assert True

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -6,6 +6,7 @@ import pytest
 
 from schematic.schemas import df_parser
 from schematic.utils.df_utils import load_df
+from schematic.schemas.generator import SchemaGenerator
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -46,6 +47,13 @@ def extended_schema_path(helpers, tmp_path):
 
     yield extended_schema_path
 
+@pytest.fixture
+def sg(helpers):
+
+    inputModelLocation = helpers.get_data_path('example.model.jsonld')
+    sg = SchemaGenerator(inputModelLocation)
+
+    yield sg
 
 class TestDfParser:
     def test_get_class(self, helpers):
@@ -269,3 +277,9 @@ class TestDfParser:
         assert(se_obj.get_class_label_from_display_name("model of manifestation", strict_camel_case = True) == "ModelOfManifestation")
         assert(se_obj.get_class_label_from_display_name("model of manifestation") == "Modelofmanifestation")
         assert(se_obj.get_class_label_from_display_name("model of manifestation", strict_camel_case = True) == "ModelOfManifestation")
+
+class TestSchemaExplorer:
+    @pytest.mark.parametrize("class_name,expected_in_schema",[("Patient",True),("ptaient",False),("Biospecimen",True),("InvalidComponent",False)])
+    def test_is_class_in_schema(sg, class_name, expected_in_schema):
+
+        assert True


### PR DESCRIPTION
This PR fixes the behavior of `is_class_in_schema` so that it no longer raises an error when a class is not in a schema.