### PR TITLE
feature-configuration-fixes

### DIFF
--- a/schematic/configuration/configuration.py
+++ b/schematic/configuration/configuration.py
@@ -181,6 +181,15 @@ class Configuration:
             self._google_sheets_config.service_acct_creds, self._parent_directory
         )
 
+    @service_account_credentials_path.setter
+    def service_account_credentials_path(self, path: str) -> None:
+        """Sets the path of the Google service account credentials.
+
+        Args:
+            path (str): The path of the Google service account credentials.
+        """
+        self._google_sheets_config.service_acct_creds = path
+
     @property
     def google_sheets_master_template_id(self) -> str:
         """

--- a/schematic/configuration/configuration.py
+++ b/schematic/configuration/configuration.py
@@ -83,13 +83,14 @@ class Configuration:
         self._google_sheets_config = GoogleSheetsConfig(
             **config.get("google_sheets", {})
         )
-        self._set_asset_store(config.get("asset_store", {}))
+        asset_store_config = config.get("asset_store", None)
+        if asset_store_config:
+            self._set_asset_store(asset_store_config)
 
     def _set_asset_store(self, config: dict[str, Any]) -> None:
         allowed_config_fields = {"synapse"}
-        if not config:
-            pass
-        if not set(config.keys()).issubset(allowed_config_fields):
+        all_fields_are_valid = set(config.keys()).issubset(allowed_config_fields)
+        if not all_fields_are_valid:
             raise ConfigNonAllowedFieldError(
                 "Non allowed fields in asset_store of configuration file.",
                 list(config.keys()),

--- a/tests/data/test_configs/valid_config2.yml
+++ b/tests/data/test_configs/valid_config2.yml
@@ -1,0 +1,15 @@
+# This is a valid config, but missing the asset store section
+
+manifest:
+  manifest_folder: "folder_name"
+  title: "title"
+  data_type:
+    - "data_type"
+
+model:
+  location: "model.jsonld"
+
+google_sheets:
+  service_acct_creds_synapse_id: "syn1"
+  service_acct_creds: "creds.json"
+  strict_validation: false

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -213,3 +213,13 @@ class TestConfiguration:
         assert config.synapse_master_fileview_id == "syn1"
         with pytest.raises(ValidationError):
             config.synapse_master_fileview_id = "syn"
+
+    def test_set_service_account_credentials_path(self) -> None:
+        """Testing for Configuration service_account_credentials_path setter"""
+        config = Configuration()
+        assert (
+            os.path.basename(config.service_account_credentials_path)
+            == "schematic_service_account_creds.json"
+        )
+        config.service_account_credentials_path = "test.json"
+        assert os.path.basename(config.service_account_credentials_path) == "test.json"

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -198,6 +198,14 @@ class TestConfiguration:
          is not valid
         """
         config = Configuration()
+        config.load_config("tests/data/test_configs/valid_config2.yml")
+
+    def test_load_config4(self) -> None:
+        """
+        Testing for Configuration.load_config where config file
+         has no asset store section
+        """
+        config = Configuration()
         with pytest.raises(ConfigNonAllowedFieldError):
             config.load_config("tests/data/test_configs/invalid_config1.yml")
         with pytest.raises(ConfigNonAllowedFieldError):


### PR DESCRIPTION
- Fixes [fds-1571](https://sagebionetworks.jira.com/browse/FDS-1571)
- Fixes [fds-1572](https://sagebionetworks.jira.com/browse/FDS-1572)
- Adds a setter to configuration.py to allow setting of service account creds file (without using a config file)
- Fixes when config file is missing the asset_store section