### PR TITLE
Add `access_token` to `/model/validate` header

### DIFF
--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -337,7 +337,7 @@ class MetadataModel(object):
 
             # automatic JSON schema generation and validation with that JSON schema
             val_errors, val_warnings = self.validateModelManifest(
-                manifestPath=manifest_path, rootNode=validate_component, restrict_rules=restrict_rules, project_scope=project_scope,
+                manifestPath=manifest_path, rootNode=validate_component, restrict_rules=restrict_rules, project_scope=project_scope, access_token=access_token
             )
 
             # if there are no errors in validation process

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -186,7 +186,7 @@ class MetadataModel(object):
 
     # TODO: abstract validation in its own module
     def validateModelManifest(
-        self, manifestPath: str, rootNode: str, restrict_rules: bool = False, jsonSchema: str = None, project_scope: List = None,
+        self, manifestPath: str, rootNode: str, restrict_rules: bool = False, jsonSchema: str = None, project_scope: List = None, access_token: str = None,
     ) -> List[str]:
         """Check if provided annotations manifest dataframe satisfies all model requirements.
 
@@ -251,7 +251,16 @@ class MetadataModel(object):
 
             return errors, warnings
 
-        errors, warnings, manifest = validate_all(self, errors, warnings, manifest, manifestPath, self.sg, jsonSchema, restrict_rules, project_scope)
+        errors, warnings, manifest = validate_all(self, 
+                                                  errors=errors, 
+                                                  warnings=warnings, 
+                                                  manifest=manifest, 
+                                                  manifestPath=manifestPath, 
+                                                  sg=self.sg, 
+                                                  jsonSchema=jsonSchema, 
+                                                  restrict_rules=restrict_rules, 
+                                                  project_scope=project_scope, 
+                                                  access_token=access_token)
         return errors, warnings
 
     def populateModelManifest(self, title, manifestPath: str, rootNode: str, return_excel = False) -> str:

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -27,6 +27,7 @@ from schematic.utils.validate_utils import (comma_separated_list_regex,
                                             rule_in_rule_list,
                                             )
 
+from synapseclient.core.exceptions import SynapseNoCredentialsError
 
 logger = logging.getLogger(__name__)
 
@@ -570,7 +571,12 @@ class ValidateAttribute(object):
         target_dataset_IDs=[]
         
         #login
-        synStore = SynapseStorage(access_token=access_token, project_scope=project_scope)        
+        try:
+            synStore = SynapseStorage(access_token=access_token, project_scope=project_scope)        
+        except SynapseNoCredentialsError as e:
+            raise ValueError(
+                "No Synapse credentials were provided. Credentials must be provided to utilize cross-manfiest validation functionality."
+                ) from e
 
         #Get list of all projects user has access to
         projects = synStore.getStorageProjects(project_scope=project_scope)

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -564,13 +564,13 @@ class ValidateAttribute(object):
         - Add string length validator
     """
 
-    def get_target_manifests(target_component, project_scope: List):
+    def get_target_manifests(target_component, project_scope: List, access_token: str = None):
         t_manifest_search = perf_counter()
         target_manifest_IDs=[]
         target_dataset_IDs=[]
         
         #login
-        synStore = SynapseStorage(project_scope=project_scope)        
+        synStore = SynapseStorage(access_token=access_token, project_scope=project_scope)        
 
         #Get list of all projects user has access to
         projects = synStore.getStorageProjects(project_scope=project_scope)
@@ -893,7 +893,7 @@ class ValidateAttribute(object):
         return errors, warnings
 
     def cross_validation(
-        self, val_rule: str, manifest_col: pd.core.series.Series, project_scope: List, sg: SchemaGenerator,
+        self, val_rule: str, manifest_col: pd.core.series.Series, project_scope: List, sg: SchemaGenerator, access_token: str,
     ) -> List[List[str]]:
         """
         Purpose:
@@ -921,7 +921,7 @@ class ValidateAttribute(object):
 
         
         #Get IDs of manifests with target component
-        synStore, target_manifest_IDs, target_dataset_IDs = ValidateAttribute.get_target_manifests(target_component,project_scope)
+        synStore, target_manifest_IDs, target_dataset_IDs = ValidateAttribute.get_target_manifests(target_component, project_scope, access_token)
 
         t_cross_manifest = perf_counter()
         #Read each manifest

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -62,7 +62,7 @@ class ValidateManifest(object):
         return ["NA", error_col, error_message, error_val]
 
     def validate_manifest_rules(
-        self, manifest: pd.core.frame.DataFrame, sg: SchemaGenerator, restrict_rules: bool, project_scope: List,
+        self, manifest: pd.core.frame.DataFrame, sg: SchemaGenerator, restrict_rules: bool, project_scope: List, access_token: str,
     ) -> (pd.core.frame.DataFrame, List[List[str]]):
         """
         Purpose:
@@ -208,7 +208,7 @@ class ValidateManifest(object):
                         manifest[col] = manifest_col
                     elif validation_type.lower().startswith("match"):
                         vr_errors, vr_warnings = validation_method(
-                            self, rule, manifest[col], project_scope, sg,
+                            self, rule, manifest[col], project_scope, sg, access_token
                         )
                     else:
                         vr_errors, vr_warnings = validation_method(
@@ -256,9 +256,9 @@ class ValidateManifest(object):
         return errors, warnings
 
 
-def validate_all(self, errors, warnings, manifest, manifestPath, sg, jsonSchema, restrict_rules, project_scope: List):
+def validate_all(self, errors, warnings, manifest, manifestPath, sg, jsonSchema, restrict_rules, project_scope: List, access_token: str):
     vm = ValidateManifest(errors, manifest, manifestPath, sg, jsonSchema)
-    manifest, vmr_errors, vmr_warnings = vm.validate_manifest_rules(manifest, sg, restrict_rules, project_scope)
+    manifest, vmr_errors, vmr_warnings = vm.validate_manifest_rules(manifest, sg, restrict_rules, project_scope, access_token)
     if vmr_errors:
         errors.extend(vmr_errors)
     if vmr_warnings:

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -220,6 +220,7 @@ paths:
                   format: binary
       security:
         - access_token: []
+        - {}
       parameters:
         - in: query
           name: schema_url

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -218,6 +218,8 @@ paths:
                   description: Upload a json or a csv file. 
                   type: string
                   format: binary
+      security:
+        - access_token: []
       parameters:
         - in: query
           name: schema_url

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -340,6 +340,9 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
 #####profile validate manifest route function 
 #@profile(sort_by='cumulative', strip_dirs=True)
 def validate_manifest_route(schema_url, data_type, restrict_rules=None, json_str=None):
+    # Access token now stored in request header
+    access_token = get_access_token()
+    
     # if restrict rules is set to None, default it to False
     if not restrict_rules:
         restrict_rules=False

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -370,7 +370,7 @@ def validate_manifest_route(schema_url, data_type, restrict_rules=None, json_str
     )
 
     errors, warnings = metadata_model.validateModelManifest(
-        manifestPath=temp_path, rootNode=data_type, restrict_rules=restrict_rules
+        manifestPath=temp_path, rootNode=data_type, restrict_rules=restrict_rules, access_token=access_token
     )
     
     res_dict = {"errors": errors, "warnings": warnings}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -597,7 +597,7 @@ class TestManifestOperation:
 
     @pytest.mark.parametrize("restrict_rules", [False, True, None])
     @pytest.mark.parametrize("json_str", [None, '[{"Patient ID": 123, "Sex": "Female", "Year of Birth": "", "Diagnosis": "Healthy", "Component": "Patient", "Cancer Type": "Breast", "Family History": "Breast, Lung"}]'])
-    def test_validate_manifest(self, data_model_jsonld, client, json_str, restrict_rules, test_manifest_csv):
+    def test_validate_manifest(self, data_model_jsonld, client, json_str, restrict_rules, test_manifest_csv, request_headers):
 
         params = {
             "schema_url": data_model_jsonld,
@@ -614,13 +614,13 @@ class TestManifestOperation:
         else: 
             params["data_type"] = "MockComponent"
 
-            headers = {
+            request_headers.update({
             'Content-Type': "multipart/form-data",
             'Accept': "application/json"
-            }
+            })
 
             # test uploading a csv file
-            response_csv = client.post('http://localhost:3001/v1/model/validate', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")}, headers=headers)
+            response_csv = client.post('http://localhost:3001/v1/model/validate', query_string=params, data={"file_name": (open(test_manifest_csv, 'rb'), "test.csv")}, headers=request_headers)
             response_dt = json.loads(response_csv.data)
             assert response_csv.status_code == 200
             


### PR DESCRIPTION
Add `access_token` to the `/model/validate` endpoint, as an optional part of the header