### PR TITLE
Handle non-standard JSONLD Formats (no display name, and single dictionary entries)

### DIFF
--- a/schematic/schemas/data_model_jsonld.py
+++ b/schematic/schemas/data_model_jsonld.py
@@ -392,7 +392,10 @@ class DataModelJsonLD(object):
         Note:
             User order only matters for nodes that are also attributes
         """
-        template_label = template["rdfs:label"]
+        try:
+            template_label = template["rdfs:label"]
+        except:
+            breakpoint()
 
         for jsonld_key, entry in template.items():
             # Make sure dealing with an edge relationship:


### PR DESCRIPTION
Used to help parse some exports from core models, but could have broader applicability.