### PR TITLE
Updated workflows to make sure `uwsgi` get installed when publishing an image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,17 +44,17 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
+      #    install your root project
+      #----------------------------------------------      
+      - name: Install library
+        run: poetry install --only-root
+
+      #----------------------------------------------
       # install dependencies if cache does not exist 
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-        
-      #----------------------------------------------
-      #    install your root project, if required 
-      #----------------------------------------------      
-      - name: Install library
-        run: poetry install --no-interaction
+        run: poetry install --no-interaction --all-extras --no-root
 
       #----------------------------------------------
       #    get current pushed tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,17 +66,17 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
-      # install dependencies if cache does not exist
+      #    install your root project
+      #----------------------------------------------      
+      - name: Install library
+        run: poetry install --only-root
+
+      #----------------------------------------------
+      # install dependencies if cache does not exist 
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root --all-extras
-
-      #----------------------------------------------
-      #    install your root project, if required
-      #----------------------------------------------
-      - name: Install library
-        run: poetry install --no-interaction --all-extras
+        run: poetry install --no-interaction --all-extras --no-root
 
       #----------------------------------------------
       #             perform linting


### PR DESCRIPTION
## Context
Failed to start uwsgi in image `v24.2.1`. When I tried running the image locally, I got an error: 
```
lpeng@w153 documents % docker run -it --rm --name schematic-test-api \
-p 443:443 \
ghcr.io/sage-bionetworks/schematic:v24.2.1

Checking for script in /app/prestart.sh
Running script /app/prestart.sh
Running inside /app/prestart.sh, you could add migrations to this file, e.g.:

#! /usr/bin/env sh

# Let the DB start
sleep 10;
# Run migrations
alembic upgrade head

/usr/lib/python3/dist-packages/supervisor/options.py:474: UserWarning: Supervisord is running as root and it is searching for its configuration file in default locations (including its current working directory); you probably want to specify a "-c" argument specifying an absolute path to a configuration file for improved security.
  self.warnings.warn(
2024-02-23 15:26:40,951 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
2024-02-23 15:26:40,951 INFO Included extra file "/etc/supervisor/conf.d/supervisord.conf" during parsing
2024-02-23 15:26:40,959 INFO RPC interface 'supervisor' initialized
2024-02-23 15:26:40,959 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2024-02-23 15:26:40,959 INFO supervisord started with pid 1
2024-02-23 15:26:41,966 INFO spawned: 'quit_on_failure' with pid 8
2024-02-23 15:26:41,972 INFO spawned: 'nginx' with pid 9
2024-02-23 15:26:41,974 INFO spawnerr: can't find command '/usr/local/bin/uwsgi'
2024-02-23 15:26:41,979 INFO success: nginx entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2024/02/23 15:26:42 [warn] 9#9: "ssl_stapling" ignored, issuer certificate not found for certificate "/etc/ssl/certs/localhost.crt"
nginx: [warn] "ssl_stapling" ignored, issuer certificate not found for certificate "/etc/ssl/certs/localhost.crt"
2024/02/23 15:26:42 [warn] 9#9: "ssl_stapling" ignored, issuer certificate not found for certificate "/etc/ssl/certs/localhost.crt"
nginx: [warn] "ssl_stapling" ignored, issuer certificate not found for certificate "/etc/ssl/certs/localhost.crt"
2024-02-23 15:26:42,999 INFO success: quit_on_failure entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2024-02-23 15:26:43,000 INFO spawnerr: can't find command '/usr/local/bin/uwsgi'
2024-02-23 15:26:45,007 INFO spawnerr: can't find command '/usr/local/bin/uwsgi'
2024-02-23 15:26:48,022 INFO spawnerr: can't find command '/usr/local/bin/uwsgi'
2024-02-23 15:26:48,022 INFO gave up: uwsgi entered FATAL state, too many start retries too quickly
2024-02-23 15:26:49,031 WARN received SIGTERM indicating exit request
2024-02-23 15:26:49,031 INFO waiting for quit_on_failure, nginx to die
2024-02-23 15:26:50,073 INFO stopped: nginx (exit status 0)
2024-02-23 15:26:50,078 INFO stopped: quit_on_failure (terminated by SIGTERM)
```
Based on the log above, I think this is because uWSGI didn't get properly installed after merging https://github.com/Sage-Bionetworks/schematic/pull/1362