### PR TITLE
Move methods of creating multiple manifests from API to manifest generator 

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1492,7 +1492,7 @@ class ManifestGenerator(object):
             return dataframe
     
     @staticmethod
-    def create_single_manifest(jsonld: str, data_type: str, access_token:Optional[str]=None, dataset_id:Optional[str]=None, strict:Optional[bool]=True, title:Optional[str]=None, output_format:Literal[None, "google sheet", "excel", "dataframe"]=None, use_annotations:Optional[bool]=False) -> Union[str, pd.DataFrame, BinaryIO]:
+    def create_single_manifest(jsonld: str, data_type: str, access_token:Optional[str]=None, dataset_id:Optional[str]=None, strict:Optional[bool]=True, title:Optional[str]=None, output_format:Literal["google_sheet", "excel", "dataframe"]="google_sheet", use_annotations:Optional[bool]=False) -> Union[str, pd.DataFrame, BinaryIO]:
         """Create a single manifest
 
         Args:
@@ -1536,7 +1536,7 @@ class ManifestGenerator(object):
         return result
     
     @staticmethod
-    def create_manifests(jsonld:str, data_types:list, access_token:Optional[str]=None, dataset_ids:Optional[list]=None, output_format:Optional[str]=None, title:Optional[str]=None, strict:Optional[bool]=None, use_annotations:Optional[bool]=False) -> Union[List[str], List[pd.DataFrame], BinaryIO]:
+    def create_manifests(jsonld:str, data_types:list, access_token:Optional[str]=None, dataset_ids:Optional[list]=None, output_format:Literal["google_sheet", "excel", "dataframe"]="google_sheet", title:Optional[str]=None, strict:Optional[bool]=True, use_annotations:Optional[bool]=False) -> Union[List[str], List[pd.DataFrame], BinaryIO]:
         """Create multiple manifests
 
         Args:

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1541,16 +1541,16 @@ class ManifestGenerator(object):
 
         Args:
             jsonld (str): jsonld schema 
-            data_type (str): data type of a manifest
+            data_type (list): a list of data types 
             access_token (str, optional): synapse access token. Required when getting an existing manifest. Defaults to None.
-            dataset_id (str, optional): dataset id when generating an existing manifest. Defaults to None.
+            dataset_id (list, optional): a list of dataset ids when generating an existing manifest. Defaults to None.
             output_format (str, optional):format of manifest. It has three options: google sheet, excel or dataframe. Defaults to None.
             title (str, optional): title of a given manifest. Defaults to None.
             strict (bool, optional): strictness with which to apply validation rules to google sheets. Defaults to None.
             use_annotations (bool, optional): whether to use annotations. Defaults to False.
 
         Returns:
-            Union[str, pd.DataFrame, BinaryIO]: Googlesheet URL or pandas dataframe or Excel.
+            Union[List[str], List[pd.DataFrame], BinaryIO]: a list of Googlesheet URLs, a list of pandas dataframes or an Excel file.
         """
         all_results = []
         if data_types[0] == 'all manifests':

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -9,7 +9,7 @@ import pandas as pd
 from pathlib import Path
 import pygsheets as ps
 from tempfile import NamedTemporaryFile
-from typing import Dict, List, Optional, Tuple, Union, BinaryIO
+from typing import Dict, List, Optional, Tuple, Union, BinaryIO, Literal
 from flask import send_from_directory
 
 from schematic.schemas.generator import SchemaGenerator
@@ -1492,7 +1492,7 @@ class ManifestGenerator(object):
             return dataframe
     
     @staticmethod
-    def create_single_manifest(jsonld: str, data_type: str, access_token:str=None, dataset_id:str=None, strict:bool=True, title:str=None, output_format:str=None, use_annotations:bool=False) -> Union[str, pd.DataFrame, BinaryIO]:
+    def create_single_manifest(jsonld: str, data_type: str, access_token:Optional[str]=None, dataset_id:Optional[str]=None, strict:Optional[bool]=True, title:Optional[str]=None, output_format:Literal[None, "google sheet", "excel", "dataframe"]=None, use_annotations:Optional[bool]=False) -> Union[str, pd.DataFrame, BinaryIO]:
         """Create a single manifest
 
         Args:

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1536,7 +1536,7 @@ class ManifestGenerator(object):
         return result
     
     @staticmethod
-    def create_manifests(jsonld:str, data_types:list, access_token:str=None, dataset_ids:list=None, output_format:str=None, title:str=None, strict:bool=None, use_annotations:bool=False) -> Union[str, pd.DataFrame, BinaryIO]:
+    def create_manifests(jsonld:str, data_types:list, access_token:Optional[str]=None, dataset_ids:Optional[list]=None, output_format:Optional[str]=None, title:Optional[str]=None, strict:Optional[bool]=None, use_annotations:Optional[bool]=False) -> Union[List[str], List[pd.DataFrame], List[BinaryIO]]:
         """Create multiple manifests
 
         Args:

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -9,7 +9,8 @@ import pandas as pd
 from pathlib import Path
 import pygsheets as ps
 from tempfile import NamedTemporaryFile
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union, BinaryIO
+from flask import send_from_directory
 
 from schematic.schemas.generator import SchemaGenerator
 from schematic.utils.google_api_utils import (
@@ -1309,7 +1310,7 @@ class ManifestGenerator(object):
         sh = gc.open_by_url(manifest_url)
         wb = sh[0]
 
-        wb.set_dataframe(manifest_df, (1, 1))
+        wb.set_dataframe(manifest_df, (1, 1), fit=True)
 
         # update validation rules (i.e. no validation rules) for out of schema columns, if any
         # TODO: similarly clear formatting for out of schema columns, if any
@@ -1489,6 +1490,111 @@ class ManifestGenerator(object):
         # Default return a DataFrame
         else:
             return dataframe
+    
+    @staticmethod
+    def create_single_manifest(jsonld: str, data_type: str, access_token:str=None, dataset_id:str=None, strict:bool=True, title:str=None, output_format:str=None, use_annotations:bool=False) -> Union[str, pd.DataFrame, BinaryIO]:
+        """Create a single manifest
+
+        Args:
+            jsonld (str): jsonld schema 
+            data_type (str): data type of a manifest
+            access_token (str, optional): synapse access token. Required when getting an existing manifest. Defaults to None.
+            dataset_id (str, optional): dataset id when generating an existing manifest. Defaults to None.
+            strict (bool, optional): strictness with which to apply validation rules to google sheets. Defaults to True.
+            title (str, optional): title of a given manifest. Defaults to None.
+            output_format (str, optional): format of manifest. It has three options: google sheet, excel or dataframe. Defaults to None.
+            use_annotations (bool, optional): whether to use annotations. Defaults to False.
+
+        Returns:
+            Union[str, pd.DataFrame, BinaryIO]: Googlesheet URL or pandas dataframe or Excel.
+        """
+        # create object of type ManifestGenerator
+        manifest_generator = ManifestGenerator(
+            path_to_json_ld=jsonld,
+            title=title,
+            root=data_type,
+            use_annotations=use_annotations,
+            alphabetize_valid_values = 'ascending',
+        )
+
+        # if returning a dataframe
+        if output_format:
+            if "dataframe" in output_format:
+                output_format = "dataframe"
+
+        print('dataset id', dataset_id)
+        print('output format', output_format)
+        print('strict', strict)
+        
+        result = manifest_generator.get_manifest(
+            dataset_id=dataset_id, sheet_url=True, output_format=output_format, access_token=access_token, strict=strict,
+        )
+
+        # return an excel file if output_format is set to "excel"
+        if output_format == "excel":
+            dir_name = os.path.dirname(result)
+            file_name = os.path.basename(result)
+            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+            return send_from_directory(directory=dir_name, path=file_name, as_attachment=True, mimetype=mimetype, max_age=0)
+               
+        return result
+    
+    @staticmethod
+    def create_manifests(jsonld:str, data_types:list, access_token:str=None, dataset_ids:list=None, output_format:str=None, title:str=None, strict:bool=None, use_annotations:bool=False) -> Union[str, pd.DataFrame, BinaryIO]:
+        """Create multiple manifests
+
+        Args:
+            jsonld (str): jsonld schema 
+            data_type (str): data type of a manifest
+            access_token (str, optional): synapse access token. Required when getting an existing manifest. Defaults to None.
+            dataset_id (str, optional): dataset id when generating an existing manifest. Defaults to None.
+            output_format (str, optional):format of manifest. It has three options: google sheet, excel or dataframe. Defaults to None.
+            title (str, optional): title of a given manifest. Defaults to None.
+            strict (bool, optional): strictness with which to apply validation rules to google sheets. Defaults to None.
+            use_annotations (bool, optional): whether to use annotations. Defaults to False.
+
+        Returns:
+            Union[str, pd.DataFrame, BinaryIO]: Googlesheet URL or pandas dataframe or Excel.
+        """
+        all_results = []
+        if data_types[0] == 'all manifests':
+            sg = SchemaGenerator(path_to_json_ld=jsonld)
+            component_digraph = sg.se.get_digraph_by_edge_type('requiresComponent')
+            components = component_digraph.nodes()
+            for component in components:
+                if title:
+                    t = f'{title}.{component}.manifest'
+                else: 
+                    t = f'Example.{component}.manifest'
+                if output_format != "excel":
+                    result = ManifestGenerator.create_single_manifest(jsonld=jsonld, data_type=component, output_format=output_format, title=t, access_token=access_token, strict=strict, use_annotations=use_annotations)
+                    all_results.append(result)
+                else: 
+                    logger.error('Currently we do not support returning multiple files as Excel format at once. Please choose a different output format. ')
+        else:
+            for i, dt in enumerate(data_types):
+                if not title: 
+                    t = f'Example.{dt}.manifest'
+                else: 
+                    if len(data_types) > 1:
+                        t = f'{title}.{dt}.manifest'
+                    else: 
+                        t = title
+                if dataset_ids:
+                    # if a dataset_id is provided add this to the function call.
+                    result = ManifestGenerator.create_single_manifest(jsonld=jsonld, data_type=dt, dataset_id=dataset_ids[i], output_format=output_format, title=t, access_token=access_token, strict=strict, use_annotations=use_annotations)
+                else:
+                    result = ManifestGenerator.create_single_manifest(jsonld=jsonld, data_type=dt, output_format=output_format, title=t, access_token=access_token, strict=strict, use_annotations=use_annotations)
+
+                # if output is pandas dataframe or google sheet url
+                if isinstance(result, str) or isinstance(result, pd.DataFrame):
+                    all_results.append(result)
+                else: 
+                    if len(data_types) > 1:
+                        logger.warning(f'Currently we do not support returning multiple files as Excel format at once. Only {t} would get returned. ')
+                    return result
+        return all_results
+        
 
     def get_manifest(
         self, dataset_id: str = None, sheet_url: bool = None, json_schema: str = None, output_format: str = None, output_path: str = None, access_token: str = None, strict: Optional[bool]=None,
@@ -1506,6 +1612,12 @@ class ManifestGenerator(object):
         Returns:
             Googlesheet URL, pandas dataframe, or an Excel spreadsheet 
         """
+
+        print('what is the dataset id??', dataset_id)
+        print('sheet url??', sheet_url)
+        print('json schema??', json_schema)
+        print('output format??', output_format)
+        print('strict??', strict)
 
         # Handle case when no dataset ID is provided
         if not dataset_id:

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1536,7 +1536,7 @@ class ManifestGenerator(object):
         return result
     
     @staticmethod
-    def create_manifests(jsonld:str, data_types:list, access_token:Optional[str]=None, dataset_ids:Optional[list]=None, output_format:Optional[str]=None, title:Optional[str]=None, strict:Optional[bool]=None, use_annotations:Optional[bool]=False) -> Union[List[str], List[pd.DataFrame], List[BinaryIO]]:
+    def create_manifests(jsonld:str, data_types:list, access_token:Optional[str]=None, dataset_ids:Optional[list]=None, output_format:Optional[str]=None, title:Optional[str]=None, strict:Optional[bool]=None, use_annotations:Optional[bool]=False) -> Union[List[str], List[pd.DataFrame], BinaryIO]:
         """Create multiple manifests
 
         Args:

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1310,7 +1310,7 @@ class ManifestGenerator(object):
         sh = gc.open_by_url(manifest_url)
         wb = sh[0]
 
-        wb.set_dataframe(manifest_df, (1, 1), fit=True)
+        wb.set_dataframe(manifest_df, (1, 1))
 
         # update validation rules (i.e. no validation rules) for out of schema columns, if any
         # TODO: similarly clear formatting for out of schema columns, if any

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1522,10 +1522,6 @@ class ManifestGenerator(object):
             if "dataframe" in output_format:
                 output_format = "dataframe"
 
-        print('dataset id', dataset_id)
-        print('output format', output_format)
-        print('strict', strict)
-        
         result = manifest_generator.get_manifest(
             dataset_id=dataset_id, sheet_url=True, output_format=output_format, access_token=access_token, strict=strict,
         )

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1608,13 +1608,6 @@ class ManifestGenerator(object):
         Returns:
             Googlesheet URL, pandas dataframe, or an Excel spreadsheet 
         """
-
-        print('what is the dataset id??', dataset_id)
-        print('sheet url??', sheet_url)
-        print('json schema??', json_schema)
-        print('output format??', output_format)
-        print('strict??', strict)
-
         # Handle case when no dataset ID is provided
         if not dataset_id:
             manifest_url = self.get_empty_manifest(json_schema_filepath=json_schema, strict=strict, sheet_url=sheet_url)

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -265,76 +265,8 @@ def get_manifest_route(schema_url: str, use_annotations: bool, dataset_ids=None,
                     f"When submitting 'all manifests' as the data_type cannot also submit dataset_id. "
                     f"Please check your submission and try again."
                 )
-
-    # Since this function is called in `get_manifest_route`, 
-    # it can use the access_token passed in from there and retain `access_token` as a parameter
-    def create_single_manifest(data_type, title, dataset_id=None, output_format=None, access_token=None, strict=strict_validation):
-        # create object of type ManifestGenerator
-        manifest_generator = ManifestGenerator(
-            path_to_json_ld=jsonld,
-            title=title,
-            root=data_type,
-            use_annotations=use_annotations,
-            alphabetize_valid_values = 'ascending',
-        )
-
-        # if returning a dataframe
-        if output_format:
-            if "dataframe" in output_format:
-                output_format = "dataframe"
-
-        result = manifest_generator.get_manifest(
-            dataset_id=dataset_id, sheet_url=True, output_format=output_format, access_token=access_token, strict=strict,
-        )
-
-        # return an excel file if output_format is set to "excel"
-        if output_format == "excel":
-            dir_name = os.path.dirname(result)
-            file_name = os.path.basename(result)
-            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-            return send_from_directory(directory=dir_name, path=file_name, as_attachment=True, mimetype=mimetype, max_age=0)
-               
-        return result
-
-    # Gather all returned result urls
-    all_results = []
-    if data_type[0] == 'all manifests':
-        sg = SchemaGenerator(path_to_json_ld=jsonld)
-        component_digraph = sg.se.get_digraph_by_edge_type('requiresComponent')
-        components = component_digraph.nodes()
-        for component in components:
-            if title:
-                t = f'{title}.{component}.manifest'
-            else: 
-                t = f'Example.{component}.manifest'
-            if output_format != "excel":
-                result = create_single_manifest(data_type=component, output_format=output_format, title=t, access_token=access_token)
-                all_results.append(result)
-            else: 
-                app.logger.error('Currently we do not support returning multiple files as Excel format at once. Please choose a different output format. ')
-    else:
-        for i, dt in enumerate(data_type):
-            if not title: 
-                t = f'Example.{dt}.manifest'
-            else: 
-                if len(data_type) > 1:
-                    t = f'{title}.{dt}.manifest'
-                else: 
-                    t = title
-            if dataset_ids:
-                # if a dataset_id is provided add this to the function call.
-                result = create_single_manifest(data_type=dt, dataset_id=dataset_ids[i], output_format=output_format, title=t, access_token=access_token)
-            else:
-                result = create_single_manifest(data_type=dt, output_format=output_format, title=t, access_token=access_token)
-
-            # if output is pandas dataframe or google sheet url
-            if isinstance(result, str) or isinstance(result, pd.DataFrame):
-                all_results.append(result)
-            else: 
-                if len(data_type) > 1:
-                    app.logger.warning(f'Currently we do not support returning multiple files as Excel format at once. Only {t} would get returned. ')
-                return result
-
+        
+    all_results = ManifestGenerator.create_manifests(jsonld=jsonld, output_format=output_format, data_types=data_type, title=title, access_token=access_token, dataset_ids=dataset_ids, strict=strict_validation, use_annotations=use_annotations)
     return all_results
 
 #####profile validate manifest route function 


### PR DESCRIPTION
## Context
Move some methods that were previously in `routes.py` to ManifestGenerator without going through refactor. Related to FDS-1350. 

## Changelog
* Move create_single_manifest function that was previously nested under `get_manifest_route` in routes.py to an independent function in `ManifestGenerator`
* Move the logic of previously generating multiple manifests that was previously under `get_manifest_route` to `ManifestGenerator`.
* Now, regardless the number of data_type and dataset_ids, the API could just call `mg.create_manifests` to generate multiple or single manifests
* Added type hinting to `create_single_manifest` and `create_manifests` and reorganize some of the parameters

## Test
1) Generate new Patient manifest as a google sheet
* Example data model 
* data_type: Patient
* output_format: google_sheet
Got expected output: a new patient manifest gets generated. The return contains one google sheet link. 

2) Generate multiple new manifests as google sheets
* Example data model 
* data_type: Patient
* output_format: google_sheet
Got expected output: three manifests gets generated. The return contains three google sheet link. 

3) Generate an existing manifest as a google sheet 
* Example data model 
* data_type: Patient
* dataset_id: syn51547836
* output_format: google_sheet
Got expected output: one manifest gets generated. The return contains one google sheet link: https://docs.google.com/spreadsheets/d/1UECgUSxinXj2lJ02f0GASw0rRmSs-nHiJnAdBJMJBqc/edit#gid=0

4) Generate an existing manifest as an Excel sheet
* Example data model 
* data_type: Patient
* dataset_id: syn51547836
* output_format: excel
Got expected output: An excel spreadsheet gets returned and then content of the manifest is the same as the one above

5) Generate multiple existing manifests as google sheets
* Example data model 
* data_type: Patient, Biospecimen
* dataset_id: `syn51547836`, `syn51547837`
* asset_view: syn51547844
* output_format: `google_sheet`
Got expected output: Two google sheet urls got returned. (See [here](https://docs.google.com/spreadsheets/d/1thlmGjlgZAr7T8kqzHnKosU6OXHhPyYpkuvzccoPqLo/edit#gid=0) and [here](https://docs.google.com/spreadsheets/d/1jWDxyex5_EnIvFawFywPBpQb9fUpaR1Bgf72q30HVQQ/edit#gid=0)) 

6) Make sure use_annotations parameter is working
* Example data model 
* use_annotations: true
* asset_view: syn51707141
* dataset_id: syn25614635
* data_type: BulkRNA-seqAssay
* output_format: google_sheet
Got expected output: https://docs.google.com/spreadsheets/d/1o0ZL86TzAbcU3pT8c09pp6Uv5j5jlTJB68BU855URP0/edit#gid=0

7) Ran all the tests in test_api.py related to generating a manifest