### PR TITLE
[bug fix] Updated poetry version in readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
     python: "3.9"
   jobs:
     post_install:
-      - pip install poetry==1.2.0
+      - pip install poetry==1.3.0
       - poetry config virtualenvs.create false
       - poetry install --with doc
     #Poetry will install my dependencies into the virtualenv created by readthedocs if I set virtualenvs.create=false


### PR DESCRIPTION
## Context: 
Readthedocs documentation should be updated as `develop` branch gets updated. All the builds in readthedocs.yml are failing because `poetry` version is outdated. 

## Solution: 
* Send developers emails when a build fails
* fix the poetry version 

See the latest doc: https://schematicpy.readthedocs.io/en/latest/
