### PR TITLE
Revert "Raise a helpful error when a datatype cannot be found in a schema"

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -54,11 +54,7 @@ class ManifestGenerator(object):
         self.creds = services_creds["creds"]
 
         # schema root
-        if root:
-            self.root = root
-        # Raise an error if no DataType has been provided
-        else:
-            raise ValueError("No DataType has been provided.")
+        self.root = root
 
         # alphabetize valid values
         self.alphabetize = alphabetize_valid_values
@@ -83,19 +79,12 @@ class ManifestGenerator(object):
 
         # additional metadata to add to manifest
         self.additional_metadata = additional_metadata
-   
-        # Check if the class is in the schema
-        root_in_schema = self.sg.se.is_class_in_schema(self.root)
-        
-        # If the class could not be found, give a notification
-        if not root_in_schema:
-            exception_message = f"The DataType entered ({self.root}) could not be found in the data model schema. " + \
-                                "Please confirm that the datatype is in the data model and that the spelling matches the class label in the .jsonld file."
-            raise LookupError(exception_message) 
 
         # Determine whether current data type is file-based
-        self.is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
-
+        is_file_based = False
+        if self.root:
+            is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
+        self.is_file_based = is_file_based
 
     def _attribute_to_letter(self, attribute, manifest_fields):
         """Map attribute to column letter in a google sheet"""

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -87,33 +87,12 @@ class TestManifestGenerator:
         generator = ManifestGenerator(
             title="mock_title",
             path_to_json_ld=helpers.get_data_path("example.model.jsonld"),
-            root = "Patient"
         )
 
         assert type(generator.title) is str
         # assert generator.sheet_service == mock_creds["sheet_service"]
-        assert generator.root is "Patient"
+        assert generator.root is None
         assert type(generator.sg) is SchemaGenerator
-
-    @pytest.mark.parametrize("data_type, exc, exc_message",
-                              [("MissingComponent", LookupError, "could not be found in the data model schema"),
-                               (None, ValueError, "No DataType has been provided.")],
-                               ids = ["DataType not found in Schema", "No DataType provided"])
-    def test_missing_root_error(self, helpers, data_type, exc, exc_message):
-        """
-        Test for errors when either no DataType is provided or when a DataType is provided but not found in the schema
-        """
-
-        # A LookupError should be raised and include message when the component cannot be found
-        with pytest.raises(exc) as e:
-            generator = ManifestGenerator(
-            path_to_json_ld=helpers.get_data_path("example.model.jsonld"),
-            root=data_type,
-            use_annotations=False,
-            )        
-
-        # Check message contents
-        assert exc_message in str(e)
 
     @pytest.mark.google_credentials_needed
     def test_get_manifest_first_time(self, manifest):
@@ -166,7 +145,7 @@ class TestManifestGenerator:
         # An annotation merged with an attribute from the data model
         if use_annotations:
             assert output["File Format"].tolist() == ["txt", "csv", "fastq"]
-
+      
     @pytest.mark.parametrize("output_format", [None, "dataframe", "excel", "google_sheet"])
     @pytest.mark.parametrize("sheet_url", [None, True, False])
     @pytest.mark.parametrize("dataset_id", [None, "syn27600056"])
@@ -432,4 +411,6 @@ class TestManifestGenerator:
 
         # remove file
         os.remove(dummy_output_path)
+
+
 


### PR DESCRIPTION
Reverts Sage-Bionetworks/schematic#1286 so that the release can proceed with the only changes being #1299 