### PR TITLE
Revert changes related to workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,16 @@
 name: Publish to PyPI
 on:
   push:
-    branches: [develop-refactor-schemas]
-# on:
-#   push:
-#     tags:
-#       - 'v[1-9][0-9].[0-9]+.[0-9]+'
-#     branches: [main]
+    tags:
+      - 'v[1-9][0-9].[0-9]+.[0-9]+'
+    branches: [main]
 
 jobs:
   pypi_release:
     runs-on: ubuntu-latest
     env:
       POETRY_VERSION:  1.3.0
-    # if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python     
@@ -99,7 +96,7 @@ jobs:
       #----------------------------------------------  
       - name: Publish package to Pypi
         id: publish-to-pypi
-        # if: steps.check-tag.outputs.match == 'true'
+        if: steps.check-tag.outputs.match == 'true'
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           PYPI_USERNAME: __token__
@@ -110,17 +107,17 @@ jobs:
       #    post a message to slack
       #----------------------------------------------  
 
-      # - name: Post to a Slack channel
-      #   if: steps.publish-to-pypi.outcome == 'success'
-      #   id: slack
-      #   uses: slackapi/slack-github-action@v1.23.0
-      #   with:
-      #     # Slack channel id, channel name, or user id to post message.
-      #     # See also: https://api.slack.com/methods/chat.postMessage#channels
-      #     # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
-      #     # ibc-fair-data channel and data-curator-schematic channel
-      #     channel-id: 'C050YD75QRL,C01ANC02U59'
-      #     # For posting a simple plain text message
-      #     slack-message: "Schematic has just been released. Check out new version: ${{ github.ref_name }}"
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Post to a Slack channel
+        if: steps.publish-to-pypi.outcome == 'success'
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # Slack channel id, channel name, or user id to post message.
+          # See also: https://api.slack.com/methods/chat.postMessage#channels
+          # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
+          # ibc-fair-data channel and data-curator-schematic channel
+          channel-id: 'C050YD75QRL,C01ANC02U59'
+          # For posting a simple plain text message
+          slack-message: "Schematic has just been released. Check out new version: ${{ github.ref_name }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/override_version.py
+++ b/override_version.py
@@ -3,9 +3,7 @@ import os
 
 data = toml.load("pyproject.toml")
 #get release version 
-# RELEASE_VERSION = os.getenv('RELEASE_VERSION')
-# temporarily hard coded release version 
-RELEASE_VERSION = 'v23.11.dev2'
+RELEASE_VERSION = os.getenv('RELEASE_VERSION')
 # Modify field
 data['tool']['poetry']['version']=RELEASE_VERSION
 print('the version number of this release is: ', RELEASE_VERSION)


### PR DESCRIPTION
Since the changes related to workflow are simply for publishing the refactor branch to PYPI one time. We should revert it afterwards and don't push it to develop. 