### PR TITLE
Move API `access_token` parameter to request header

### DIFF
--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -25,6 +25,7 @@ paths:
       description: Endpoint to create dynamically create metadata manifest files
       security:
         - bearerAuth: []
+        - {}
       parameters:
         - in: query
           name: schema_url

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -115,15 +115,9 @@ paths:
     get:
       summary: Endpoint to download an existing manifest by using a manifest id
       description: Endpoint to download an existing manifest by using a manifest id
+      security:
+        - bearerAuth: []
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          example: Token
-          required: true
         - in: query
           name: manifest_id
           schema:
@@ -164,15 +158,9 @@ paths:
     get:
       summary: Endpoint to download an existing manifest by using a dataset id
       description: Endpoint to download an existing manifest by using a dataset id
+      security:
+        - bearerAuth: []
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          example: Token
-          required: true
         - in: query
           name: asset_view
           schema:
@@ -303,6 +291,8 @@ paths:
                   description: Upload a json or a csv file. 
                   type: string
                   format: binary
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: schema_url
@@ -347,13 +337,6 @@ paths:
           description: If true, annotations with blank values will be hidden from a dataset's annotation list in Synaspe. If false, annotations with blank values will be displayed. Default to false
           required: false
           example: false
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          required: true
         - in: query
           name: asset_view
           schema:
@@ -503,15 +486,9 @@ paths:
       summary:  Get datatype of attributes in manifest
       description: Get datatype of attributes in manifest
       operationId: schematic_api.api.routes.get_manifest_datatype
+      security:
+        - bearerAuth: []
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          example: Token
-          required: true
         - in: query
           name: asset_view
           schema:
@@ -540,15 +517,9 @@ paths:
       summary: Get all storage projects the current user has access to
       description: Gets all storage projects the current user has access to, within the scope of the 'storageFileview' attribute.
       operationId: schematic_api.api.routes.get_storage_projects
+      security:
+        - bearerAuth: []
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          example: Token
-          required: true
         - in: query
           name: asset_view
           schema:
@@ -569,15 +540,9 @@ paths:
       summary: Gets all datasets in folder under a given storage project that the current user has access to.
       description: Gets all datasets in folder under a given storage project that the current user has access to.
       operationId: schematic_api.api.routes.get_storage_projects_datasets
+      security:
+        - bearerAuth: []
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          example: Token
-          required: true
         - in: query
           name: asset_view
           schema:
@@ -606,15 +571,9 @@ paths:
       summary: Get all files in a given dataset folder
       description: Get all files in a given dataset folder
       operationId: schematic_api.api.routes.get_files_storage_dataset
+      security:
+        - bearerAuth: []
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          example: Token
-          required: true
         - in: query
           name: asset_view
           schema:
@@ -659,15 +618,9 @@ paths:
       summary: Retrieve asset view table as a dataframe.
       description: Retrieve asset view table as a dataframe.
       operationId: schematic_api.api.routes.get_asset_view_table
+      security:
+        - bearerAuth: []
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          example: Token
-          required: true
         - in: query
           name: asset_view
           schema:
@@ -696,15 +649,9 @@ paths:
       summary: Gets all metadata manifest files across all datasets in a specified project.
       description: Gets all metadata manifest files across all datasets in a specified project.
       operationId: schematic_api.api.routes.get_project_manifests
+      security:
+        - bearerAuth: []
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          example: Token
-          required: true
         - in: query
           name: project_id
           schema:
@@ -744,15 +691,9 @@ paths:
       summary: Check type of an entity
       description: Check type of an entity and return entity type
       operationId: schematic_api.api.routes.check_entity_type
+      security:
+        - bearerAuth: []      
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          example: Token
-          required: true
         - in: query
           name: entity_id
           schema:
@@ -774,15 +715,9 @@ paths:
       summary: Check if a file or a folder is in a given asset view. Return "true" or "false"
       description: Check if a file or a folder is in a given asset view. Return "true" or "false"
       operationId: schematic_api.api.routes.check_if_files_in_assetview
+      security:
+        - bearerAuth: []      
       parameters:
-        - in: query
-          name: access_token
-          schema:
-            type: string
-            nullable: false
-          description: Token
-          example: Token
-          required: true
         - in: query
           name: asset_view
           schema:

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -23,6 +23,8 @@ paths:
     get:
       summary: Endpoint to facilitate manifest generation
       description: Endpoint to create dynamically create metadata manifest files
+      security:
+        - bearerAuth: []
       parameters:
         - in: query
           name: schema_url
@@ -32,12 +34,6 @@ paths:
           example: >-
             https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld
           required: true
-        - in: query
-          name: access_token
-          schema:
-            type: string
-          description: Token is needed if getting an existing manifest on AWS
-          required: false
         - in: query
           name: title
           schema:

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -11,7 +11,7 @@ servers:
 
 components:
   securitySchemes:
-    bearerAuth:
+    access_token:
       type: http
       scheme: bearer
       bearerFormat: JWT
@@ -24,7 +24,7 @@ paths:
       summary: Endpoint to facilitate manifest generation
       description: Endpoint to create dynamically create metadata manifest files
       security:
-        - bearerAuth: []
+        - access_token: []
         - {}
       parameters:
         - in: query
@@ -117,7 +117,7 @@ paths:
       summary: Endpoint to download an existing manifest by using a manifest id
       description: Endpoint to download an existing manifest by using a manifest id
       security:
-        - bearerAuth: []
+        - access_token: []
       parameters:
         - in: query
           name: manifest_id
@@ -160,7 +160,7 @@ paths:
       summary: Endpoint to download an existing manifest by using a dataset id
       description: Endpoint to download an existing manifest by using a dataset id
       security:
-        - bearerAuth: []
+        - access_token: []
       parameters:
         - in: query
           name: asset_view
@@ -293,7 +293,7 @@ paths:
                   type: string
                   format: binary
       security:
-        - bearerAuth: []
+        - access_token: []
       parameters:
         - in: query
           name: schema_url
@@ -488,7 +488,7 @@ paths:
       description: Get datatype of attributes in manifest
       operationId: schematic_api.api.routes.get_manifest_datatype
       security:
-        - bearerAuth: []
+        - access_token: []
       parameters:
         - in: query
           name: asset_view
@@ -519,7 +519,7 @@ paths:
       description: Gets all storage projects the current user has access to, within the scope of the 'storageFileview' attribute.
       operationId: schematic_api.api.routes.get_storage_projects
       security:
-        - bearerAuth: []
+        - access_token: []
       parameters:
         - in: query
           name: asset_view
@@ -542,7 +542,7 @@ paths:
       description: Gets all datasets in folder under a given storage project that the current user has access to.
       operationId: schematic_api.api.routes.get_storage_projects_datasets
       security:
-        - bearerAuth: []
+        - access_token: []
       parameters:
         - in: query
           name: asset_view
@@ -573,7 +573,7 @@ paths:
       description: Get all files in a given dataset folder
       operationId: schematic_api.api.routes.get_files_storage_dataset
       security:
-        - bearerAuth: []
+        - access_token: []
       parameters:
         - in: query
           name: asset_view
@@ -620,7 +620,7 @@ paths:
       description: Retrieve asset view table as a dataframe.
       operationId: schematic_api.api.routes.get_asset_view_table
       security:
-        - bearerAuth: []
+        - access_token: []
       parameters:
         - in: query
           name: asset_view
@@ -651,7 +651,7 @@ paths:
       description: Gets all metadata manifest files across all datasets in a specified project.
       operationId: schematic_api.api.routes.get_project_manifests
       security:
-        - bearerAuth: []
+        - access_token: []
       parameters:
         - in: query
           name: project_id
@@ -693,7 +693,7 @@ paths:
       description: Check type of an entity and return entity type
       operationId: schematic_api.api.routes.check_entity_type
       security:
-        - bearerAuth: []      
+        - access_token: []      
       parameters:
         - in: query
           name: entity_id
@@ -717,7 +717,7 @@ paths:
       description: Check if a file or a folder is in a given asset view. Return "true" or "false"
       operationId: schematic_api.api.routes.check_if_files_in_assetview
       security:
-        - bearerAuth: []      
+        - access_token: []      
       parameters:
         - in: query
           name: asset_view

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -9,6 +9,14 @@ info:
 servers:
   - url: /v1
 
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      x-bearerInfoFunc: schematic_api.api.security_controller_.info_from_bearerAuth
+
 # TO DO: refactor query parameters and remove access_token
 paths:
   /manifest/generate:

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -14,6 +14,7 @@ from werkzeug.debug import DebuggedApplication
 from flask_cors import cross_origin
 from flask import send_from_directory
 from flask import current_app as app
+from flask import request
 
 import pandas as pd
 import json
@@ -146,6 +147,18 @@ class JsonConverter:
         else: 
             temp_path = save_file(file_key='file_name')
             return temp_path
+
+def get_access_token() -> str:
+    """Get access token from header"""
+    bearer_token = None
+    # Check if the Authorization header is present
+    if "Authorization" in request.headers:
+        auth_header = request.headers["Authorization"]
+
+        # Ensure the header starts with 'Bearer ' and retrieve the token
+        if auth_header.startswith("Bearer "):
+            bearer_token = auth_header.split(" ")[1]
+    return bearer_token
         
 def parse_bool(str_bool):
     if str_bool.lower().startswith('t'):

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -14,6 +14,7 @@ from werkzeug.debug import DebuggedApplication
 from flask_cors import cross_origin
 from flask import send_from_directory
 from flask import current_app as app
+from flask import request
 
 import pandas as pd
 import json
@@ -146,7 +147,19 @@ class JsonConverter:
         else: 
             temp_path = save_file(file_key='file_name')
             return temp_path
-        
+
+def get_access_token() -> str:
+    """Get access token from header"""
+    bearer_token = None
+    # Check if the Authorization header is present
+    if "Authorization" in request.headers:
+        auth_header = request.headers["Authorization"]
+
+        # Ensure the header starts with 'Bearer ' and retrieve the token
+        if auth_header.startswith("Bearer "):
+            bearer_token = auth_header.split(" ")[1]
+    return bearer_token
+ 
 def parse_bool(str_bool):
     if str_bool.lower().startswith('t'):
         return True
@@ -196,7 +209,7 @@ def get_temp_jsonld(schema_url):
     return tmp_file.name
 
 # @before_request
-def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None, asset_view = None, output_format=None, title=None, access_token=None, strict_validation:bool=True):
+def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None, asset_view = None, output_format=None, title=None, bearerAuth=None, strict_validation:bool=True):
     """Get the immediate dependencies that are related to a given source node.
         Args:
             schema_url: link to data model in json ld format
@@ -210,6 +223,7 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
         Returns:
             Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
     """
+    access_token = get_access_token()
 
     # call config_handler()
     config_handler(asset_view = asset_view)
@@ -819,6 +833,9 @@ def get_schematic_version() -> str:
     """
     Return the current version of schematic
     """
+
+    access_token = get_access_token()
+
     if "VERSION" in os.environ:
         version = os.environ["VERSION"]
     else:

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -209,7 +209,7 @@ def get_temp_jsonld(schema_url):
     return tmp_file.name
 
 # @before_request
-def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None, asset_view = None, output_format=None, title=None, access_token=None, strict_validation:bool=True):
+def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None, asset_view = None, output_format=None, title=None, strict_validation:bool=True):
     """Get the immediate dependencies that are related to a given source node.
         Args:
             schema_url: link to data model in json ld format
@@ -223,6 +223,9 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
         Returns:
             Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
     """
+
+    # Get access token from request header
+    access_token = get_access_token()
 
     # call config_handler()
     config_handler(asset_view = asset_view)

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -218,7 +218,6 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
             output_format: contains three option: "excel", "google_sheet", and "dataframe". if set to "excel", return an excel spreadsheet
             use_annotations: Whether to use existing annotations during manifest generation
             asset_view: ID of view listing all project data assets. For example, for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project.
-            access_token: Token
             strict: bool, strictness with which to apply validation rules to google sheets.
         Returns:
             Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
@@ -267,7 +266,8 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
                     f"Please check your submission and try again."
                 )
 
-
+    # Since this function is called in `get_manifest_route`, 
+    # it can use the access_token passed in from there and retain `access_token` as a parameter
     def create_single_manifest(data_type, title, dataset_id=None, output_format=None, access_token=None, strict=strict_validation):
         # create object of type ManifestGenerator
         manifest_generator = ManifestGenerator(
@@ -393,7 +393,8 @@ def submit_manifest_route(schema_url, asset_view=None, manifest_record_type=None
 
     metadata_model = initalize_metadata_model(schema_url)
 
-    access_token = connexion.request.args["access_token"]
+    # Access token now stored in request header
+    access_token = get_access_token()
 
 
     use_schema_label = connexion.request.args["use_schema_label"]
@@ -445,7 +446,10 @@ def populate_manifest_route(schema_url, title=None, data_type=None, return_excel
 
     return populated_manifest_link
 
-def get_storage_projects(access_token, asset_view):
+def get_storage_projects(asset_view):
+    # Access token now stored in request header
+    access_token = get_access_token()
+
     # call config handler 
     config_handler(asset_view=asset_view)
 
@@ -457,7 +461,10 @@ def get_storage_projects(access_token, asset_view):
     
     return lst_storage_projects
 
-def get_storage_projects_datasets(access_token, asset_view, project_id):
+def get_storage_projects_datasets(asset_view, project_id):
+    # Access token now stored in request header
+    access_token = get_access_token()
+
     # call config handler
     config_handler(asset_view=asset_view)
 
@@ -469,7 +476,10 @@ def get_storage_projects_datasets(access_token, asset_view, project_id):
     
     return sorted_dataset_lst
 
-def get_files_storage_dataset(access_token, asset_view, dataset_id, full_path, file_names=None):
+def get_files_storage_dataset(asset_view, dataset_id, full_path, file_names=None):
+    # Access token now stored in request header
+    access_token = get_access_token()
+
     # call config handler
     config_handler(asset_view=asset_view)
 
@@ -484,7 +494,10 @@ def get_files_storage_dataset(access_token, asset_view, dataset_id, full_path, f
     file_lst = store.getFilesInStorageDataset(datasetId=dataset_id, fileNames=file_names, fullpath=full_path)
     return file_lst
 
-def check_if_files_in_assetview(access_token, asset_view, entity_id):
+def check_if_files_in_assetview(asset_view, entity_id):
+    # Access token now stored in request header
+    access_token = get_access_token()
+    
     # call config handler 
     config_handler(asset_view=asset_view)
 
@@ -496,7 +509,10 @@ def check_if_files_in_assetview(access_token, asset_view, entity_id):
 
     return if_exists
 
-def check_entity_type(access_token, entity_id):
+def check_entity_type(entity_id):
+    # Access token now stored in request header
+    access_token = get_access_token()
+        
     # call config handler 
     config_handler()
 
@@ -562,17 +578,19 @@ def get_viz_tangled_tree_layers(schema_url, figure_type):
 
     return layers[0]
 
-def download_manifest(access_token, manifest_id, new_manifest_name='', as_json=True):
+def download_manifest(manifest_id, new_manifest_name='', as_json=True):
     """
     Download a manifest based on a given manifest id. 
     Args:
-        access_token: token of asset store
         manifest_syn_id: syn id of a manifest
         newManifestName: new name of a manifest that gets downloaded.
         as_json: boolean; If true, return a manifest as a json. Default to True
     Return: 
         file path of the downloaded manifest
     """
+    # Access token now stored in request header
+    access_token = get_access_token()
+
     # call config_handler()
     config_handler()
 
@@ -592,7 +610,10 @@ def download_manifest(access_token, manifest_id, new_manifest_name='', as_json=T
         return manifest_local_file_path
 
 #@profile(sort_by='cumulative', strip_dirs=True)  
-def download_dataset_manifest(access_token, dataset_id, asset_view, as_json, new_manifest_name=''):
+def download_dataset_manifest(dataset_id, asset_view, as_json, new_manifest_name=''):
+    # Access token now stored in request header
+    access_token = get_access_token()
+        
     # call config handler
     config_handler(asset_view=asset_view)
 
@@ -616,7 +637,10 @@ def download_dataset_manifest(access_token, dataset_id, asset_view, as_json, new
 
     return manifest_local_file_path
 
-def get_asset_view_table(access_token, asset_view, return_type):
+def get_asset_view_table(asset_view, return_type):
+    # Access token now stored in request header
+    access_token = get_access_token()
+
     # call config handler
     config_handler(asset_view=asset_view)
 
@@ -637,7 +661,10 @@ def get_asset_view_table(access_token, asset_view, return_type):
         return export_path
 
 
-def get_project_manifests(access_token, project_id, asset_view):
+def get_project_manifests(project_id, asset_view):
+    # Access token now stored in request header
+    access_token = get_access_token()
+        
     # use the default asset view from config
     config_handler(asset_view=asset_view)
 
@@ -649,7 +676,10 @@ def get_project_manifests(access_token, project_id, asset_view):
 
     return lst_manifest
 
-def get_manifest_datatype(access_token, manifest_id, asset_view):
+def get_manifest_datatype(manifest_id, asset_view):
+    # Access token now stored in request header
+    access_token = get_access_token()
+    
     # use the default asset view from config
     config_handler(asset_view=asset_view)
 

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -14,7 +14,6 @@ from werkzeug.debug import DebuggedApplication
 from flask_cors import cross_origin
 from flask import send_from_directory
 from flask import current_app as app
-from flask import request
 
 import pandas as pd
 import json
@@ -147,19 +146,7 @@ class JsonConverter:
         else: 
             temp_path = save_file(file_key='file_name')
             return temp_path
-
-def get_access_token() -> str:
-    """Get access token from header"""
-    bearer_token = None
-    # Check if the Authorization header is present
-    if "Authorization" in request.headers:
-        auth_header = request.headers["Authorization"]
-
-        # Ensure the header starts with 'Bearer ' and retrieve the token
-        if auth_header.startswith("Bearer "):
-            bearer_token = auth_header.split(" ")[1]
-    return bearer_token
- 
+        
 def parse_bool(str_bool):
     if str_bool.lower().startswith('t'):
         return True
@@ -209,7 +196,7 @@ def get_temp_jsonld(schema_url):
     return tmp_file.name
 
 # @before_request
-def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None, asset_view = None, output_format=None, title=None, bearerAuth=None, strict_validation:bool=True):
+def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None, asset_view = None, output_format=None, title=None, access_token=None, strict_validation:bool=True):
     """Get the immediate dependencies that are related to a given source node.
         Args:
             schema_url: link to data model in json ld format
@@ -223,7 +210,6 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
         Returns:
             Googlesheet URL (if sheet_url is True), or pandas dataframe (if sheet_url is False).
     """
-    access_token = get_access_token()
 
     # call config_handler()
     config_handler(asset_view = asset_view)
@@ -833,9 +819,6 @@ def get_schematic_version() -> str:
     """
     Return the current version of schematic
     """
-
-    access_token = get_access_token()
-
     if "VERSION" in os.environ:
         version = os.environ["VERSION"]
     else:

--- a/schematic_api/api/security_controller_.py
+++ b/schematic_api/api/security_controller_.py
@@ -1,0 +1,14 @@
+from typing import List
+
+
+def info_from_bearerAuth(token):
+    """
+    Check and retrieve authentication information from custom bearer token.
+    Returned value will be passed in 'token_info' parameter of your operation function, if there is one.
+    'sub' or 'uid' will be set in 'user' parameter of your operation function, if there is one.
+    :param token Token provided by Authorization header
+    :type token: str
+    :return: Decoded token information or None if token is invalid
+    :rtype: dict | None
+    """
+    return {"uid": "user_id"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,6 +93,13 @@ def syn_token(config:Configuration):
         token = config_parser["authentication"]["authtoken"]
     yield token
 
+@pytest.fixture
+def request_headers(syn_token):
+    headers = {
+        "Authorization": "Bearer " + syn_token
+    }
+    yield headers
+
 @pytest.mark.schematic_api
 class TestSynapseStorage:
     @pytest.mark.synapse_credentials_needed

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -104,14 +104,13 @@ def request_headers(syn_token):
 class TestSynapseStorage:
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("return_type", ["json", "csv"])
-    def test_get_storage_assets_tables(self, client, syn_token, return_type):
+    def test_get_storage_assets_tables(self, client, return_type, request_headers):
         params = {
-            "access_token": syn_token,
             "asset_view": "syn23643253",
             "return_type": return_type
         }
 
-        response = client.get('http://localhost:3001/v1/storage/assets/tables', query_string=params)
+        response = client.get('http://localhost:3001/v1/storage/assets/tables', query_string=params, headers=request_headers)
 
         assert response.status_code == 200
 
@@ -132,9 +131,8 @@ class TestSynapseStorage:
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("full_path", [True, False])
     @pytest.mark.parametrize("file_names", [None, "Sample_A.txt"])
-    def test_get_dataset_files(self,full_path, file_names, syn_token, client):
+    def test_get_dataset_files(self,full_path, file_names, request_headers, client):
         params = {
-            "access_token": syn_token,
             "asset_view": "syn23643253",
             "dataset_id": "syn23643250",
             "full_path": full_path,
@@ -143,7 +141,7 @@ class TestSynapseStorage:
         if file_names:
             params["file_names"] = file_names
         
-        response = client.get('http://localhost:3001/v1/storage/dataset/files', query_string=params)
+        response = client.get('http://localhost:3001/v1/storage/dataset/files', query_string=params, headers=request_headers)
 
         assert response.status_code == 200
         response_dt = json.loads(response.data)
@@ -160,53 +158,50 @@ class TestSynapseStorage:
             else: 
                 assert ["syn25705259","Boolean Test"] and ["syn23667202","DataTypeX_table"] in response_dt
         
+
     @pytest.mark.synapse_credentials_needed
-    def test_get_storage_project_dataset(self, syn_token, client):
+    def test_get_storage_project_dataset(self, request_headers, client):
         params = {
-        "access_token": syn_token,
         "asset_view": "syn23643253",
         "project_id": "syn26251192"
         }
 
-        response = client.get("http://localhost:3001/v1/storage/project/datasets", query_string = params)
+        response = client.get("http://localhost:3001/v1/storage/project/datasets", query_string = params, headers = request_headers)
         assert response.status_code == 200
         response_dt = json.loads(response.data)
         assert ["syn26251193","Issue522"] in response_dt
 
     @pytest.mark.synapse_credentials_needed
-    def test_get_storage_project_manifests(self, syn_token, client):
+    def test_get_storage_project_manifests(self, request_headers, client):
 
         params = {
-        "access_token": syn_token,
         "asset_view": "syn23643253",
         "project_id": "syn30988314"
         }
 
-        response = client.get("http://localhost:3001/v1/storage/project/manifests", query_string=params)
+        response = client.get("http://localhost:3001/v1/storage/project/manifests", query_string=params, headers=request_headers)
 
         assert response.status_code == 200
 
     @pytest.mark.synapse_credentials_needed
-    def test_get_storage_projects(self, syn_token, client):
+    def test_get_storage_projects(self, request_headers, client):
 
         params = {
-        "access_token": syn_token,
         "asset_view": "syn23643253"
         }
 
-        response = client.get("http://localhost:3001/v1/storage/projects", query_string = params)
+        response = client.get("http://localhost:3001/v1/storage/projects", query_string = params, headers = request_headers)
 
         assert response.status_code == 200
 
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("entity_id", ["syn34640850", "syn23643253", "syn24992754"])
-    def test_get_entity_type(self, syn_token, client, entity_id):
+    def test_get_entity_type(self, request_headers, client, entity_id):
         params = {
-            "access_token": syn_token,
             "asset_view": "syn23643253",
             "entity_id": entity_id
         }
-        response = client.get("http://localhost:3001/v1/storage/entity/type", query_string = params)
+        response = client.get("http://localhost:3001/v1/storage/entity/type", query_string = params, headers = request_headers)
 
         assert response.status_code == 200
         response_dt = json.loads(response.data)
@@ -219,13 +214,12 @@ class TestSynapseStorage:
 
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("entity_id", ["syn30988314", "syn27221721"])
-    def test_if_in_assetview(self, syn_token, client, entity_id):
+    def test_if_in_assetview(self, request_headers, client, entity_id):
         params = {
-            "access_token": syn_token,
             "asset_view": "syn23643253",
             "entity_id": entity_id
         }
-        response = client.get("http://localhost:3001/v1/storage/if_in_asset_view", query_string = params)        
+        response = client.get("http://localhost:3001/v1/storage/if_in_asset_view", query_string = params, headers = request_headers)        
         assert response.status_code == 200
         response_dt = json.loads(response.data)
 
@@ -418,7 +412,7 @@ class TestManifestOperation:
     #@pytest.mark.parametrize("output_format", [None, "excel", "google_sheet", "dataframe (only if getting existing manifests)"])
     @pytest.mark.parametrize("output_format", ["excel"])
     @pytest.mark.parametrize("data_type", ["Biospecimen", "Patient", "all manifests", ["Biospecimen", "Patient"]])
-    def test_generate_existing_manifest(self, client, data_model_jsonld, data_type, output_format, caplog):
+    def test_generate_existing_manifest(self, client, data_model_jsonld, data_type, output_format, caplog, request_headers):
         # set dataset
         if data_type == "Patient":
             dataset_id = ["syn51730545"] #Mock Patient Manifest folder on synapse
@@ -435,15 +429,18 @@ class TestManifestOperation:
             "title": "Example",
             "data_type": data_type,
             "use_annotations": False, 
-            "access_token": None
             }
+        
+        # Previous form of the test had `access_token` set to `None`
+        request_headers["Authorization"] = None
+
         if dataset_id: 
             params['dataset_id'] = dataset_id
         
         if output_format: 
             params['output_format'] = output_format
 
-        response = client.get('http://localhost:3001/v1/manifest/generate', query_string=params)
+        response = client.get('http://localhost:3001/v1/manifest/generate', query_string=params, headers=request_headers)
 
         assert response.status_code == 200
 
@@ -474,7 +471,7 @@ class TestManifestOperation:
     @pytest.mark.empty_token
     @pytest.mark.parametrize("output_format", ["excel", "google_sheet", "dataframe (only if getting existing manifests)", None])
     @pytest.mark.parametrize("data_type", ["all manifests", ["Biospecimen", "Patient"], "Patient"])
-    def test_generate_new_manifest(self, caplog, client, data_model_jsonld, data_type, output_format):
+    def test_generate_new_manifest(self, caplog, client, data_model_jsonld, data_type, output_format, request_headers):
         params = {
             "schema_url": data_model_jsonld,
             "asset_view": "syn23643253",
@@ -482,8 +479,10 @@ class TestManifestOperation:
             "data_type": data_type,
             "use_annotations": False,
             "dataset_id": None,
-            "access_token": None
         }
+
+        # Previous form of the test had `access_token` set to `None`
+        request_headers["Authorization"] = None
 
         if output_format: 
             params["output_format"] = output_format
@@ -639,14 +638,13 @@ class TestManifestOperation:
         assert "warnings" in response_dt.keys()
 
     @pytest.mark.synapse_credentials_needed
-    def test_get_datatype_manifest(self, client, syn_token):
+    def test_get_datatype_manifest(self, client, request_headers):
         params = {
-            "access_token": syn_token,
             "asset_view": "syn23643253",
             "manifest_id": "syn27600110"
         }
 
-        response = client.get('http://localhost:3001/v1/get/datatype/manifest', query_string=params)  
+        response = client.get('http://localhost:3001/v1/get/datatype/manifest', query_string=params, headers=request_headers)  
 
         assert response.status_code == 200
         response_dt = json.loads(response.data)
@@ -665,16 +663,15 @@ class TestManifestOperation:
     @pytest.mark.parametrize("manifest_id, expected_component, expected_file_name", [("syn51078535", "BulkRNA-seqAssay", "synapse_storage_manifest.csv"), ("syn51156998", "Biospecimen", "synapse_storage_manifest_biospecimen.csv")])
     @pytest.mark.parametrize("new_manifest_name",[None,"Example.csv"]) 
     @pytest.mark.parametrize("as_json",[None,True,False]) 
-    def test_manifest_download(self, config: Configuration, client, syn_token, manifest_id, new_manifest_name, as_json, expected_component, expected_file_name):
+    def test_manifest_download(self, config: Configuration, client, request_headers, manifest_id, new_manifest_name, as_json, expected_component, expected_file_name):
         params = {
-            "access_token": syn_token,
             "manifest_id": manifest_id,
             "new_manifest_name": new_manifest_name, 
             "as_json": as_json
 
         }
 
-        response = client.get('http://localhost:3001/v1/manifest/download', query_string = params)
+        response = client.get('http://localhost:3001/v1/manifest/download', query_string = params, headers = request_headers)
         assert response.status_code == 200
 
         # if as_json is set to True or as_json is not defined, then a json gets returned
@@ -716,13 +713,12 @@ class TestManifestOperation:
 
     @pytest.mark.synapse_credentials_needed        
     # test downloading a manifest with access restriction and see if the correct error message got raised
-    def test_download_access_restricted_manifest(self, client, syn_token):
+    def test_download_access_restricted_manifest(self, client, request_headers):
         params = {
-            "access_token": syn_token,
             "manifest_id": "syn29862078"
         }  
 
-        response = client.get('http://localhost:3001/v1/manifest/download', query_string = params)
+        response = client.get('http://localhost:3001/v1/manifest/download', query_string = params, headers = request_headers)
         assert response.status_code == 500
         with pytest.raises(TypeError) as exc_info:
             raise TypeError('the type error got raised')
@@ -731,16 +727,15 @@ class TestManifestOperation:
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("as_json", [None, True, False])
     @pytest.mark.parametrize("new_manifest_name", [None, "Test"])
-    def test_dataset_manifest_download(self, client, as_json, syn_token, new_manifest_name):
+    def test_dataset_manifest_download(self, client, as_json, request_headers, new_manifest_name):
         params = {
-            "access_token": syn_token,
             "asset_view": "syn28559058",
             "dataset_id": "syn28268700",
             "as_json": as_json,
             "new_manifest_name": new_manifest_name
         }
 
-        response = client.get('http://localhost:3001/v1/dataset/manifest/download', query_string = params)
+        response = client.get('http://localhost:3001/v1/dataset/manifest/download', query_string = params, headers = request_headers)
         assert response.status_code == 200
         response_dt = response.data
 
@@ -759,11 +754,10 @@ class TestManifestOperation:
     
     @pytest.mark.synapse_credentials_needed    
     @pytest.mark.submission
-    def test_submit_manifest_table_and_file_replace(self, client, syn_token, data_model_jsonld, test_manifest_submit):
+    def test_submit_manifest_table_and_file_replace(self, client, request_headers, data_model_jsonld, test_manifest_submit):
         """Testing submit manifest in a csv format as a table and a file. Only replace the table
         """
         params = {
-            "access_token": syn_token,
             "schema_url": data_model_jsonld,
             "data_type": "Biospecimen",
             "restrict_rules": False, 
@@ -775,16 +769,15 @@ class TestManifestOperation:
             "use_schema_label": True
         }
 
-        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_submit, 'rb'), "test.csv")})
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_submit, 'rb'), "test.csv")}, headers=request_headers)
         assert response_csv.status_code == 200
 
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.submission
-    def test_submit_manifest_file_only_replace(self, client, syn_token, data_model_jsonld, test_manifest_submit):
+    def test_submit_manifest_file_only_replace(self, client, request_headers, data_model_jsonld, test_manifest_submit):
         """Testing submit manifest in a csv format as a file
         """
         params = {
-            "access_token": syn_token,
             "schema_url": data_model_jsonld,
             "data_type": "Biospecimen",
             "restrict_rules": False, 
@@ -794,17 +787,16 @@ class TestManifestOperation:
             "table_manipulation": 'replace',
             "use_schema_label": True
         }
-        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_submit, 'rb'), "test.csv")})
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_submit, 'rb'), "test.csv")}, headers=request_headers)
         assert response_csv.status_code == 200 
     
     @pytest.mark.synapse_credentials_needed    
     @pytest.mark.submission
-    def test_submit_manifest_json_str_replace(self, client, syn_token, data_model_jsonld):
+    def test_submit_manifest_json_str_replace(self, client, request_headers, data_model_jsonld):
         """Submit json str as a file
         """
         json_str = '[{"Sample ID": 123, "Patient ID": 1,"Tissue Status": "Healthy","Component": "Biospecimen"}]'
         params = {
-            "access_token": syn_token,
             "schema_url": data_model_jsonld,
             "data_type": "Biospecimen",
             "json_str": json_str,
@@ -816,14 +808,13 @@ class TestManifestOperation:
             "use_schema_label": True
         }
         params["json_str"] = json_str
-        response = client.post('http://localhost:3001/v1/model/submit', query_string = params, data={"file_name":''})
+        response = client.post('http://localhost:3001/v1/model/submit', query_string = params, data={"file_name":''}, headers = request_headers)
         assert response.status_code == 200
 
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.submission
-    def test_submit_manifest_w_file_and_entities(self, client, syn_token, data_model_jsonld, test_manifest_submit):
+    def test_submit_manifest_w_file_and_entities(self, client, request_headers, data_model_jsonld, test_manifest_submit):
         params = {
-            "access_token": syn_token,
             "schema_url": data_model_jsonld,
             "data_type": "Biospecimen",
             "restrict_rules": False, 
@@ -835,14 +826,13 @@ class TestManifestOperation:
         }
 
         # test uploading a csv file
-        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_submit, 'rb'), "test.csv")})
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_submit, 'rb'), "test.csv")}, headers=request_headers)
         assert response_csv.status_code == 200
 
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.submission
-    def test_submit_manifest_table_and_file_upsert(self, client, syn_token, data_model_jsonld, test_upsert_manifest_csv, ):
+    def test_submit_manifest_table_and_file_upsert(self, client, request_headers, data_model_jsonld, test_upsert_manifest_csv, ):
         params = {
-            "access_token": syn_token,
             "schema_url": data_model_jsonld,
             "data_type": "MockRDB",
             "restrict_rules": False, 
@@ -854,7 +844,7 @@ class TestManifestOperation:
         }
 
         # test uploading a csv file
-        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_upsert_manifest_csv, 'rb'), "test.csv")},)            
+        response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_upsert_manifest_csv, 'rb'), "test.csv")}, headers=request_headers)            
         assert response_csv.status_code == 200     
 
 @pytest.mark.schematic_api

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -488,7 +488,7 @@ class TestManifestOperation:
             params["output_format"] = output_format
     
 
-        response = client.get('http://localhost:3001/v1/manifest/generate', query_string=params)
+        response = client.get('http://localhost:3001/v1/manifest/generate', query_string=params, headers=request_headers)
         assert response.status_code == 200
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -127,7 +127,7 @@ class TestSynapseStorage:
             os.remove(response_dt)
         else: 
             pass
-
+    
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("full_path", [True, False])
     @pytest.mark.parametrize("file_names", [None, "Sample_A.txt"])
@@ -158,7 +158,6 @@ class TestSynapseStorage:
             else: 
                 assert ["syn25705259","Boolean Test"] and ["syn23667202","DataTypeX_table"] in response_dt
         
-
     @pytest.mark.synapse_credentials_needed
     def test_get_storage_project_dataset(self, request_headers, client):
         params = {
@@ -711,7 +710,7 @@ class TestManifestOperation:
         except: 
             pass
 
-    @pytest.mark.synapse_credentials_needed        
+    @pytest.mark.synapse_credentials_needed
     # test downloading a manifest with access restriction and see if the correct error message got raised
     def test_download_access_restricted_manifest(self, client, request_headers):
         params = {
@@ -723,7 +722,7 @@ class TestManifestOperation:
         with pytest.raises(TypeError) as exc_info:
             raise TypeError('the type error got raised')
         assert exc_info.value.args[0] == "the type error got raised"
-
+    
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("as_json", [None, True, False])
     @pytest.mark.parametrize("new_manifest_name", [None, "Test"])
@@ -751,8 +750,8 @@ class TestManifestOperation:
 
             assert isinstance(response_path, str)
             assert response_path.endswith(".csv")
-    
-    @pytest.mark.synapse_credentials_needed    
+
+    @pytest.mark.synapse_credentials_needed
     @pytest.mark.submission
     def test_submit_manifest_table_and_file_replace(self, client, request_headers, data_model_jsonld, test_manifest_submit):
         """Testing submit manifest in a csv format as a table and a file. Only replace the table
@@ -789,7 +788,6 @@ class TestManifestOperation:
         }
         response_csv = client.post('http://localhost:3001/v1/model/submit', query_string=params, data={"file_name": (open(test_manifest_submit, 'rb'), "test.csv")}, headers=request_headers)
         assert response_csv.status_code == 200 
-    
     @pytest.mark.synapse_credentials_needed    
     @pytest.mark.submission
     def test_submit_manifest_json_str_replace(self, client, request_headers, data_model_jsonld):


### PR DESCRIPTION
This PR pulls from some of the work done previously by @linglp in #1218 and [#1599](https://github.com/Sage-Bionetworks/sage-monorepo/pull/1599) and comments from @thomasyu888, but with modifications. It is applied to `schematic` to enhance security of the API and apps deployed on AWS that use schematic as the backend.

Synapse Access Tokens are now implemented as Bearer Authentication tokens in the request headers instead of as query parameters sent in the request body. Providing this token is required for all endpoints where it is an option, with the exception of `/manifest/generate`, where it is acceptable to not provide a token if not required for accessing resources on synapse, to preserve the existing functionality.

Tests that previously had `access_token` as a parameter were marked in #1289 for test comparison purposes. They've also been updated to pass in the token in the request header as part of this PR. All of these tests are passing bar 7, which are also failing on #1289, an analogue of `develop` with only the markers changed. I believe some API tests had been identified as having problems before @linglp's leave, these are likely among them.

Tests of the `/manifest/generate` endpoint that do not require an access token to be provided are also marked and are all passing.

Access tokens are no longer visible in the logs, confirmed on the dev instance
![image](https://github.com/Sage-Bionetworks/schematic/assets/61707471/e00b7628-0624-4c19-bee1-1e709db569c4)


### To Test

- Try the endpoints that use the access token from SwaggerUI
- Try interacting with the API now that `access_token` is no longer a query parameter and instead should be included in the header
- (note) you should be able to just pass in the auth token without the `Bearer: ` prefix when working through Swagger

Depends on #1289 