### PR TITLE
Update parallel_map to parallel_applymap

### DIFF
--- a/schematic/utils/df_utils.py
+++ b/schematic/utils/df_utils.py
@@ -98,7 +98,7 @@ def find_and_convert_ints(dataframe: pd.DataFrame) -> tuple[pd.DataFrame, pd.Dat
 
     else:  # parallelize iterations for large manifests
         pandarallel.initialize(verbose=1)
-        ints = dataframe.parallel_map(
+        ints = dataframe.parallel_applymap(
             lambda cell: convert_ints(cell), na_action="ignore"
         ).fillna(False)
 


### PR DESCRIPTION
Fixes an issue where load df was breaking for large manifests bc parallel map cannot be applied to data frames.
https://sagebionetworks.jira.com/browse/FDS-1740