### PR TITLE
[bug fix] Added `fit=true` parameter when setting a dataframe

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1309,7 +1309,7 @@ class ManifestGenerator(object):
         sh = gc.open_by_url(manifest_url)
         wb = sh[0]
 
-        wb.set_dataframe(manifest_df, (1, 1))
+        wb.set_dataframe(manifest_df, (1, 1), fit=True)
 
         # update validation rules (i.e. no validation rules) for out of schema columns, if any
         # TODO: similarly clear formatting for out of schema columns, if any


### PR DESCRIPTION
Related to: https://sagebionetworks.jira.com/browse/FDS-919

## Context:
We ran into a problem when generating a manifest for HTAN. See the parameters used for manifest generation below: 
schema_url: https://raw.githubusercontent.com/ncihtan/data-models/main/HTAN.model.jsonld
data_type: ImagingLevel1
dataset_id: syn27782965

The error: 
```
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/googleapiclient/_helpers.py", line 130, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/googleapiclient/http.py", line 938, in execute
    raise HttpError(resp, content, uri=self.uri)
googleapiclient.errors.HttpError: <HttpError 400 when requesting https://sheets.googleapis.com/v4/spreadsheets/1RwqsmRz8Hlub-zZpLP_vy7Nad9_LHLrSvh0Ek0kZFyg/values/%27Sheet1%27%21A11539%3AN15385?valueInputOption=USER_ENTERED&alt=json returned "Range (Sheet1!A11539:N15385) exceeds grid limits. Max rows: 11538, max columns: 25". Details: "Range (Sheet1!A11539:N15385) exceeds grid limits. Max rows: 11538, max columns: 25">
```

## Why this error occurred? 
In schematic, we are essentially copying and pasting the dataframe that we generated into google sheet as a final step. The library that we use is called pygsheet, and the function is: set_dataframe  (You could read more about this function[ here](https://pygsheets.readthedocs.io/en/stable/worksheet.html?highlight=set_dataframe#pygsheets.Worksheet.set_dataframe)). This error happened because the google sheet that we initially generated only has 1000 rows (see documentation [here](https://pygsheets.readthedocs.io/en/stable/worksheet.html#pygsheets.Worksheet.rows)), but since the data frame that we pasted is much bigger, the error occurred.(Refer to the comment [here](https://github.com/nithinmurali/pygsheets/issues/124#issuecomment-331649104)). 

## Solution
Luckily the fix is simple. We could resize the google sheet that we initially generated to fit the bigger dataframe by using the `fit` parameter described here in the documentation: https://pygsheets.readthedocs.io/en/stable/worksheet.html?highlight=set_dataframe#pygsheets.Worksheet.set_dataframe