### PR TITLE
Run rule combinations tests at every push instead of only selectively

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Run tests
         env:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
+          SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
         run: >
           source .venv/bin/activate;
           pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,24 +121,13 @@ jobs:
       #----------------------------------------------
       #              run test suite
       #----------------------------------------------
-      - name: Run regular tests and rule combination tests
+      - name: Run tests
         env:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
-        if: ${{ contains(github.event.head_commit.message, 'runcombos') }}
         run: >
           source .venv/bin/activate;
           pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
           -m "not (google_credentials_needed or schematic_api or table_operations)" --reruns 2 -n auto
-
-      - name: Run tests
-        env:
-          SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
-          SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
-        if: ${{ false == contains(github.event.head_commit.message, 'runcombos') }}
-        run: >
-          source .venv/bin/activate;
-          pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
-          -m "not (google_credentials_needed or rule_combos or schematic_api or table_operations)" --reruns 2  -n auto
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Modify the `test.yml` workflow so that the validation rule combinations tests run at every push instead of only when explicitly triggered