### PR TITLE
[bug fix] Remove `great_expectations/expectations/Manifest_test_suite.json` before running validation tests

### DIFF
--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -1,4 +1,5 @@
 import json
+import os
 import logging
 import string
 
@@ -256,7 +257,11 @@ class MetadataModel(object):
                 )
 
             return errors, warnings
-
+        
+        # check if suite has been created. If so, delete it
+        if os.path.exists("great_expectations/expectations/Manifest_test_suite.json"):
+            os.remove("great_expectations/expectations/Manifest_test_suite.json")
+            
         errors, warnings, manifest = validate_all(self, 
                                                   errors=errors, 
                                                   warnings=warnings, 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -43,6 +43,10 @@ def get_rule_combinations():
             continue
     
 class TestManifestValidation:
+    # check if suite has been created. If so, delete it
+    if os.path.exists("great_expectations/expectations/Manifest_test_suite.json"):
+        os.remove("great_expectations/expectations/Manifest_test_suite.json")
+
     def test_valid_manifest(self,helpers,metadataModel):
         manifestPath = helpers.get_data_path("mock_manifests/Valid_Test_Manifest.csv")
         rootNode = 'MockComponent'
@@ -377,12 +381,11 @@ class TestManifestValidation:
             invalid_entry = ['71738', '98085', '210065'],
             sg = sg,
             )[1] in warnings 
-        
+    
 
     @pytest.mark.rule_combos(reason = 'This introduces a great number of tests covering every possible rule combination that are only necessary on occasion.')
     @pytest.mark.parametrize("base_rule, second_rule", get_rule_combinations())
-    def test_rule_combinations(self, helpers, sg, base_rule, second_rule, metadataModel):
-        #print(base_rule,second_rule)
+    def test_rule_combinations(self, helpers, sg, base_rule, second_rule, metadataModel,):
         rule_regex = re.compile(base_rule+'.*')
 
         manifestPath = helpers.get_data_path("mock_manifests/Rule_Combo_Manifest.csv")
@@ -429,7 +432,8 @@ class TestManifestValidation:
             sg = sg,
             jsonSchema = sg.get_json_schema_requirements(rootNode, rootNode + "_validation")
         )
-        
+
+
         #perform validation with no exceptions raised
         _, errors, warnings = validateManifest.validate_manifest_rules(
             manifest = manifest, 


### PR DESCRIPTION
## Context
Related to: https://sagebionetworks.jira.com/browse/FDS-1459

1. Currently when running `python -m rule-combos`, the code assumes that `Manifest_test_suite.json` does not exist. If `test_manifest_suite.json` exists, it would raise an error and cause the rule combination tests to fail. 
2. I tried assessing if this will affect the users by having an empty `Manifest_test_suite.json`.. When I ran: 
```
schematic model --config config.yml validate --manifest_path tests/data/mock_manifests/Valid_Test_Manifest.csv --data_type MockComponent
```
I got an error: 
```
  File "/Users/lpeng/Library/Caches/pypoetry/virtualenvs/schematicpy-9OomxyhV-py3.10/lib/python3.10/site-packages/great_expectations/data_context/store/expectations_store.py", line 185, in add
    raise gx_exceptions.ExpectationSuiteError(
great_expectations.exceptions.exceptions.ExpectationSuiteError: An ExpectationSuite named Manifest_test_suite already exists.
```

## Solution 
1. Delete `great_expectations/expectations/test_manifest_suite.json` before running `test_rule_combinations`. Since `test_rule_combinations` is under class `TestManifestValidation`, and I only want the check to happen once for all parameters under `test_rule_combinations`, I put the check under class `TestManifestValidation`
2. For the same code, I also added it in `validateModelManifest` to avoid users running into the issue. 

## Test
1. Make sure that all validation tests still pass in 235.33s (0:03:55). Without the check, all the validation tests finished in 224.16s (0:03:44). 
2. I also made sure that `pytest -s tests/test_validation.py::TestManifestValidation` and `pytest -s tests/test_validation.py::TestManifestValidation::test_rule_combinations` could be run without errors. 
3. Made sure that `schematic model --config config.yml validate --manifest_path tests/data/mock_manifests/Valid_Test_Manifest.csv --data_type MockComponent` could be run without errors 

