### PR TITLE
[bug fix] Make access token optional to fix CLI manifest submission 

### DIFF
--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -298,7 +298,7 @@ class MetadataModel(object):
         dataset_id: str,
         manifest_record_type: str,
         restrict_rules: bool,
-        access_token: str,
+        access_token: Optional[str] = None,
         validate_component: Optional[str] = None,
         use_schema_label: bool = True,
         hide_blanks: bool = False,


### PR DESCRIPTION
Update typing to make the `access_token` parameter optional to prevent breaking changes to the CLI.