### PR TITLE
Bug Fix: Fix issue with trailing comma creating an empty node

### DIFF
--- a/schematic/schemas/data_model_parser.py
+++ b/schematic/schemas/data_model_parser.py
@@ -163,10 +163,10 @@ class DataModelCSVParser:
         # If the entry should be preserved as a bool dont convert to str.
         if rel_val_type == bool and type(attr[relationship]) == bool:
             parsed_rel_entry = attr[relationship]
-        # Move strings to list if they are comma separated. Schema order is preserved.
+        # Move strings to list if they are comma separated. Schema order is preserved, remove any empty strings added by trailing commas
         elif rel_val_type == list:
             parsed_rel_entry = attr[relationship].strip().split(",")
-            parsed_rel_entry = [r.strip() for r in parsed_rel_entry]
+            parsed_rel_entry = [r.strip() for r in parsed_rel_entry if r]
         # Convert value string if dictated by rel_val_type, strip whitespace.
         elif rel_val_type == str:
             parsed_rel_entry = str(attr[relationship]).strip()


### PR DESCRIPTION
### Background

Fix for issue described in [FDS-1392](https://sagebionetworks.jira.com/browse/FDS-1392).

> When a CSV data model has a trailing comma in a list, causing an empty string to be recorded as a node, this creates an empty value node, and errors when trying to create the JSONLD.
> 
> For this issue, delete any empty nodes from lists so this does not create the cascading issues.
> 

### To Reproduce

Using the current `develop-refactor-schemas` branch, attempt converting attached `EL.data.model.csv` (see below) to JSONLD with the following CLI command:

```
schematic schema convert path/to/EL.data.model.csv
```
It should error.

### To Test

Use the fix branch with the same model and command, and it should pass.

For sanity, you can test the model where I deleted the problematic comma, and it goes through the conversion on the current branch.
[EL_del_comma.data.model.csv](https://github.com/Sage-Bionetworks/schematic/files/13397900/EL_del_comma.data.model.csv)
[EL.data.model.csv](https://github.com/Sage-Bionetworks/schematic/files/13397901/EL.data.model.csv)


[FDS-1392]: https://sagebionetworks.jira.com/browse/FDS-1392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ