### PR TITLE
Resolved an issue where a visualization endpoint intermittently returned the wrong information

### DIFF
--- a/schematic/visualization/tangled_tree.py
+++ b/schematic/visualization/tangled_tree.py
@@ -749,7 +749,6 @@ class TangledTree(object):
         '''
         # Gather the data model's, topological generations, nodes and edges
         topological_gen, nodes, edges, subg = self.get_topological_generations()
-        all_layers = []
 
         if self.figure_type == 'component':
             # Gather all source nodes
@@ -765,7 +764,7 @@ class TangledTree(object):
             layers_json = self.get_node_layers_json(topological_gen, source_nodes, child_parents, parent_children, all_parent_children=all_parent_children)
 
             # If indicated save outputs locally else gather all layers.
-            all_layers = self.save_outputs(save_file, layers_json, all_layers=all_layers)         
+            all_layers = self.save_outputs(save_file, layers_json)         
 
         if self.figure_type == 'dependency':
             # Get component digraph and nodes.
@@ -777,6 +776,7 @@ class TangledTree(object):
             attributes_df = pd.read_table(StringIO(attributes_csv_str), sep=",")
 
             
+            all_layers =[]
             for cn in component_nodes:
                 # Gather attribute and dependency information per node
                 conditional_attributes, ca_alias, all_attributes = self.gather_component_dependency_info(cn, attributes_df)

--- a/schematic/visualization/tangled_tree.py
+++ b/schematic/visualization/tangled_tree.py
@@ -688,7 +688,7 @@ class TangledTree(object):
 
         return layers_json
 
-    def save_outputs(self, save_file, layers_json, cn='', all_layers=[]):
+    def save_outputs(self, save_file, layers_json, cn='', all_layers=None):
         '''
         Inputs:
             save_file (bool): Indicates whether to save a file locally or not.:
@@ -702,6 +702,8 @@ class TangledTree(object):
                 If save_file == False: Each string represents contains the layers for a single tangled tree.
                 If save_file ==True: is an empty list.
         '''
+        if all_layers is None:
+            all_layers = []
         if save_file == True:
             if cn:
                 output_file_name = f"{self.schema_abbr}_{self.figure_type}_{cn}_tangled_tree.json"

--- a/schematic/visualization/tangled_tree.py
+++ b/schematic/visualization/tangled_tree.py
@@ -747,6 +747,7 @@ class TangledTree(object):
         '''
         # Gather the data model's, topological generations, nodes and edges
         topological_gen, nodes, edges, subg = self.get_topological_generations()
+        all_layers = []
 
         if self.figure_type == 'component':
             # Gather all source nodes
@@ -762,7 +763,7 @@ class TangledTree(object):
             layers_json = self.get_node_layers_json(topological_gen, source_nodes, child_parents, parent_children, all_parent_children=all_parent_children)
 
             # If indicated save outputs locally else gather all layers.
-            all_layers = self.save_outputs(save_file, layers_json)         
+            all_layers = self.save_outputs(save_file, layers_json, all_layers=all_layers)         
 
         if self.figure_type == 'dependency':
             # Get component digraph and nodes.
@@ -774,7 +775,6 @@ class TangledTree(object):
             attributes_df = pd.read_table(StringIO(attributes_csv_str), sep=",")
 
             
-            all_layers =[]
             for cn in component_nodes:
                 # Gather attribute and dependency information per node
                 conditional_attributes, ca_alias, all_attributes = self.gather_component_dependency_info(cn, attributes_df)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -881,6 +881,7 @@ class TestSchemaVisualization:
 
     @pytest.mark.parametrize("figure_type", ["component", "dependency"])
     def test_visualize_tangled_tree_layers(self, client, figure_type, data_model_jsonld):
+        # TODO: Determine a 2nd data model to use for this test, test both models sequentially, add checks for content of response
         params = {
             "schema_url": data_model_jsonld,
             "figure_type": figure_type


### PR DESCRIPTION
Was able to repro erroneous behavior on prod, staging, and a local `develop` api, for `visualize/tangled_tree/layers` endpoint only. 
Behavior was caused because over a session, the value for `all_layers` in `TangledTree.get_tangled_tree_layers` would be preserved between requests sent to the endpoint, with the new layer information just being appended to it. The endpoint then takes the first element of the `all_layers` list after it is returned, assuming that it is a list of length 1. What was actually happening is that the layers for each request were all being returned in this list and so when the first one was returned it could differ from what was requested in the most recent request.