### PR TITLE
Scan docker images with trivy immediately after they are created in t…

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -55,3 +55,17 @@ jobs:
           build-args: |
             TAG=${{ env.RELEASE_VERSION }}
             
+      - name: Lowercase image name for trivy
+        id: string
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ env.IMAGE_PATH }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ steps.string.outputs.lowercase }}:${{ steps.meta.outputs.version }}'
+          format: 'table'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+


### PR DESCRIPTION
…he docker_build workflow

Use the [trivy github action](https://github.com/aquasecurity/trivy-action) to scan docker images immediately after they are created. Apparently, Sage's github package repo has different capitalization that the code repo, github.com/Sage-Bionetworks vs ghcr.io/sage-bionetworks. Trivy is sensitive to this difference, so add a [step to lowercase](https://github.com/marketplace/actions/change-string-case) the image name.

If a critical or high vulnerability is found, the docker image will still be built. The workflow logs will show a table of vulnerabilities.

Schematic: [FDS-952](https://sagebionetworks.jira.com/browse/FDS-952)

[FDS-952]: https://sagebionetworks.jira.com/browse/FDS-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ