### PR TITLE
Raise a helpful error when a datatype cannot be found in a schema 

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -54,7 +54,11 @@ class ManifestGenerator(object):
         self.creds = services_creds["creds"]
 
         # schema root
-        self.root = root
+        if root:
+            self.root = root
+        # Raise an error if no DataType has been provided
+        else:
+            raise ValueError("No DataType has been provided.")
 
         # alphabetize valid values
         self.alphabetize = alphabetize_valid_values
@@ -79,12 +83,19 @@ class ManifestGenerator(object):
 
         # additional metadata to add to manifest
         self.additional_metadata = additional_metadata
+   
+        # Check if the class is in the schema
+        root_in_schema = self.sg.se.is_class_in_schema(self.root)
+        
+        # If the class could not be found, give a notification
+        if not root_in_schema:
+            exception_message = f"The DataType entered ({self.root}) could not be found in the data model schema. " + \
+                                "Please confirm that the datatype is in the data model and that the spelling matches the class label in the .jsonld file."
+            raise LookupError(exception_message) 
 
         # Determine whether current data type is file-based
-        is_file_based = False
-        if self.root:
-            is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
-        self.is_file_based = is_file_based
+        self.is_file_based = "Filename" in self.sg.get_node_dependencies(self.root)
+
 
     def _attribute_to_letter(self, attribute, manifest_fields):
         """Map attribute to column letter in a google sheet"""


### PR DESCRIPTION
For the linked issue, the error arose because the data type was not spelled according to the conventions of the class label in the schema. The error raised by networkx: return self._nodes[n] \ KeyError: 'AssayRNASeqMetadataTemplate' was not very good at communicating what was going wrong. I've wrapped another error around this message for the case of generating a manifest that should be more explanatory and offers suggestions for remedying.

Re-merge of the reverted PR #1286 (was reverted not due to issues but to allow for re-releasing a failed release without any other changes)