### PR TITLE
[bug fix] Fixed tests in `test_api.py`

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,8 +155,9 @@ class TestSynapseStorage:
         else: 
             if file_names: 
                 assert ["syn23643255","Sample_A.txt"] and ["syn24226530","Sample_A.txt"] and ["syn25057024","Sample_A.txt"] in response_dt
+                assert ['syn23643256', 'Sample_C.txt'] and ['syn24226531', 'Sample_B.txt'] not in response_dt
             else: 
-                assert ["syn25705259","Boolean Test"] and ["syn23667202","DataTypeX_table"] in response_dt
+                assert ['syn23643256', 'Sample_C.txt'] and ['syn24226530', 'Sample_A.txt'] and ['syn24226531', 'Sample_B.txt'] in response_dt
         
     @pytest.mark.synapse_credentials_needed
     def test_get_storage_project_dataset(self, request_headers, client):
@@ -902,9 +903,7 @@ class TestSchemaVisualization:
         response = client.get("http://localhost:3001/v1/visualize/component", query_string = params)
 
         assert response.status_code == 200
-
         assert "Attribute,Label,Description,Required,Cond_Req,Valid Values,Conditional Requirements,Component" in response.text
-        assert response_text in response.text
 
 @pytest.mark.schematic_api
 @pytest.mark.rule_benchmark

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -892,7 +892,7 @@ class TestSchemaVisualization:
 
         assert response.status_code == 200
 
-    @pytest.mark.parametrize("component, response_text", [("Patient", "Component,Component,TBD,False,,,,Patient"), ("BulkRNA-seqAssay", "Component,Component,TBD,False,,,,BulkRNA-seqAssay")])
+    @pytest.mark.parametrize("component, response_text", [("Patient", "Component,Component,TBD,True,,,,Patient"), ("BulkRNA-seqAssay", "Component,Component,TBD,True,,,,BulkRNA-seqAssay")])
     def test_visualize_component(self, client, data_model_jsonld,component, response_text):
         params = {
             "schema_url": data_model_jsonld,
@@ -904,6 +904,7 @@ class TestSchemaVisualization:
 
         assert response.status_code == 200
         assert "Attribute,Label,Description,Required,Cond_Req,Valid Values,Conditional Requirements,Component" in response.text
+        assert response_text in response.text
 
 @pytest.mark.schematic_api
 @pytest.mark.rule_benchmark


### PR DESCRIPTION
There are two tests failing in `test_api`: 
1) test_get_dataset_files when full_path = False, file_names = None
The test failed because we changed the `walk` function in schematic. Since we changed the `walk` function to only include files and folders, tables are no longer in the output. I updated the tests to make sure that they now pass

2) test_visualize_component
"Component" should be required, so I updated the `False` to `True`

Note: i found out this issue when doing a release of schematic v24.1.1
Related to: https://sagebionetworks.jira.com/browse/FDS-1604
