### PR TITLE
Develop fix timeout

### DIFF
--- a/certificate.conf
+++ b/certificate.conf
@@ -7,6 +7,8 @@ server {
     proxy_read_timeout 300;
     proxy_connect_timeout 300;
     proxy_send_timeout 300;
+    send_timeout 300;
+    uwsgi_read_timeout 300;
     location / {
         try_files $uri @app;
     }

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -1252,4 +1252,37 @@ paths:
           description: Schematic version was not able to be identified.
       tags:
         - Version
-        
+
+  /test_time_out:
+    get:
+      summary: Test time out 1 
+      description: Test time out 1
+      operationId: schematic_api.api.routes.test_time_out
+      responses:
+        "200":
+          description: Test
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Test
+      tags:
+        - Test     
+
+  /test_time_out_two:
+    get:
+      summary: Test time out 2
+      description: Test time out 2
+      operationId: schematic_api.api.routes.test_time_out_two
+      responses:
+        "200":
+          description: Test
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Test
+      tags:
+        - Test   

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -1255,8 +1255,8 @@ paths:
 
   /test_time_out:
     get:
-      summary: Test time out 1 
-      description: Test time out 1
+      summary: sleep 59.9s
+      description: sleep 59.9s
       operationId: schematic_api.api.routes.test_time_out
       responses:
         "200":
@@ -1272,8 +1272,8 @@ paths:
 
   /test_time_out_two:
     get:
-      summary: Test time out 2
-      description: Test time out 2
+      summary: sleep 60s
+      description: sleep 60s
       operationId: schematic_api.api.routes.test_time_out_two
       responses:
         "200":
@@ -1286,3 +1286,37 @@ paths:
           description: Test
       tags:
         - Test   
+
+  /test_time_out_three:
+    get:
+      summary: sleep 120s
+      description: sleep 120s 
+      operationId: schematic_api.api.routes.test_time_out_three
+      responses:
+        "200":
+          description: Test
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Test
+      tags:
+        - Test 
+
+  /test_time_out_four:
+    get:
+      summary: sleep 180s
+      description: sleep 180s 
+      operationId: schematic_api.api.routes.test_time_out_four
+      responses:
+        "200":
+          description: Test
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Test
+      tags:
+        - Test 

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -1018,11 +1018,23 @@ def get_schematic_version() -> str:
 def test_time_out():
     """return test time out
     """
-    time.sleep(60)
+    time.sleep(59.9)
     return "okay"
 
 def test_time_out_two():
     """return test time out
     """
-    time.sleep(59.9)
+    time.sleep(60)
+    return "okay"
+
+def test_time_out_three():
+    """return test time out
+    """
+    time.sleep(120)
+    return "okay"
+
+def test_time_out_four():
+    """return test time out
+    """
+    time.sleep(180)
     return "okay"

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -7,6 +7,7 @@ import urllib.request
 import logging
 import pathlib
 import pickle
+import time
 
 import connexion
 from connexion.decorators.uri_parsing import Swagger2URIParser
@@ -39,7 +40,7 @@ from synapseclient.core.exceptions import (
 )
 from schematic.utils.general import entity_type_mapping
 from schematic.utils.schema_utils import get_property_label_from_display_name
-
+from schematic.utils.general import profile
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
@@ -728,7 +729,7 @@ def get_asset_view_table(asset_view, return_type):
         file_view_table_df.to_csv(export_path, index=False)
         return export_path
 
-
+@profile(sort_by='cumulative', strip_dirs=True)
 def get_project_manifests(project_id, asset_view):
     # Access token now stored in request header
     access_token = get_access_token()
@@ -1013,3 +1014,15 @@ def get_schematic_version() -> str:
             "Using this endpoint to check the version of schematic is only supported when the API is running in a docker container."
         )
     return version
+
+def test_time_out():
+    """return test time out
+    """
+    time.sleep(60)
+    return "okay"
+
+def test_time_out_two():
+    """return test time out
+    """
+    time.sleep(59.9)
+    return "okay"

--- a/uwsgi-nginx-entrypoint.sh
+++ b/uwsgi-nginx-entrypoint.sh
@@ -22,6 +22,8 @@ else
     content_server=$content_server'    proxy_read_timeout 300;\n'
     content_server=$content_server'    proxy_connect_timeout 300;\n'
     content_server=$content_server'    proxy_send_timeout 300;\n'
+    content_server=$content_server'    send_timeout 300;\n'
+    content_server=$content_server'    uwsgi_read_timeout 300;\n'
     content_server=$content_server'    location / {\n'
     content_server=$content_server'        try_files $uri @app;\n'
     content_server=$content_server'    }\n'


### PR DESCRIPTION
## Description 

Made sure that time out no longer happened. 

Tested by creating a docker image locally and tested endpoints that sleep 60s, 120s, and 180s:  

```
schematic-api-aws  | [pid: 20|app: 0|req: 3/6] 172.22.0.1 () {52 vars in 859 bytes} [Fri Feb  2 15:54:38 2024] GET /v1/test_time_out_three => generated 4 bytes in 119956 msecs (HTTP/2.0 200) 2 headers in 79 bytes (2 switches on core 0)
schematic-api-aws  | 172.22.0.1 - - [02/Feb/2024:15:56:38 +0000] "GET /v1/test_time_out_three HTTP/2.0" 200 4 "https://127.0.0.1/v1/ui/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" "-"
schematic-api-aws  | [pid: 19|app: 0|req: 4/7] 172.22.0.1 () {52 vars in 857 bytes} [Fri Feb  2 15:56:47 2024] GET /v1/test_time_out_four => generated 4 bytes in 179988 msecs (HTTP/2.0 200) 2 headers in 79 bytes (2 switches on core 0)
schematic-api-aws  | 172.22.0.1 - - [02/Feb/2024:15:59:47 +0000] "GET /v1/test_time_out_four HTTP/2.0" 200 4 "https://127.0.0.1/v1/ui/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" "-"
schematic-api-aws  | 172.22.0.1 - - [02/Feb/2024:16:08:14 +0000] "GET /v1/test_time_out_two HTTP/2.0" 200 4 "https://127.0.0.1/v1/ui/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" "-"
```
^ the endpoints all returned `200`