### PR TITLE
Resolved issues with cross-manifest validation that occured when a manifest was only a single row

### DIFF
--- a/schematic/utils/validate_utils.py
+++ b/schematic/utils/validate_utils.py
@@ -76,7 +76,10 @@ def np_array_to_str_list(np_array):
     return np.char.mod('%d', np_array).tolist()
 
 def iterable_to_str_list(iterable):
-    "Parse an iterable into a list of strings"
+    """
+    Parse an object into a list of strings
+    Accepts str, Number, and iterable inputs
+    """
 
     # If object is a string, just return wrapped as a list
     if isinstance(iterable, str):

--- a/schematic/utils/validate_utils.py
+++ b/schematic/utils/validate_utils.py
@@ -6,6 +6,7 @@ from schematic.utils.io_utils import load_json
 from schematic import LOADER
 from typing import List
 import numpy as np
+from numbers import Number
 
 def validate_schema(schema):
     """Validate schema against schema.org standard"""
@@ -76,10 +77,18 @@ def np_array_to_str_list(np_array):
 
 def iterable_to_str_list(iterable):
     "Parse an iterable into a list of strings"
-    strlist = []
 
-    for element in iterable:
-        strlist.append(str(element))
+    # If object is a string, just return wrapped as a list
+    if isinstance(iterable, str):
+        return [iterable]
+    # If object is numberical, convert to string and wrap as a list
+    elif isinstance(iterable, Number):
+        return [str(iterable)]
+    # If the object is iterable and not a string, convert every element to string and wratp as a list
+    else:
+        strlist = []
+        for element in iterable:
+            strlist.append(str(element))
 
     return strlist
     


### PR DESCRIPTION
Updates the util function `iterable_to_str_list` to A) handle the case where a single string is passed in and B) handle the case where a non-iterable object, such as a numerical object, is passed in.

Fixes FDS-1384
Fixes FDS-1425