### PR TITLE
[bug fix] Updated workflow to install dependencies and root project together

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -54,17 +54,11 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
-      # install dependencies if cache does not exist
+      # install dependencies and root project
       #----------------------------------------------
-      - name: Install dependencies
+      - name: Install dependencies and root project
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root --all-extras
-
-      #----------------------------------------------
-      #    install your root project, if required
-      #----------------------------------------------
-      - name: Install library
-        run: poetry install --no-interaction
+        run: poetry install --no-interaction --all-extras
 
       #----------------------------------------------
       #              run API test suite

--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -65,11 +65,11 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
-      # install dependencies if cache does not exist 
+      # install dependencies and root project
       #----------------------------------------------
-      - name: Install dependencies
+      - name: Install dependencies and root project
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        run: poetry install --no-interaction --all-extras
 
       # create documentation
       - run: poetry add pdoc@13.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,18 +44,12 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
-      #    install your root project
-      #----------------------------------------------      
-      - name: Install library
-        run: poetry install --only-root
-
+      # install dependencies and root project
       #----------------------------------------------
-      # install dependencies if cache does not exist 
-      #----------------------------------------------
-      - name: Install dependencies
+      - name: Install dependencies and root project
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --all-extras --no-root
-
+        run: poetry install --no-interaction --all-extras
+        
       #----------------------------------------------
       #    get current pushed tag
       #----------------------------------------------      

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ name: Test schematic
 
 on:
   push:
-    branches: ['main', 'develop-fix-workflow']
+    branches: ['main']
   pull_request:
     branches: ['*']
   workflow_dispatch:  # Allow manually triggering the workflow
@@ -68,7 +68,7 @@ jobs:
       #----------------------------------------------
       # install dependencies and root project
       #----------------------------------------------
-      - name: Install dependencies
+      - name: Install dependencies and root project
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --all-extras
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ name: Test schematic
 
 on:
   push:
-    branches: ['main']
+    branches: ['main', 'develop-fix-workflow']
   pull_request:
     branches: ['*']
   workflow_dispatch:  # Allow manually triggering the workflow
@@ -66,17 +66,11 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
-      #    install your root project
-      #----------------------------------------------      
-      - name: Install library
-        run: poetry install --only-root
-
-      #----------------------------------------------
-      # install dependencies if cache does not exist 
+      # install dependencies and root project
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --all-extras --no-root
+        run: poetry install --no-interaction --all-extras
 
       #----------------------------------------------
       #             perform linting


### PR DESCRIPTION
## Context
When installing dependencies, we had: 
```
        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
```
which made that github action skipped dependencies installation after `poetry install --only-root`. See screen shot that made the action failed. 

<img width="1063" alt="Screen Shot 2024-02-23 at 1 48 22 PM" src="https://github.com/Sage-Bionetworks/schematic/assets/55448354/4b6ed1f4-347d-4c6f-af1c-c076b93f5653">

I think it makes sense to just install root and dependencies together. 
I tested it locally to make sure that the project itself could be installed: 
```
(schematicpy-py3.10) lpeng@ip-192-168-0-2 schematic % poetry install --no-interaction --all-extras
Configuration file exists at /Users/lpeng/Library/Preferences/pypoetry, reusing this directory.

Consider moving TOML configuration files to /Users/lpeng/Library/Application Support/pypoetry, as support for the legacy directory will be removed in an upcoming release.
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: schematicpy (23.11.1)

```
