### PR TITLE
redid poetry install in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   pypi_release:
     runs-on: ubuntu-latest
+    env:
+      POETRY_VERSION:  1.2.0
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     steps:
       #----------------------------------------------

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,15 +20,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       #----------------------------------------------
-      #          install & configure poetry         
+      #          install & configure poetry
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
+        run: |
+          curl -sSL https://install.python-poetry.org \
+            | python3 - --version ${{ env.POETRY_VERSION }};
+          poetry config virtualenvs.create true;
+          poetry config virtualenvs.in-project true;
 
       #----------------------------------------------
       #       load cached venv if cache exists      


### PR DESCRIPTION
The current publish workflow [isn't working](https://github.com/Sage-Bionetworks/schematic/actions/runs/6263847206/job/17009190821).

See this [slack discussion.](https://sagebionetworks.slack.com/archives/C050YD75QRL/p1695310474346439)

I've substituted the poetry install form the testing workflow.

error message:

```
Run snok/install-poetry@v1.1.1
Run curl -O -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py
  File "/home/runner/work/schematic/schematic/get-poetry.py", line 1
    404: Not Found
    ^^^
SyntaxError: illegal target for annotation
Error: Process completed with exit code 1.
```