### PR TITLE
Remove temp data model references from test_api

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -78,16 +78,13 @@ def test_manifest_json(helpers):
 
 @pytest.fixture(scope="class")
 def data_model_jsonld():
-    # data_model_jsonld ="https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld"
-    data_model_jsonld = "https://raw.githubusercontent.com/mialy-defelice/data_models/main/example.model.jsonld"
+    data_model_jsonld ="https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld"
     yield data_model_jsonld
 
 
 @pytest.fixture(scope="class")
 def benchmark_data_model_jsonld():
-    # benchmark_data_model_jsonld = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.single_rule.model.jsonld"
-    # Placeholder till the model is updated on develop
-    benchmark_data_model_jsonld = "https://raw.githubusercontent.com/mialy-defelice/data_models/main/example.single_rule.model.jsonld"
+    benchmark_data_model_jsonld = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.single_rule.model.jsonld"
     yield benchmark_data_model_jsonld
 
 
@@ -96,8 +93,7 @@ def get_MockComponent_attribute():
     Yield all of the mock conponent attributes one at a time
     TODO: pull in jsonld from fixture
     """
-    # schema_url = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.single_rule.model.jsonld"
-    schema_url = "https://raw.githubusercontent.com/mialy-defelice/data_models/main/example.single_rule.model.jsonld"
+    schema_url = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.single_rule.model.jsonld"
     data_model_parser = DataModelParser(path_to_data_model=schema_url)
     # Parse Model
     parsed_data_model = data_model_parser.parse_model()
@@ -109,7 +105,7 @@ def get_MockComponent_attribute():
     graph_data_model = data_model_grapher.graph
 
     dmge = DataModelGraphExplorer(graph_data_model)
-    # sg = SchemaGenerator("https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.single_rule.model.jsonld")
+
     attributes = dmge.get_node_dependencies("MockComponent")
     attributes.remove("Component")
 


### PR DESCRIPTION
This PR removes temporary data model references that were necessary during the Schema Refactor, but are no longer needed.

To test run `pytest tests_api.py`