### PR TITLE
[bug fix] Added missing import statements

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -50,6 +50,8 @@ from schematic.utils.general import (entity_type_mapping,
                                      get_dir_size,
                                      convert_gb_to_bytes,
                                      create_temp_folder,
+                                     check_synapse_cache_size,
+                                     clear_synapse_cache,
                                      profile,
                                      calculate_datetime)
 from schematic.utils.schema_utils import get_class_label_from_display_name


### PR DESCRIPTION
## Context
Two functions that are only used on AWS are not being imported. That caused an error for: https://sagebionetworks.jira.com/browse/FDS-1385.. Some other endpoints that use `synapseStorage` class also has similiar errors. 