### PR TITLE
Avoid repeatedly calling `generate_data_model_graph`

### DIFF
--- a/schematic/manifest/commands.py
+++ b/schematic/manifest/commands.py
@@ -153,7 +153,7 @@ def get_manifest(
 
     # Generate graph
     logger.info("Generating data model graph.")
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     def create_single_manifest(data_type, output_csv=None, output_xlsx=None):
         # create object of type ManifestGenerator

--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1677,7 +1677,7 @@ class ManifestGenerator(object):
         data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
         # Generate graph
-        graph_data_model = data_model_grapher.generate_data_model_graph()
+        graph_data_model = data_model_grapher.graph
 
         # Gather all returned result urls
         all_results = []

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -63,7 +63,7 @@ class MetadataModel(object):
         data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
         # Generate graph
-        self.graph_data_model = data_model_grapher.generate_data_model_graph()
+        self.graph_data_model = data_model_grapher.graph
 
         self.dmge = DataModelGraphExplorer(self.graph_data_model)
 

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -78,7 +78,7 @@ def convert(schema, data_model_labels, output_jsonld):
 
     # Generate graph
     logger.info("Generating data model graph.")
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     # Validate generated data model.
     logger.info("Validating the data model internally.")

--- a/schematic/visualization/attributes_explorer.py
+++ b/schematic/visualization/attributes_explorer.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class AttributesExplorer:
     """AttributesExplorer class"""
 
-    # pylint: disable=R0913
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         path_to_jsonld: str,

--- a/schematic/visualization/attributes_explorer.py
+++ b/schematic/visualization/attributes_explorer.py
@@ -24,9 +24,9 @@ class AttributesExplorer:
         self,
         path_to_jsonld: str,
         data_model_labels: DisplayLabelType,
-        data_model_grapher: DataModelGraph = None, 
-        data_model_graph_explorer: DataModelGraphExplorer=None,
-        parsed_data_model: Dict[str, Dict[str, Any]]=None
+        data_model_grapher: DataModelGraph = None,
+        data_model_graph_explorer: DataModelGraphExplorer = None,
+        parsed_data_model: Dict[str, Dict[str, Any]] = None,
     ) -> None:
         self.path_to_jsonld = path_to_jsonld
 
@@ -35,8 +35,8 @@ class AttributesExplorer:
         # Parse Model
         if not parsed_data_model:
             data_model_parser = DataModelParser(
-            path_to_data_model=self.path_to_jsonld,
-        )            
+                path_to_data_model=self.path_to_jsonld,
+            )
             parsed_data_model = data_model_parser.parse_model()
 
         # Instantiate DataModelGraph

--- a/schematic/visualization/attributes_explorer.py
+++ b/schematic/visualization/attributes_explorer.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from schematic.schemas.data_model_parser import DataModelParser
 from schematic.schemas.data_model_graph import DataModelGraph, DataModelGraphExplorer
+from typing import Any, Dict
 from schematic.schemas.data_model_json_schema import DataModelJSONSchema
 from schematic.utils.io_utils import load_json
 
@@ -21,27 +22,33 @@ class AttributesExplorer:
         self,
         path_to_jsonld: str,
         data_model_labels: str,
+        data_model_grapher: DataModelGraph = None, 
+        data_model_graph_explorer: DataModelGraphExplorer=None,
+        parsed_data_model: Dict[str, Dict[str, Any]]=None
     ) -> None:
         self.path_to_jsonld = path_to_jsonld
 
         self.jsonld = load_json(self.path_to_jsonld)
 
-        # Instantiate Data Model Parser
-        data_model_parser = DataModelParser(
-            path_to_data_model=self.path_to_jsonld,
-        )
-
         # Parse Model
-        parsed_data_model = data_model_parser.parse_model()
+        if not parsed_data_model:
+            data_model_parser = DataModelParser(
+            path_to_data_model=self.path_to_jsonld,
+        )            
+            parsed_data_model = data_model_parser.parse_model()
 
         # Instantiate DataModelGraph
-        data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
+        if not data_model_grapher:
+            data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
         # Generate graph
         self.graph_data_model = data_model_grapher.graph
 
         # Instantiate Data Model Graph Explorer
-        self.dmge = DataModelGraphExplorer(self.graph_data_model)
+        if not data_model_graph_explorer:
+            self.dmge = DataModelGraphExplorer(self.graph_data_model)
+        else:
+            self.dmge = data_model_graph_explorer
 
         # Instantiate Data Model Json Schema
         self.data_model_js = DataModelJSONSchema(

--- a/schematic/visualization/attributes_explorer.py
+++ b/schematic/visualization/attributes_explorer.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 class AttributesExplorer:
     """AttributesExplorer class"""
 
+    # pylint: disable=R0913
     def __init__(
         self,
         path_to_jsonld: str,

--- a/schematic/visualization/attributes_explorer.py
+++ b/schematic/visualization/attributes_explorer.py
@@ -2,7 +2,7 @@
 import json
 import logging
 import os
-from typing import Optional, no_type_check, Any, Dict
+from typing import Optional, no_type_check
 import numpy as np
 import pandas as pd
 

--- a/schematic/visualization/attributes_explorer.py
+++ b/schematic/visualization/attributes_explorer.py
@@ -2,14 +2,12 @@
 import json
 import logging
 import os
-from typing import Optional, no_type_check
-
+from typing import Optional, no_type_check, Any, Dict
 import numpy as np
 import pandas as pd
 
 from schematic.schemas.data_model_parser import DataModelParser
 from schematic.schemas.data_model_graph import DataModelGraph, DataModelGraphExplorer
-from typing import Any, Dict
 from schematic.schemas.data_model_json_schema import DataModelJSONSchema
 from schematic.utils.schema_utils import DisplayLabelType
 from schematic.utils.io_utils import load_json
@@ -24,9 +22,9 @@ class AttributesExplorer:
         self,
         path_to_jsonld: str,
         data_model_labels: DisplayLabelType,
-        data_model_grapher: DataModelGraph = None,
-        data_model_graph_explorer: DataModelGraphExplorer = None,
-        parsed_data_model: Dict[str, Dict[str, Any]] = None,
+        data_model_grapher: Optional[DataModelGraph] = None,
+        data_model_graph_explorer: Optional[DataModelGraphExplorer] = None,
+        parsed_data_model: Optional[dict] = None,
     ) -> None:
         self.path_to_jsonld = path_to_jsonld
 

--- a/schematic/visualization/attributes_explorer.py
+++ b/schematic/visualization/attributes_explorer.py
@@ -38,7 +38,7 @@ class AttributesExplorer:
         data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
         # Generate graph
-        self.graph_data_model = data_model_grapher.generate_data_model_graph()
+        self.graph_data_model = data_model_grapher.graph
 
         # Instantiate Data Model Graph Explorer
         self.dmge = DataModelGraphExplorer(self.graph_data_model)

--- a/schematic/visualization/tangled_tree.py
+++ b/schematic/visualization/tangled_tree.py
@@ -52,7 +52,7 @@ class TangledTree:  # pylint: disable=too-many-instance-attributes
         data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
         # Generate graph
-        self.graph_data_model = data_model_grapher.generate_data_model_graph()
+        self.graph_data_model = data_model_grapher.graph
 
         # Instantiate Data Model Graph Explorer
         self.dmge = DataModelGraphExplorer(self.graph_data_model)

--- a/schematic/visualization/tangled_tree.py
+++ b/schematic/visualization/tangled_tree.py
@@ -67,7 +67,7 @@ class TangledTree:  # pylint: disable=too-many-instance-attributes
 
         # Initialize AttributesExplorer
         self.attributes_explorer = AttributesExplorer(
-            self.path_to_json_ld, data_model_labels
+            self.path_to_json_ld, data_model_labels, data_model_grapher = data_model_grapher, data_model_graph_explorer = self.dmge, parsed_data_model = parsed_data_model
         )
 
         # Create output paths.

--- a/schematic/visualization/tangled_tree.py
+++ b/schematic/visualization/tangled_tree.py
@@ -86,7 +86,11 @@ class TangledTree:  # pylint: disable=too-many-instance-attributes
 
         # Initialize AttributesExplorer
         self.attributes_explorer = AttributesExplorer(
-            self.path_to_json_ld, data_model_labels, data_model_grapher = data_model_grapher, data_model_graph_explorer = self.dmge, parsed_data_model = parsed_data_model
+            self.path_to_json_ld,
+            data_model_labels,
+            data_model_grapher=data_model_grapher,
+            data_model_graph_explorer=self.dmge,
+            parsed_data_model=parsed_data_model,
         )
 
         # Create output paths.

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -209,7 +209,6 @@ def save_file(file_key="csv_file"):
 
     return temp_path
 
-
 def initalize_metadata_model(schema_url, data_model_labels):
     # get path to temp data model file (csv or jsonld) as appropriate
     data_model = get_temp_model_path(schema_url)
@@ -769,7 +768,7 @@ def get_schema_pickle(schema_url, data_model_labels):
     data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     # write to local pickle file
     path = os.getcwd()
@@ -790,7 +789,7 @@ def get_subgraph_by_edge_type(schema_url, relationship, data_model_labels):
     data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     dmge = DataModelGraphExplorer(graph_data_model)
 
@@ -814,7 +813,7 @@ def find_class_specific_properties(schema_url, schema_class, data_model_labels):
     data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     dmge = DataModelGraphExplorer(graph_data_model)
 
@@ -856,7 +855,7 @@ def get_node_dependencies(
     data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     dmge = DataModelGraphExplorer(graph_data_model)
 
@@ -911,7 +910,7 @@ def get_node_range(
     data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     dmge = DataModelGraphExplorer(graph_data_model)
 
@@ -940,7 +939,7 @@ def get_if_node_required(
     data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     dmge = DataModelGraphExplorer(graph_data_model)
 
@@ -969,7 +968,7 @@ def get_node_validation_rules(
     data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     # Instantiate DataModelGraphExplorer
     dmge = DataModelGraphExplorer(graph_data_model)
@@ -1002,7 +1001,7 @@ def get_nodes_display_names(
     data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     # Instantiate DataModelGraphExplorer
     dmge = DataModelGraphExplorer(graph_data_model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ class Helpers:
         )
 
         # Generate graph
-        graph_data_model = data_model_grapher.generate_data_model_graph()
+        graph_data_model = data_model_grapher.graph
 
         # Instantiate DataModelGraphExplorer
         DMGE = DataModelGraphExplorer(graph_data_model)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -106,7 +106,7 @@ def get_MockComponent_attribute():
     data_model_grapher = DataModelGraph(parsed_data_model)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     dmge = DataModelGraphExplorer(graph_data_model)
     # sg = SchemaGenerator("https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.single_rule.model.jsonld")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -34,7 +34,7 @@ def generate_graph_data_model(helpers, path_to_data_model, data_model_labels):
     data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     return graph_data_model
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -99,7 +99,7 @@ def generate_graph_data_model(
     data_model_grapher = DataModelGraph(parsed_data_model, data_model_labels)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     return graph_data_model
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -192,7 +192,7 @@ class TestSynapseStorage:
         data_model_grapher = DataModelGraph(parsed_data_model)
 
         # Generate graph
-        graph_data_model = data_model_grapher.generate_data_model_graph()
+        graph_data_model = data_model_grapher.graph
 
         # Instantiate DataModelGraphExplorer
         dmge = DataModelGraphExplorer(graph_data_model)
@@ -558,7 +558,7 @@ class TestTableOperations:
         data_model_grapher = DataModelGraph(parsed_data_model)
 
         # Generate graph
-        graph_data_model = data_model_grapher.generate_data_model_graph()
+        graph_data_model = data_model_grapher.graph
 
         # Instantiate DataModelGraphExplorer
         dmge = DataModelGraphExplorer(graph_data_model)
@@ -636,7 +636,7 @@ class TestTableOperations:
         data_model_grapher = DataModelGraph(parsed_data_model)
 
         # Generate graph
-        graph_data_model = data_model_grapher.generate_data_model_graph()
+        graph_data_model = data_model_grapher.graph
 
         # Instantiate DataModelGraphExplorer
         dmge = DataModelGraphExplorer(graph_data_model)
@@ -740,7 +740,7 @@ class TestTableOperations:
         data_model_grapher = DataModelGraph(parsed_data_model)
 
         # Generate graph
-        graph_data_model = data_model_grapher.generate_data_model_graph()
+        graph_data_model = data_model_grapher.graph
 
         # Instantiate DataModelGraphExplorer
         dmge = DataModelGraphExplorer(graph_data_model)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1020,7 +1020,7 @@ class TestCsvUtils:
         data_model_grapher = DataModelGraph(parsed_data_model)
 
         # Generate graph
-        graph_data_model = data_model_grapher.generate_data_model_graph()
+        graph_data_model = data_model_grapher.graph
 
         # Convert graph to JSONLD
         jsonld_data_model = convert_graph_to_jsonld(Graph=graph_data_model)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -31,7 +31,7 @@ def graph_data_model_func(helpers, data_model_name):
     data_model_grapher = DataModelGraph(parsed_data_model)
 
     # Generate graph
-    graph_data_model = data_model_grapher.generate_data_model_graph()
+    graph_data_model = data_model_grapher.graph
 
     return graph_data_model
 


### PR DESCRIPTION
## Context: 
Related to https://sagebionetworks.jira.com/browse/FDS-1750

## Test
Since this affected multiple parts of the code base, I did: 
1) ran `test_api.py` locally and make sure that everything works there as expected
2) ran `model/componet-requirements` endpoint and used HTAN schema url as an input parameter
3) use `manifest/generate` endpoint to generate a new manifest 