### PR TITLE
[bug fix] Fix wrong function name reference in function `get_viz_component_attributes_explorer`

### DIFF
--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -604,7 +604,7 @@ def get_viz_component_attributes_explorer(
 
     attributes_csv = AttributesExplorer(
         data_model, data_model_labels
-    ).parse_component_attributes(
+    )._parse_component_attributes(
         component, save_file=False, include_index=include_index
     )
 


### PR DESCRIPTION
## Context
Related to: https://sagebionetworks.jira.com/browse/FDS-1790

After PR https://github.com/Sage-Bionetworks/schematic/pull/1373, the name of function `parse_component_attributes` gets updated to `_parse_component_attributes`. But `get_viz_component_attributes_explorer` was still referring the wrong function name. 

## Test
Made sure that `get_viz_component_attributes_explorer` could now returned without errors
Made sure that `test_viz.py` ran without errors 
Made sure that `pytest tests/test_api.py::TestSchemaVisualization::test_visualize_component` ran without errors