### PR TITLE
Match None Manifest Validation Rule FDS-1766

### DIFF
--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -151,7 +151,7 @@ class GreatExpectationsHelpers(object):
             # "url": "expect_column_values_to_be_valid_urls",
             # "matchAtLeastOne": "expect_foreign_keys_in_column_a_to_exist_in_column_b",
             # "matchExactlyOne": "expect_foreign_keys_in_column_a_to_exist_in_column_b",
-            # "matchUnique": "expect_compound_columns_to_be_unique",
+            # "matchNone": "expect_compound_columns_to_be_unique",
         }
 
         # create blank expectation suite

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -151,6 +151,7 @@ class GreatExpectationsHelpers(object):
             # "url": "expect_column_values_to_be_valid_urls",
             # "matchAtLeastOne": "expect_foreign_keys_in_column_a_to_exist_in_column_b",
             # "matchExactlyOne": "expect_foreign_keys_in_column_a_to_exist_in_column_b",
+            # "matchUnique": "expect_compound_columns_to_be_unique",
         }
 
         # create blank expectation suite

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -4,7 +4,7 @@ import re
 from time import perf_counter
 
 # allows specifying explicit variable types
-from typing import Any, Dict, List, Optional, Text, Literal, Union, Tuple
+from typing import Any, Optional, Text, Literal, Union
 from urllib import error
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
@@ -39,7 +39,7 @@ class GenerateError:
         error_message: str,
         invalid_entry: str,
         dmge: DataModelGraphExplorer,
-    ) -> Tuple[list[list[str]], list[list[str]]]:
+    ) -> tuple[list[list[str]], list[list[str]]]:
         """
         Purpose: Process error messages generated from schema
         Input:
@@ -69,7 +69,7 @@ class GenerateError:
         invalid_entry: str,
         dmge: DataModelGraphExplorer,
         val_rule: str,
-    ) -> Tuple[list[list[str]], list[list[str]]]:
+    ) -> tuple[list[list[str]], list[list[str]]]:
         """
         Purpose:
             If an error is found in the string formatting, detect and record
@@ -113,7 +113,7 @@ class GenerateError:
         attribute_name: str,
         invalid_entry: str,
         dmge: DataModelGraphExplorer,
-    ) -> Tuple[list[list[str]], list[list[str]]]:
+    ) -> tuple[list[list[str]], list[list[str]]]:
         """
         Purpose:
             Generate an logging error as well as a stored error message, when
@@ -153,7 +153,7 @@ class GenerateError:
         attribute_name: str,
         invalid_entry: str,
         dmge: DataModelGraphExplorer,
-    ) -> Tuple[list[list[str]], list[list[str]]]:
+    ) -> tuple[list[list[str]], list[list[str]]]:
         """
         Purpose:
             Generate an logging error as well as a stored error message, when
@@ -194,7 +194,7 @@ class GenerateError:
         invalid_entry: str,
         dmge: DataModelGraphExplorer,
         val_rule: str,
-    ) -> Tuple[list[list[str]], list[list[str]]]:
+    ) -> tuple[list[list[str]], list[list[str]]]:
         """
         Purpose:
             Generate an logging error as well as a stored error message, when
@@ -258,11 +258,11 @@ class GenerateError:
         val_rule: str,
         attribute_name: str,
         dmge: DataModelGraphExplorer,
-        matching_manifests: list[str] = [],
+        matching_manifests: list[str] = None,
         manifest_id: Optional[list[str]] = None,
         invalid_entry: Optional[list[str]] = None,
         row_num: Optional[list[str]] = None,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Purpose:
             Generate an logging error as well as a stored error message, when
@@ -289,7 +289,7 @@ class GenerateError:
             )
 
         elif "matchExactly" in val_rule:
-            if matching_manifests != []:
+            if matching_manifests and matching_manifests != []:
                 error_message = f"All values from attribute {attribute_name} in the source manifest are present in {len(matching_manifests)} manifests instead of only 1."
                 error_message += (
                     f" Manifests {matching_manifests} match the values in the source attribute."
@@ -330,7 +330,7 @@ class GenerateError:
         dmge: DataModelGraphExplorer,
         row_num=None,
         invalid_entry=None,
-    ) -> Tuple[list[str], list[str]]:
+    ) -> tuple[list[str], list[str]]:
         """
         Purpose:
             Generate an logging error or warning as well as a stored error/warning message when validating the content of a manifest attribute.
@@ -468,7 +468,7 @@ class GenerateError:
         error_col: str,
         error_message: str,
         error_val: Union[str, list[str]],
-    ) -> Tuple[list[str], list[str]]:
+    ) -> tuple[list[str], list[str]]:
         """
         Purpose:
             Log and store error messages in a list for further storage.
@@ -524,9 +524,11 @@ class ValidateAttribute(object):
         - Add year validator
         - Add string length validator
     """
+    def __init__(self, dmge: DataModelGraphExplorer):
+        self.dmge=dmge
 
     def get_target_manifests(
-        target_component, project_scope: list, access_token: str = None
+        self, target_component, project_scope: list, access_token: str = None
     ):
         t_manifest_search = perf_counter()
         target_manifest_ids = []
@@ -566,8 +568,7 @@ class ValidateAttribute(object):
         self,
         val_rule: str,
         manifest_col: pd.core.series.Series,
-        dmge: DataModelGraphExplorer,
-    ) -> Tuple[list[list[str]], list[list[str]], pd.core.series.Series]:
+    ) -> tuple[list[list[str]], list[list[str]], pd.core.series.Series]:
         """
         Purpose:
             Determine if values for a particular attribute are comma separated.
@@ -606,7 +607,7 @@ class ValidateAttribute(object):
                         attribute_name=manifest_col.name,
                         list_error=list_error,
                         invalid_entry=manifest_col[i],
-                        dmge=dmge,
+                        dmge=self.dmge,
                         val_rule=val_rule,
                     )
                     if vr_errors:
@@ -623,8 +624,7 @@ class ValidateAttribute(object):
         self,
         val_rule: str,
         manifest_col: pd.core.series.Series,
-        dmge: DataModelGraphExplorer,
-    ) -> Tuple[list[list[str]], list[list[str]]]:
+    ) -> tuple[list[list[str]], list[list[str]]]:
         """
         Purpose:
             Check if values for a given manifest attribue conform to the reguar expression,
@@ -665,7 +665,7 @@ class ValidateAttribute(object):
         errors = []
         warnings = []
 
-        validation_rules = dmge.get_node_validation_rules(
+        validation_rules = self.dmge.get_node_validation_rules(
             node_display_name=manifest_col.name
         )
         if validation_rules and "::" in validation_rules[0]:
@@ -689,7 +689,7 @@ class ValidateAttribute(object):
                             module_to_call=reg_exp_rules[1],
                             attribute_name=manifest_col.name,
                             invalid_entry=manifest_col[i],
-                            dmge=dmge,
+                            dmge=self.dmge,
                         )
                         if vr_errors:
                             errors.append(vr_errors)
@@ -710,7 +710,7 @@ class ValidateAttribute(object):
                         module_to_call=reg_exp_rules[1],
                         attribute_name=manifest_col.name,
                         invalid_entry=manifest_col[i],
-                        dmge=dmge,
+                        dmge=self.dmge,
                     )
                     if vr_errors:
                         errors.append(vr_errors)
@@ -723,8 +723,7 @@ class ValidateAttribute(object):
         self,
         val_rule: str,
         manifest_col: pd.core.series.Series,
-        dmge: DataModelGraphExplorer,
-    ) -> Tuple[list[list[str]], list[list[str]]]:
+    ) -> tuple[list[list[str]], list[list[str]]]:
         """
         Purpose:
             Check if values for a given manifest attribue are the same type
@@ -734,7 +733,6 @@ class ValidateAttribute(object):
                 'float', 'int', 'num', 'str'
             - manifest_col: pd.core.series.Series, column for a given
                 attribute in the manifest
-            - dmge: DataModelGraphExplorer Object
         Returns:
             -This function will return errors when the user input value
             does not match schema specifications.
@@ -762,7 +760,7 @@ class ValidateAttribute(object):
                         row_num=str(i + 2),
                         attribute_name=manifest_col.name,
                         invalid_entry=str(manifest_col[i]),
-                        dmge=dmge,
+                        dmge=self.dmge,
                     )
                     if vr_errors:
                         errors.append(vr_errors)
@@ -776,7 +774,7 @@ class ValidateAttribute(object):
                         row_num=str(i + 2),
                         attribute_name=manifest_col.name,
                         invalid_entry=str(manifest_col[i]),
-                        dmge=dmge,
+                        dmge=self.dmge,
                     )
                     if vr_errors:
                         errors.append(vr_errors)
@@ -785,8 +783,8 @@ class ValidateAttribute(object):
         return errors, warnings
 
     def url_validation(
-        self, val_rule: str, manifest_col: str, dmge: DataModelGraphExplorer
-    ) -> Tuple[list[list[str]], list[list[str]]]:
+        self, val_rule: str, manifest_col: str,
+    ) -> tuple[list[list[str]], list[list[str]]]:
         """
         Purpose:
             Validate URL's submitted for a particular attribute in a manifest.
@@ -796,7 +794,6 @@ class ValidateAttribute(object):
             - val_rule: str, Validation rule
             - manifest_col: pd.core.series.Series, column for a given
                 attribute in the manifest
-            - dmge: DataModelGraphExplorer Object
         Output:
             This function will return errors when the user input value
             does not match schema specifications.
@@ -826,7 +823,7 @@ class ValidateAttribute(object):
                     attribute_name=manifest_col.name,
                     argument=url_args,
                     invalid_entry=manifest_col[i],
-                    dmge=dmge,
+                    dmge=self.dmge,
                     val_rule=val_rule,
                 )
                 if vr_errors:
@@ -854,7 +851,7 @@ class ValidateAttribute(object):
                         attribute_name=manifest_col.name,
                         argument=url_args,
                         invalid_entry=manifest_col[i],
-                        dmge=dmge,
+                        dmge=self.dmge,
                         val_rule=val_rule,
                     )
                     if vr_errors:
@@ -874,7 +871,7 @@ class ValidateAttribute(object):
                                 attribute_name=manifest_col.name,
                                 argument=arg,
                                 invalid_entry=manifest_col[i],
-                                dmge=dmge,
+                                dmge=self.dmge,
                                 val_rule=val_rule,
                             )
                             if vr_errors:
@@ -884,11 +881,11 @@ class ValidateAttribute(object):
         return errors, warnings
 
     def _parse_validation_log(
-        validation_log: Dict[str, pd.core.series.Series]
-    ) -> tuple([[], [], []]):
+        self, validation_log: dict[str, pd.core.series.Series]
+    ) -> tuple[[list[str], list[str], list[str]]]:
         """Parse validation log, so values can be used to raise warnings/errors
         Args:
-            validation_log, Dict[str, pd.core.series.Series]:
+            validation_log, dict[str, pd.core.series.Series]:
         Returns:
             invalid_rows, list: invalid rows recorded in the validation log
             invalid_entry, list: invalid values recorded in the validation log
@@ -911,8 +908,8 @@ class ValidateAttribute(object):
         return invalid_rows, invalid_entries, manifest_ids
 
     def _merge_format_invalid_rows_values(
-        series_1: pd.core.series.Series, series_2: pd.core.series.Series
-    ) -> tuple([[], []]):
+        self, series_1: pd.core.series.Series, series_2: pd.core.series.Series
+    ) -> tuple[[list[str], list[str]]]:
         """Merge two series to identify gather all invalid values, and parse out invalid rows and entries
         Args:
             series_1, pd.core.series.Series: first set of invalid values to extract
@@ -940,12 +937,13 @@ class ValidateAttribute(object):
         return invalid_rows, invalid_entry
 
     def _format_invalid_row_values(
-        invalid_values: Dict[str, pd.core.series.Series]
-    ) -> tuple([[], []]):
+        self,
+        invalid_values: dict[str, pd.core.series.Series]
+    ) -> tuple[[list[str], list[str]]]:
         """Parse invalid_values dictionary, to extract invalid_rows and invalid_entry to be used later
         to raise warnings or errors.
         Args:
-            invalid_values, Dict[str, pd.core.series.Series]:
+            invalid_values, dict[str, pd.core.series.Series]:
         Returns:
             invalid_rows, list: invalid rows recorded in invalid_values
             invalid_entry, list: invalid values recorded in invalid_values
@@ -959,18 +957,18 @@ class ValidateAttribute(object):
         return invalid_rows, invalid_entry
 
     def _gather_set_warnings_errors(
+        self,
         val_rule: str,
         source_attribute: str,
-        set_validation_store: list[{}, [], {}],
-        dmge: DataModelGraphExplorer,
-    ) -> tuple([[], []]):
+        set_validation_store: tuple[dict[str, pd.core.series.Series], list[str], dict[str, pd.core.series.Series]],
+    ) -> tuple[[list[str], list[str]]]:
         """Based on the cross manifest validation rule, and in set rule scope, pass variables to
         _get_cross_errors_warnings
             to log appropriate error or warning.
         Args:
             val_rule, str: Validation Rule
             source_attribute, str: Source manifest column name
-            set_validation_store, list[{},[],{}]: contains the missing_manifest_log, present_manifest_log,
+            set_validation_store, tuple[dict[str, pd.core.series.Series], list[string], dict[str, pd.core.series.Series]]: contains the missing_manifest_log, present_manifest_log,
                 and repeat_manifest_log
             dmge: DataModelGraphExplorer Object.
 
@@ -994,24 +992,23 @@ class ValidateAttribute(object):
                 invalid_rows,
                 invalid_entries,
                 manifest_ids,
-            ) = ValidateAttribute._parse_validation_log(
+            ) = self._parse_validation_log(
                 validation_log=missing_manifest_log
             )
-            errors, warnings = ValidateAttribute._get_cross_errors_warnings(
+            errors, warnings = self._get_cross_errors_warnings(
                 val_rule=val_rule,
                 row_num=invalid_rows,
                 attribute_name=source_attribute,
                 invalid_entry=invalid_entries,
                 manifest_id=manifest_ids,
-                dmge=dmge,
             )
 
         elif "matchExactlyOne" in val_rule and len(present_manifest_log) != 1:
-            errors, warnings = ValidateAttribute._get_cross_errors_warnings(
+            errors, warnings = self._get_cross_errors_warnings(
                 val_rule=val_rule,
                 attribute_name=source_attribute,
                 matching_manifests=present_manifest_log,
-                dmge=dmge,
+
             )
 
         elif "matchNone" in val_rule and repeat_manifest_log:
@@ -1019,34 +1016,32 @@ class ValidateAttribute(object):
                 invalid_rows,
                 invalid_entries,
                 manifest_ids,
-            ) = ValidateAttribute._parse_validation_log(
+            ) = self._parse_validation_log(
                 validation_log=repeat_manifest_log
             )
-            errors, warnings = ValidateAttribute._get_cross_errors_warnings(
+            errors, warnings = self._get_cross_errors_warnings(
                 val_rule=val_rule,
                 row_num=invalid_rows,
                 attribute_name=source_attribute,
                 invalid_entry=invalid_entries,
                 manifest_id=manifest_ids,
-                dmge=dmge,
             )
 
         return errors, warnings
 
     def _get_cross_errors_warnings(
+        self,
         val_rule: str,
         attribute_name: str,
-        dmge: DataModelGraphExplorer,
         row_num: Optional[list[str]] = None,
-        matching_manifests: Optional[list[str]] = [],
+        matching_manifests: Optional[list[str]] = None,
         manifest_id: Optional[list[str]] = None,
         invalid_entry: Optional[list[str]] = None,
-    ) -> tuple([[], []]):
+    ) -> tuple[[list[str], list[str]]]:
         """Helper to call GenerateError.generate_cross_warning in a consistent way, gather warnings and errors.
         Args:
             val_rule, str: Validation Rule
             attribute_name, str: source attribute name
-            dmge: DataModelGraphExplorer Object
             row_num, list: default=None, list of rows in the source manifest where invalid values were located
             matching_manifests, list: default=[], ist of manifests with all values in the target attribute present
             manifest_id, list: default=None, list of manifests where invalid values were located.
@@ -1066,7 +1061,7 @@ class ValidateAttribute(object):
             matching_manifests=matching_manifests,
             invalid_entry=invalid_entry,
             manifest_id=manifest_id,
-            dmge=dmge,
+            dmge=self.dmge,
         )
         if vr_errors:
             errors.append(vr_errors)
@@ -1075,17 +1070,16 @@ class ValidateAttribute(object):
         return errors, warnings
 
     def _gather_value_warnings_errors(
+        self,
         val_rule: str,
         source_attribute: str,
-        value_validation_store: list[{}, {}, {}],
-        dmge: DataModelGraphExplorer,
-    ) -> tuple([[], []]):
+        value_validation_store: tuple[dict[str, pd.core.series.Series], dict[str, pd.core.series.Series], dict[str, pd.core.series.Series]],
+    ) -> tuple[[list[str], list[str]]]:
         """For value rule scope, find invalid rows and entries, and generate appropriate errors and warnings
         Args:
             val_rule, str: Validation rule
             source_attribute, str: source manifest column name
-            value_validation_store, list[{},{},{}]: contains missing_values, duplicated_values, and repeat values
-            dmge, DataModelGraphExplorer Object
+            value_validation_store, tuple(dict[str, pd.core.series.Series], dict[str, pd.core.series.Series], dict[str, pd.core.series.Series]): contains missing_values, duplicated_values, and repeat values
         Returns:
             errors, list[str]: list of errors to raise, as appropriate, if values in current manifest do
             not pass relevant cross mannifest validation across the target manifest(s)
@@ -1101,7 +1095,7 @@ class ValidateAttribute(object):
 
         # Determine invalid rows and entries based on the rule type
         if "matchAtLeastOne" in val_rule and not missing_values.empty:
-            invalid_rows, invalid_entry = ValidateAttribute._format_invalid_row_values(
+            invalid_rows, invalid_entry = self._format_invalid_row_values(
                 missing_values
             )
 
@@ -1111,67 +1105,65 @@ class ValidateAttribute(object):
             (
                 invalid_rows,
                 invalid_entry,
-            ) = ValidateAttribute._merge_format_invalid_rows_values(
+            ) = self._merge_format_invalid_rows_values(
                 duplicated_values, missing_values
             )
 
         elif "matchNone" in val_rule and repeat_values.any():
-            invalid_rows, invalid_entry = ValidateAttribute._format_invalid_row_values(
+            invalid_rows, invalid_entry = self._format_invalid_row_values(
                 repeat_values
             )
 
         # If invalid rows/entries found, raise warning/error
         if invalid_rows and invalid_entry:
-            errors, warnings = ValidateAttribute._get_cross_errors_warnings(
+            errors, warnings = self._get_cross_errors_warnings(
                 val_rule=val_rule,
                 row_num=invalid_rows,
                 attribute_name=source_attribute,
                 invalid_entry=invalid_entry,
-                dmge=dmge,
             )
         return errors, warnings
 
     def _run_validation_across_targets_set(
+        self,
         val_rule: str,
-        column_names: Dict[str, str],
+        column_names: dict[str, str],
         manifest_col: pd.core.series.Series,
         target_attribute: str,
         target_column: pd.core.series.Series,
         target_manifest: pd.core.series.Series,
         target_manifest_id: str,
-        missing_manifest_log: Dict[str, pd.core.series.Series],
-        present_manifest_log: Dict[str, pd.core.series.Series],
-        repeat_manifest_log: Dict[str, pd.core.series.Series],
-    ) -> tuple(
-        [
-            Dict[str, pd.core.series.Series],
-            Dict[str, pd.core.series.Series],
-            Dict[str, pd.core.series.Series],
-        ],
-    ):
+        missing_manifest_log: dict[str, pd.core.series.Series],
+        present_manifest_log: dict[str, pd.core.series.Series],
+        repeat_manifest_log: dict[str, pd.core.series.Series],
+    ) -> tuple[
+            dict[str, pd.core.series.Series],
+            dict[str, pd.core.series.Series],
+            dict[str, pd.core.series.Series],
+    ]:
         """For set rule scope, go through the given target column and look
         Args:
             val_rule, str: Validation rule
-            column_names, Dict[str,str]: {stripped_col_name:original_column_name}
+            column_names, dict[str,str]: {stripped_col_name:original_column_name}
             target_column, pd.core.series.Series: Empty target_column to fill out in this function
             manifest_col, pd.core.series.Series: Source manifest column
             target_attribute, str: current target attribute
             target_column, pd.core.series.Series: Current target column
             target_manifest, pd.core.series.Series: Current target manifest
             target_manifest_id, str: Current target manifest Synapse ID
-            missing_manifest_log, Dict[str, pd.core.series.Series]:
+            missing_manifest_log, dict[str, pd.core.series.Series]:
                 Log of manifests with missing values, {synapse_id: index,missing value}, updated.
-            present_manifest_log, Dict[str, pd.core.series.Series]
+            present_manifest_log, dict[str, pd.core.series.Series]
                 Log of present manifests, {synapse_id: index,present value}, updated.
-            repeat_manifest_log, Dict[str, pd.core.series.Series]
+            repeat_manifest_log, dict[str, pd.core.series.Series]
                 Log of manifests with repeat values, {synapse_id: index,repeat value}, updated.
 
         Returns:
-            missing_manifest_log, Dict[str, pd.core.series.Series]:
+            missing_manifest_log, dict[str, pd.core.series.Series]:
                 Log of manifests with missing values, {synapse_id: index,missing value}, updated.
-            present_manifest_log, Dict[str, pd.core.series.Series]
+            present_manifest_log, dict[str, pd.core.series.Series]
                 Log of present manifests, {synapse_id: index,present value}, updated.
-            repeat_manifest_log, Dict[str, pd.core.series.Series]
+            repeat_manifest_log, dict[str, pd.core.series.Series]
                 Log of manifests with repeat values, {synapse_id: index,repeat value}, updated.
         """
         # If the manifest has the target attribute for the component do the cross validation
@@ -1202,14 +1194,15 @@ class ValidateAttribute(object):
         return missing_manifest_log, present_manifest_log, repeat_manifest_log
 
     def _gather_target_columns_value(
-        column_names: Dict[str, str],
+        self,
+        column_names: dict[str, str],
         target_attribute: str,
         concatenated_target_column: pd.core.series.Series,
         target_manifest: pd.core.series.Series,
     ) -> pd.core.series.Series:
         """
         Args:
-            column_names, Dict: {stripped_col_name:original_column_name}
+            column_names, dict: {stripped_col_name:original_column_name}
             target_attribute, str: current target attribute
             concatenated_target_column, pd.core.series.Series: target column in the process of being built, possibly
                 passed through this function multiple times based on the number of manifests
@@ -1241,9 +1234,10 @@ class ValidateAttribute(object):
         return concatenated_target_column
 
     def _run_validation_across_targets_value(
+        self,
         manifest_col: pd.core.series.Series,
         concatenated_target_column: pd.core.series.Series,
-    ) -> tuple([pd.core.series.Series, pd.core.series.Series, pd.core.series.Series]):
+    ) -> tuple[[pd.core.series.Series, pd.core.series.Series, pd.core.series.Series]]:
         """Get missing values, duplicated values and repeat values assesed comapring the source manifest to all
             the values in all target columns.
         Args:
@@ -1272,12 +1266,12 @@ class ValidateAttribute(object):
 
         return missing_values, duplicated_values, repeat_values
 
-    def _get_column_names(target_manifest: pd.core.series.Series) -> Dict[str, str]:
+    def _get_column_names(self, target_manifest: pd.core.series.Series) -> dict[str, str]:
         """Convert manifest column names into validation rule input format
         Args:
             target_manifest, pd.core.series.Series: Current target manifest
         Returns:
-            column_names, Dict[str,str]: {stripped_col_name:original_column_name}
+            column_names, dict[str,str]: {stripped_col_name:original_column_name}
         """
         column_names = {}
         for original_column_name in target_manifest.columns:
@@ -1285,7 +1279,7 @@ class ValidateAttribute(object):
             column_names[stripped_col_name] = original_column_name
         return column_names
 
-    def _get_rule_scope(val_rule: str) -> ScopeTypes:
+    def _get_rule_scope(self, val_rule: str) -> ScopeTypes:
         """Parse scope from validation rule
         Args:
             val_rule, str: Validation Rule
@@ -1296,13 +1290,14 @@ class ValidateAttribute(object):
         return scope
 
     def _run_validation_across_target_manifests(
+        self,
         project_scope: Optional[list[str]],
         rule_scope: ScopeTypes,
         access_token: str,
         val_rule: str,
         manifest_col: pd.core.series.Series,
         target_column: pd.core.series.Series,
-    ) -> tuple([float, List]):
+    ) -> tuple[[float, list]]:
         """Run cross manifest validation from a source manifest, across all relevant target manifests,
             based on scope. Output start time and validation outputs..
         Args:
@@ -1314,7 +1309,8 @@ class ValidateAttribute(object):
             target_column, pd.core.series.Series: Empty target_column to fill out in this function
         Returns:
             start_time, float: start time in fractional seconds
-            validation_store, Union[List[{}, [], {}], List[{},{},{}]]: validation outputs, exact types depend on scope,
+            validation_store, Union[tuple[dict[str, pd.core.series.Series], list[str], dict[str, pd.core.series.Series]], 
+            tuple[dict[str, pd.core.series.Series], dict[str, pd.core.series.Series], dict[str, pd.core.series.Series]]: validation outputs, exact types depend on scope,
         """
         # Initialize variables
         present_manifest_log = []
@@ -1333,7 +1329,7 @@ class ValidateAttribute(object):
             synStore,
             target_manifest_ids,
             target_dataset_ids,
-        ) = ValidateAttribute.get_target_manifests(
+        ) = self.get_target_manifests(
             target_component, project_scope, access_token
         )
 
@@ -1353,7 +1349,7 @@ class ValidateAttribute(object):
             target_manifest = pd.read_csv(entity.path)
 
             # Get manifest column names
-            column_names = ValidateAttribute._get_column_names(
+            column_names = self._get_column_names(
                 target_manifest=target_manifest
             )
 
@@ -1364,7 +1360,7 @@ class ValidateAttribute(object):
                     missing_manifest_log,
                     present_manifest_log,
                     repeat_manifest_log,
-                ) = ValidateAttribute._run_validation_across_targets_set(
+                ) = self._run_validation_across_targets_set(
                     val_rule=val_rule,
                     column_names=column_names,
                     manifest_col=manifest_col,
@@ -1380,7 +1376,7 @@ class ValidateAttribute(object):
             # the current manifest
             # column values against the concatenated target column
             if "value" in rule_scope:
-                target_column = ValidateAttribute._gather_target_columns_value(
+                target_column = self._gather_target_columns_value(
                     column_names=column_names,
                     target_attribute=target_attribute,
                     concatenated_target_column=target_column,
@@ -1389,11 +1385,11 @@ class ValidateAttribute(object):
 
         # Store outputs according to the scope for which they are used.
         if "set" in rule_scope:
-            validation_store = [
+            validation_store = (
                 missing_manifest_log,
                 present_manifest_log,
                 repeat_manifest_log,
-            ]
+            )
 
         elif "value" in rule_scope:
             # From the concatenated target column, for value scope, run validation
@@ -1401,11 +1397,11 @@ class ValidateAttribute(object):
                 missing_values,
                 duplicated_values,
                 repeat_values,
-            ) = ValidateAttribute._run_validation_across_targets_value(
+            ) = self._run_validation_across_targets_value(
                 manifest_col=manifest_col,
                 concatenated_target_column=target_column,
             )
-            validation_store = [missing_values, duplicated_values, repeat_values]
+            validation_store = (missing_values, duplicated_values, repeat_values)
 
         return (start_time, validation_store)
 
@@ -1414,9 +1410,8 @@ class ValidateAttribute(object):
         val_rule: str,
         manifest_col: pd.core.series.Series,
         project_scope: Optional[list[str]],
-        dmge: DataModelGraphExplorer,
         access_token: str,
-    ) -> List[List[str]]:
+    ) -> list[list[str]]:
         """
         Purpose:
             Do cross validation between the current manifest and all other manifests in a given asset view (limited
@@ -1429,20 +1424,20 @@ class ValidateAttribute(object):
             dmge: DataModelGraphExplorer Object
             access_token, str: Asset Store access token
         Returns:
-            errors, warnings, List[List[str]]: raise warnings and errors as appropriate if values in current manifest do
+            errors, warnings, list[list[str]]: raise warnings and errors as appropriate if values in current manifest do
             no pass relevant cross mannifest validation across the target manifest(s)
         """
         # Initialize target_column
         target_column = pd.Series(dtype=object)
 
         # Get the rule_scope from the validation rule
-        rule_scope = ValidateAttribute._get_rule_scope(val_rule)
+        rule_scope = self._get_rule_scope(val_rule)
 
         # Run validation from source to target manifest(s), gather outputs
         (
             start_time,
             validation_store,
-        ) = ValidateAttribute._run_validation_across_target_manifests(
+        ) = self._run_validation_across_target_manifests(
             project_scope=project_scope,
             rule_scope=rule_scope,
             access_token=access_token,
@@ -1453,18 +1448,16 @@ class ValidateAttribute(object):
 
         # Raise warnings/errors based on validation output and rule_scope.
         if "set" in rule_scope:
-            errors, warnings = ValidateAttribute._gather_set_warnings_errors(
+            errors, warnings = self._gather_set_warnings_errors(
                 val_rule=val_rule,
                 source_attribute=manifest_col.name,
                 set_validation_store=validation_store,
-                dmge=dmge,
             )
         elif "value" in rule_scope:
-            errors, warnings = ValidateAttribute._gather_value_warnings_errors(
+            errors, warnings = self._gather_value_warnings_errors(
                 val_rule=val_rule,
                 source_attribute=manifest_col.name,
                 value_validation_store=validation_store,
-                dmge=dmge,
             )
 
         logger.debug(f"cross manifest validation time {perf_counter()-start_time}")

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -524,8 +524,9 @@ class ValidateAttribute(object):
         - Add year validator
         - Add string length validator
     """
+
     def __init__(self, dmge: DataModelGraphExplorer):
-        self.dmge=dmge
+        self.dmge = dmge
 
     def get_target_manifests(
         self, target_component, project_scope: list, access_token: str = None
@@ -783,7 +784,9 @@ class ValidateAttribute(object):
         return errors, warnings
 
     def url_validation(
-        self, val_rule: str, manifest_col: str,
+        self,
+        val_rule: str,
+        manifest_col: str,
     ) -> tuple[list[list[str]], list[list[str]]]:
         """
         Purpose:
@@ -937,8 +940,7 @@ class ValidateAttribute(object):
         return invalid_rows, invalid_entry
 
     def _format_invalid_row_values(
-        self,
-        invalid_values: dict[str, pd.core.series.Series]
+        self, invalid_values: dict[str, pd.core.series.Series]
     ) -> tuple[[list[str], list[str]]]:
         """Parse invalid_values dictionary, to extract invalid_rows and invalid_entry to be used later
         to raise warnings or errors.
@@ -960,7 +962,11 @@ class ValidateAttribute(object):
         self,
         val_rule: str,
         source_attribute: str,
-        set_validation_store: tuple[dict[str, pd.core.series.Series], list[str], dict[str, pd.core.series.Series]],
+        set_validation_store: tuple[
+            dict[str, pd.core.series.Series],
+            list[str],
+            dict[str, pd.core.series.Series],
+        ],
     ) -> tuple[[list[str], list[str]]]:
         """Based on the cross manifest validation rule, and in set rule scope, pass variables to
         _get_cross_errors_warnings
@@ -992,9 +998,7 @@ class ValidateAttribute(object):
                 invalid_rows,
                 invalid_entries,
                 manifest_ids,
-            ) = self._parse_validation_log(
-                validation_log=missing_manifest_log
-            )
+            ) = self._parse_validation_log(validation_log=missing_manifest_log)
             errors, warnings = self._get_cross_errors_warnings(
                 val_rule=val_rule,
                 row_num=invalid_rows,
@@ -1008,7 +1012,6 @@ class ValidateAttribute(object):
                 val_rule=val_rule,
                 attribute_name=source_attribute,
                 matching_manifests=present_manifest_log,
-
             )
 
         elif "matchNone" in val_rule and repeat_manifest_log:
@@ -1016,9 +1019,7 @@ class ValidateAttribute(object):
                 invalid_rows,
                 invalid_entries,
                 manifest_ids,
-            ) = self._parse_validation_log(
-                validation_log=repeat_manifest_log
-            )
+            ) = self._parse_validation_log(validation_log=repeat_manifest_log)
             errors, warnings = self._get_cross_errors_warnings(
                 val_rule=val_rule,
                 row_num=invalid_rows,
@@ -1073,7 +1074,11 @@ class ValidateAttribute(object):
         self,
         val_rule: str,
         source_attribute: str,
-        value_validation_store: tuple[dict[str, pd.core.series.Series], dict[str, pd.core.series.Series], dict[str, pd.core.series.Series]],
+        value_validation_store: tuple[
+            dict[str, pd.core.series.Series],
+            dict[str, pd.core.series.Series],
+            dict[str, pd.core.series.Series],
+        ],
     ) -> tuple[[list[str], list[str]]]:
         """For value rule scope, find invalid rows and entries, and generate appropriate errors and warnings
         Args:
@@ -1110,9 +1115,7 @@ class ValidateAttribute(object):
             )
 
         elif "matchNone" in val_rule and repeat_values.any():
-            invalid_rows, invalid_entry = self._format_invalid_row_values(
-                repeat_values
-            )
+            invalid_rows, invalid_entry = self._format_invalid_row_values(repeat_values)
 
         # If invalid rows/entries found, raise warning/error
         if invalid_rows and invalid_entry:
@@ -1137,9 +1140,9 @@ class ValidateAttribute(object):
         present_manifest_log: dict[str, pd.core.series.Series],
         repeat_manifest_log: dict[str, pd.core.series.Series],
     ) -> tuple[
-            dict[str, pd.core.series.Series],
-            dict[str, pd.core.series.Series],
-            dict[str, pd.core.series.Series],
+        dict[str, pd.core.series.Series],
+        dict[str, pd.core.series.Series],
+        dict[str, pd.core.series.Series],
     ]:
         """For set rule scope, go through the given target column and look
         Args:
@@ -1266,7 +1269,9 @@ class ValidateAttribute(object):
 
         return missing_values, duplicated_values, repeat_values
 
-    def _get_column_names(self, target_manifest: pd.core.series.Series) -> dict[str, str]:
+    def _get_column_names(
+        self, target_manifest: pd.core.series.Series
+    ) -> dict[str, str]:
         """Convert manifest column names into validation rule input format
         Args:
             target_manifest, pd.core.series.Series: Current target manifest
@@ -1309,7 +1314,7 @@ class ValidateAttribute(object):
             target_column, pd.core.series.Series: Empty target_column to fill out in this function
         Returns:
             start_time, float: start time in fractional seconds
-            validation_store, Union[tuple[dict[str, pd.core.series.Series], list[str], dict[str, pd.core.series.Series]], 
+            validation_store, Union[tuple[dict[str, pd.core.series.Series], list[str], dict[str, pd.core.series.Series]],
             tuple[dict[str, pd.core.series.Series], dict[str, pd.core.series.Series], dict[str, pd.core.series.Series]]: validation outputs, exact types depend on scope,
         """
         # Initialize variables
@@ -1329,9 +1334,7 @@ class ValidateAttribute(object):
             synStore,
             target_manifest_ids,
             target_dataset_ids,
-        ) = self.get_target_manifests(
-            target_component, project_scope, access_token
-        )
+        ) = self.get_target_manifests(target_component, project_scope, access_token)
 
         # Start timer
         start_time = perf_counter()
@@ -1349,9 +1352,7 @@ class ValidateAttribute(object):
             target_manifest = pd.read_csv(entity.path)
 
             # Get manifest column names
-            column_names = self._get_column_names(
-                target_manifest=target_manifest
-            )
+            column_names = self._get_column_names(target_manifest=target_manifest)
 
             # Read each target manifest and run validation of current manifest column (set) against each
             # manifest individually, gather results

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -421,6 +421,8 @@ class GenerateError:
             elif val_rule.__contains__("value"):
                 cross_error_str = f"Value(s) {invalid_entry} from row(s) {row_num} of the attribute {attribute_name} in the source manifest are not present in only one other manifest. "
 
+        elif val_rule.__contains__("matchUnique"):
+            breakpoint()
         logLevel(cross_error_str)
         error_row = row_num  # index row of the manifest where the error presented.
         error_col = attribute_name  # Attribute name
@@ -618,7 +620,6 @@ class ValidateAttribute(object):
                 ):
                     target_manifest_IDs.append(target_dataset[1][0])
                     target_dataset_IDs.append(target_dataset[0][0])
-
         logger.debug(
             f"Cross manifest gathering elapsed time {perf_counter()-t_manifest_search}"
         )
@@ -971,6 +972,7 @@ class ValidateAttribute(object):
         missing_values = {}
         missing_manifest_log = {}
         present_manifest_log = []
+        total_target_manifest_entries = 0
         target_column = pd.Series(dtype=object)
         # parse sources and targets
         source_attribute = manifest_col.name
@@ -1010,6 +1012,8 @@ class ValidateAttribute(object):
                     # Do the validation on both columns
                     missing_values = manifest_col[~manifest_col.isin(target_column)]
 
+                    # Count the number of entries
+                    total_target_manifest_entries += len(target_column)
                     if missing_values.empty:
                         present_manifest_log.append(target_manifest_ID)
                     else:
@@ -1081,6 +1085,8 @@ class ValidateAttribute(object):
                     errors.append(vr_errors)
                 if vr_warnings:
                     warnings.append(vr_warnings)
+            elif val_rule.__contains__("matchUnique") and duplicated_values.any():
+                breakpoint()
 
         # generate warnings if necessary
         elif scope.__contains__("set"):
@@ -1123,6 +1129,11 @@ class ValidateAttribute(object):
                     errors.append(vr_errors)
                 if vr_warnings:
                     warnings.append(vr_warnings)
+            elif val_rule.__contains__("matchUnique"):
+                for mml_values in missing_manifest_log.values():
+                    total_values = len(mml_values)
+                if len(total_target_manifest_entries) != total_values:
+                    breakpoint()
 
         logger.debug(
             f"cross manifest validation time {perf_counter()-t_cross_manifest}"

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -365,10 +365,10 @@ class GenerateError:
         val_rule: str,
         attribute_name: str,
         dmge: DataModelGraphExplorer,
-        matching_manifests: list = [],
-        manifest_id: list = None,
-        invalid_entry: list = None,
-        row_num: list = None,
+        matching_manifests: list[str] = [],
+        manifest_id: Optional[list[str]] = None,
+        invalid_entry: Optional[list[str]] = None,
+        row_num: Optional[list[str]] = None,
     ) -> List[str]:
         """
         Purpose:
@@ -428,8 +428,10 @@ class GenerateError:
 
         elif "matchNone" in val_rule:
             cross_error_str = f(
-                "Value(s) {invalid_entry} from row(s) {row_num} for the attribute {attribute_name} "
-                f"in the source manifest are not unique."
+                (
+                    f"Value(s) {invalid_entry} from row(s) {row_num} for the attribute {attribute_name} "
+                    f"in the source manifest are not unique."
+                )
             )
             cross_error_str += (
                 f" Manifest(s) {manifest_id} contain duplicate values."
@@ -1020,7 +1022,8 @@ class ValidateAttribute(object):
     def _format_invalid_row_values(
         invalid_values: Dict[str, pd.core.series.Series]
     ) -> tuple([[], []]):
-        """Parse invalid_values dictionary, to extract invalid_rows and invalid_entry to be used later to raise warnings or errors.
+        """Parse invalid_values dictionary, to extract invalid_rows and invalid_entry to be used later
+        to raise warnings or errors.
         Args:
             invalid_values, Dict[str, pd.core.series.Series]:
         Returns:
@@ -1041,12 +1044,14 @@ class ValidateAttribute(object):
         set_validation_store: list[{}, [], {}],
         dmge: DataModelGraphExplorer,
     ) -> tuple([[], []]):
-        """Based on the cross manifest validation rule, and in set rule scope, pass variables to _get_cross_errors_warnings
+        """Based on the cross manifest validation rule, and in set rule scope, pass variables to
+        _get_cross_errors_warnings
             to log appropriate error or warning.
         Args:
             val_rule, str: Validation Rule
             source_attribute, str: Source manifest column name
-            set_validation_store, list[{},[],{}]: contains the missing_manifest_log, present_manifest_log, and repeat_manifest_log
+            set_validation_store, list[{},[],{}]: contains the missing_manifest_log, present_manifest_log,
+                and repeat_manifest_log
             dmge: DataModelGraphExplorer Object.
 
         Returns:
@@ -1123,7 +1128,7 @@ class ValidateAttribute(object):
             attribute_name, str: source attribute name
             dmge: DataModelGraphExplorer Object
             row_num, list: default=None, list of rows in the source manifest where invalid values were located
-            matching_manifests, list: default=[],
+            matching_manifests, list: default=[], ist of manifests with all values in the target attribute present
             manifest_id, list: default=None, list of manifests where invalid values were located.
             invalid_entry, list: default=None, list of entries in the source manifest where invalid values were located.
         Returns:
@@ -1255,7 +1260,8 @@ class ValidateAttribute(object):
 
             # Do the validation on both columns
             if "matchNone" in val_rule:
-                # Look for repeats between the source manifest and target_column, if there are repeats log the repeat value and manifest
+                # Look for repeats between the source manifest and target_column, if there are
+                # repeats log the repeat value and manifest
                 repeat_values = manifest_col[manifest_col.isin(target_column)]
 
                 if repeat_values.any():
@@ -1265,17 +1271,19 @@ class ValidateAttribute(object):
                 missing_values = manifest_col[~manifest_col.isin(target_column)]
 
                 if missing_values.empty:
-                    # If there are no missing values in the target column, log this manifest as one where all items are present
+                    # If there are no missing values in the target column, log this manifest as
+                    # one where all items are present
                     present_manifest_log.append(target_manifest_id)
                 else:
-                    # If there are missing values in the target manifest, log the manifest and the missing values.
+                    # If there are missing values in the target manifest, log the manifest
+                    # and the missing values.
                     missing_manifest_log[target_manifest_id] = missing_values
 
         return missing_manifest_log, present_manifest_log, repeat_manifest_log
 
     def _gather_target_columns_value(
-        column_names,
-        target_attribute,
+        column_names: Dict[str, str],
+        target_attribute: str,
         concatenated_target_column: pd.core.series.Series,
         target_manifest: pd.core.series.Series,
     ) -> pd.core.series.Series:
@@ -1448,7 +1456,8 @@ class ValidateAttribute(object):
                     present_manifest_log=present_manifest_log,
                     repeat_manifest_log=repeat_manifest_log,
                 )
-            # Concatenate target manifest columns, in a subsequent step will run cross manifest validation from the current manifest
+            # Concatenate target manifest columns, in a subsequent step will run cross manifest validation from
+            # the current manifest
             # column values against the concatenated target column
             if "value" in rule_scope:
                 target_column = ValidateAttribute._gather_target_columns_value(

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -4,7 +4,7 @@ import re
 from time import perf_counter
 
 # allows specifying explicit variable types
-from typing import Any, Dict, List, Optional, Text, Literal, Union
+from typing import Any, Dict, List, Optional, Text, Literal, Union, Tuple
 from urllib import error
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
@@ -281,8 +281,8 @@ class GenerateError:
         """
 
         if "matchAtLeast" in val_rule:
-            cross_error_str = f"Value(s) {invalid_entry} from row(s) {row_num} of the attribute {attribute_name} in the source manifest are missing."
-            cross_error_str += (
+            error_message = f"Value(s) {invalid_entry} from row(s) {row_num} of the attribute {attribute_name} in the source manifest are missing."
+            error_message += (
                 f" Manifest(s) {manifest_id} are missing the value(s)."
                 if manifest_id
                 else ""
@@ -298,28 +298,20 @@ class GenerateError:
                 )
 
             elif "set" in val_rule:
-                cross_error_str = f"No matches for the values from attribute {attribute_name} in the source manifest are present in any other manifests instead of being present in exactly 1. "
+                error_message = f"No matches for the values from attribute {attribute_name} in the source manifest are present in any other manifests instead of being present in exactly 1. "
             elif "value" in val_rule:
-                cross_error_str = f"Value(s) {invalid_entry} from row(s) {row_num} of the attribute {attribute_name} in the source manifest are not present in only one other manifest. "
+                error_message = f"Value(s) {invalid_entry} from row(s) {row_num} of the attribute {attribute_name} in the source manifest are not present in only one other manifest. "
 
         elif "matchNone" in val_rule:
-            cross_error_str = f(
-                (
+            error_message = (
                     f"Value(s) {invalid_entry} from row(s) {row_num} for the attribute {attribute_name} "
                     f"in the source manifest are not unique."
-                )
             )
-            cross_error_str += (
+            error_message += (
                 f" Manifest(s) {manifest_id} contain duplicate values."
                 if manifest_id
                 else ""
             )
-
-        logLevel(cross_error_str)
-        error_row = row_num  # index row of the manifest where the error presented.
-        error_col = attribute_name  # Attribute name
-        error_message = cross_error_str
-        error_val = invalid_entry  # Value from source manifest missing from targets
 
         error_list, warning_list = GenerateError.raise_and_store_message(
             dmge=dmge,
@@ -1010,7 +1002,7 @@ class ValidateAttribute(object):
                 row_num=invalid_rows,
                 attribute_name=source_attribute,
                 invalid_entry=invalid_entries,
-                manifest_ID=manifest_ids,
+                manifest_id=manifest_ids,
                 dmge=dmge,
             )
 

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -1376,9 +1376,6 @@ class ValidateAttribute(object):
             )
             validation_store = [missing_values, duplicated_values, repeat_values]
 
-        
-        
-
         return (
             t_cross_manifest,
             validation_store

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -304,8 +304,8 @@ class GenerateError:
 
         elif "matchNone" in val_rule:
             error_message = (
-                    f"Value(s) {invalid_entry} from row(s) {row_num} for the attribute {attribute_name} "
-                    f"in the source manifest are not unique."
+                f"Value(s) {invalid_entry} from row(s) {row_num} for the attribute {attribute_name} "
+                f"in the source manifest are not unique."
             )
             error_message += (
                 f" Manifest(s) {manifest_id} contain duplicate values."

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -616,6 +616,7 @@ class ValidateAttribute(object):
 
         # Get list of all projects user has access to
         projects = synStore.getStorageProjects(project_scope=project_scope)
+
         for project in projects:
             # get all manifests associated with datasets in the projects
             target_datasets = synStore.getProjectManifests(projectId=project[0])
@@ -1006,7 +1007,8 @@ class ValidateAttribute(object):
         invalid_entry = iterable_to_str_list(invalid_values.squeeze())
         return invalid_rows, invalid_entry
 
-    def _format_invalid_row_values(invalid_values):
+    def _format_invalid_row_values(invalid_values:Dict[str, pd.core.series.Series])->tuple([[], []]
+        ):
         """
         Args:
             invalid_values, Dict[str, pd.core.series.Series]:
@@ -1173,9 +1175,9 @@ class ValidateAttribute(object):
                 duplicated_values, missing_values
             )
 
-        elif "matchNone" in val_rule and duplicated_values.any():
-            invalid_rows, invalid_entry = ValidateAttribute._format_invalid_row_values(duplicated_values)
-        
+        elif "matchNone" in val_rule and repeat_values.any():
+            invalid_rows, invalid_entry = ValidateAttribute._format_invalid_row_values(repeat_values)
+
         # If invalid rows/entries found, raise warning/error
         if invalid_rows and invalid_entry:
             errors, warnings = ValidateAttribute._get_cross_errors_warnings(
@@ -1185,7 +1187,6 @@ class ValidateAttribute(object):
                 invalid_entry=invalid_entry,
                 dmge=dmge,
             )
-
         return errors, warnings
 
     def _run_validation_across_targets_set(
@@ -1423,7 +1424,7 @@ class ValidateAttribute(object):
                     concatenated_target_column=target_column,
                     target_manifest=target_manifest,
                 )
-        
+
         # Store outputs according to the scope for which they are used.
         if "set" in rule_scope:
             validation_store = [

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -971,6 +971,7 @@ class ValidateAttribute(object):
         warnings = []
         missing_values = {}
         missing_manifest_log = {}
+        repeat_manifest_log = {}
         present_manifest_log = []
         total_target_manifest_entries = 0
         target_column = pd.Series(dtype=object)
@@ -1011,6 +1012,11 @@ class ValidateAttribute(object):
 
                     # Do the validation on both columns
                     missing_values = manifest_col[~manifest_col.isin(target_column)]
+
+                    repeat_values = manifest_col[~manifest_col.isin(target_column)]
+
+                    if repeat_values:
+                        repeat_manifest_log[target_manifest_ID] = repeat_values
 
                     # Count the number of entries
                     total_target_manifest_entries += len(target_column)
@@ -1130,9 +1136,7 @@ class ValidateAttribute(object):
                 if vr_warnings:
                     warnings.append(vr_warnings)
             elif val_rule.__contains__("matchUnique"):
-                for mml_values in missing_manifest_log.values():
-                    total_values = len(mml_values)
-                if len(total_target_manifest_entries) != total_values:
+                if repeat_manifest_log:
                     breakpoint()
 
         logger.debug(

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -1009,7 +1009,7 @@ class ValidateAttribute(object):
 
     def _format_invalid_row_values(invalid_values:Dict[str, pd.core.series.Series])->tuple([[], []]
         ):
-        """
+        """ Parse invalid_values dictionary, to extract invalid_rows and invalid_entry to be used later to raise warnings or errors.
         Args:
             invalid_values, Dict[str, pd.core.series.Series]:
         Returns:
@@ -1031,7 +1031,7 @@ class ValidateAttribute(object):
         set_validation_store: list,
         dmge: DataModelGraphExplorer,
     ) -> tuple([[], []]):
-        """
+        """ Based on the cross manifest validation rule, and in set rule scope, pass variables to _get_cross_errors_warnings to log appropriate error or warning.
         Args:
             val_rule, str: Validation Rule
             source_attribute, str: Source manifest column name
@@ -1106,7 +1106,7 @@ class ValidateAttribute(object):
         manifest_ID: list = None,
         invalid_entry: list = None,
     ) -> tuple([[], []]):
-        """
+        """Helper to call GenerateError.generate_cross_warning in a consistent way, gather warnings and errors.
         Args:
             val_rule, str: Validation Rule
             attribute_name, str: source attribute name
@@ -1145,7 +1145,7 @@ class ValidateAttribute(object):
         value_validation_store: list,
         dmge: DataModelGraphExplorer,
     ) -> tuple([[], []]):
-        """
+        """ For value rule scope, find invalid rows and entries, and generate appropriate errors and warnings
         Args:
             val_rule, str: Validation rule
             source_attribute, str: source manifest column name
@@ -1204,7 +1204,7 @@ class ValidateAttribute(object):
         Dict[str, pd.core.series.Series],
         Dict[str, pd.core.series.Series]],
         ):
-        """
+        """ For set rule scope, go through the given target column and look 
         Args:
             val_rule, str: Validation rule
             target_column, pd.core.series.Series: Empty target_column to fill out in this function
@@ -1234,16 +1234,20 @@ class ValidateAttribute(object):
 
             # Do the validation on both columns
             if "matchNone" in val_rule:
+                # Look for repeats between the source manifest and target_column, if there are repeats log the repeat value and manifest
                 repeat_values = manifest_col[manifest_col.isin(target_column)]
 
                 if repeat_values.any():
                     repeat_manifest_log[target_manifest_ID] = repeat_values
             else:
+                # Determine elements in manifest column that are missing from the target column
                 missing_values = manifest_col[~manifest_col.isin(target_column)]
 
                 if missing_values.empty:
+                    # If there are no missing values in the target column, log this manifest as one where all items are present
                     present_manifest_log.append(target_manifest_ID)
                 else:
+                    # If there are missing values in the target manifest, log the manifest and the missing values.
                     missing_manifest_log[target_manifest_ID] = missing_values
 
         return missing_manifest_log, present_manifest_log, repeat_manifest_log
@@ -1434,7 +1438,7 @@ class ValidateAttribute(object):
             ]
 
         elif "value" in rule_scope:
-            # From the concatedated target column, for value scope, run validation
+            # From the concatenated target column, for value scope, run validation
             (
                 missing_values,
                 duplicated_values,
@@ -1460,7 +1464,7 @@ class ValidateAttribute(object):
     ) -> List[List[str]]:
         """
         Purpose:
-            Do cross validation between the current manifest and all other manifests a user has access to on Synapse.
+            Do cross validation between the current manifest and all other manifests in a given asset view (limited by project scope, if provided).
         Args:
             val_rule, str: Validation rule
             manifest_col, pd.core.series.Series: column for a given

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -34,7 +34,8 @@ from synapseclient.core.exceptions import SynapseNoCredentialsError
 
 logger = logging.getLogger(__name__)
 
-ScopeTypes = Literal['set', 'value']
+ScopeTypes = Literal["set", "value"]
+
 
 class GenerateError:
     def generate_schema_error(
@@ -955,8 +956,8 @@ class ValidateAttribute(object):
                                 warnings.append(vr_warnings)
         return errors, warnings
 
-    def _parse_validation_log(validation_log: Dict) -> tuple([[],[],[]]):
-        """ Parse validation log, so values can be used to raise warnings/errors
+    def _parse_validation_log(validation_log: Dict) -> tuple([[], [], []]):
+        """Parse validation log, so values can be used to raise warnings/errors
         Args:
             validation_log, Dict[str, pd.core.series.Series]:
         Returns:
@@ -1007,9 +1008,10 @@ class ValidateAttribute(object):
         invalid_entry = iterable_to_str_list(invalid_values.squeeze())
         return invalid_rows, invalid_entry
 
-    def _format_invalid_row_values(invalid_values:Dict[str, pd.core.series.Series])->tuple([[], []]
-        ):
-        """ Parse invalid_values dictionary, to extract invalid_rows and invalid_entry to be used later to raise warnings or errors.
+    def _format_invalid_row_values(
+        invalid_values: Dict[str, pd.core.series.Series]
+    ) -> tuple([[], []]):
+        """Parse invalid_values dictionary, to extract invalid_rows and invalid_entry to be used later to raise warnings or errors.
         Args:
             invalid_values, Dict[str, pd.core.series.Series]:
         Returns:
@@ -1024,14 +1026,13 @@ class ValidateAttribute(object):
         invalid_entry = iterable_to_str_list(invalid_values)
         return invalid_rows, invalid_entry
 
-
     def _gather_set_warnings_errors(
         val_rule: str,
         source_attribute: str,
         set_validation_store: list,
         dmge: DataModelGraphExplorer,
     ) -> tuple([[], []]):
-        """ Based on the cross manifest validation rule, and in set rule scope, pass variables to _get_cross_errors_warnings to log appropriate error or warning.
+        """Based on the cross manifest validation rule, and in set rule scope, pass variables to _get_cross_errors_warnings to log appropriate error or warning.
         Args:
             val_rule, str: Validation Rule
             source_attribute, str: Source manifest column name
@@ -1138,14 +1139,13 @@ class ValidateAttribute(object):
             warnings.append(vr_warnings)
         return errors, warnings
 
-    
     def _gather_value_warnings_errors(
         val_rule: str,
         source_attribute: str,
         value_validation_store: list,
         dmge: DataModelGraphExplorer,
     ) -> tuple([[], []]):
-        """ For value rule scope, find invalid rows and entries, and generate appropriate errors and warnings
+        """For value rule scope, find invalid rows and entries, and generate appropriate errors and warnings
         Args:
             val_rule, str: Validation rule
             source_attribute, str: source manifest column name
@@ -1166,17 +1166,24 @@ class ValidateAttribute(object):
 
         # Determine invalid rows and entries based on the rule type
         if "matchAtLeastOne" in val_rule and not missing_values.empty:
-            invalid_rows, invalid_entry = ValidateAttribute._format_invalid_row_values(missing_values)
+            invalid_rows, invalid_entry = ValidateAttribute._format_invalid_row_values(
+                missing_values
+            )
 
         elif "matchExactlyOne" in val_rule and (
             duplicated_values.any() or missing_values.any()
         ):
-            invalid_rows, invalid_entry = ValidateAttribute._merge_format_invalid_rows_values(
+            (
+                invalid_rows,
+                invalid_entry,
+            ) = ValidateAttribute._merge_format_invalid_rows_values(
                 duplicated_values, missing_values
             )
 
         elif "matchNone" in val_rule and repeat_values.any():
-            invalid_rows, invalid_entry = ValidateAttribute._format_invalid_row_values(repeat_values)
+            invalid_rows, invalid_entry = ValidateAttribute._format_invalid_row_values(
+                repeat_values
+            )
 
         # If invalid rows/entries found, raise warning/error
         if invalid_rows and invalid_entry:
@@ -1200,11 +1207,14 @@ class ValidateAttribute(object):
         missing_manifest_log: dict,
         present_manifest_log: dict,
         repeat_manifest_log: dict,
-    ) -> tuple([Dict[str, pd.core.series.Series],
-        Dict[str, pd.core.series.Series],
-        Dict[str, pd.core.series.Series]],
-        ):
-        """ For set rule scope, go through the given target column and look 
+    ) -> tuple(
+        [
+            Dict[str, pd.core.series.Series],
+            Dict[str, pd.core.series.Series],
+            Dict[str, pd.core.series.Series],
+        ],
+    ):
+        """For set rule scope, go through the given target column and look
         Args:
             val_rule, str: Validation rule
             target_column, pd.core.series.Series: Empty target_column to fill out in this function
@@ -1293,8 +1303,8 @@ class ValidateAttribute(object):
     def _run_validation_across_targets_value(
         manifest_col: pd.core.series.Series,
         concatenated_target_column: pd.core.series.Series,
-    ) -> tuple([pd.core.series.Series,pd.core.series.Series,pd.core.series.Series]):
-        """ Get missing values, duplicated values and repeat values assesed comapring the source manifest to all the values in all target columns.
+    ) -> tuple([pd.core.series.Series, pd.core.series.Series, pd.core.series.Series]):
+        """Get missing values, duplicated values and repeat values assesed comapring the source manifest to all the values in all target columns.
         Args:
             manifest_col, pd.core.series.Series: Current source manifest column
             concatenated_target_column, pd.core.series.Series: All target columns concatenated into a single column
@@ -1305,7 +1315,7 @@ class ValidateAttribute(object):
         """
         # Find values that are present in the source manifest, but not present in the target manifest
         missing_values = manifest_col[~manifest_col.isin(concatenated_target_column)]
-        
+
         # Find values that duplicated in the concatenated target column, and also present in the source manifest column
         duplicated_values = manifest_col[
             manifest_col.isin(
@@ -1331,8 +1341,8 @@ class ValidateAttribute(object):
             column_names[stripped_col_name] = original_column_name
         return column_names
 
-    def _get_rule_scope(val_rule:str) -> ScopeTypes:
-        """ Parse scope from validation rule
+    def _get_rule_scope(val_rule: str) -> ScopeTypes:
+        """Parse scope from validation rule
         Args:
             val_rule, str: Validation Rule
         Returns:
@@ -1349,7 +1359,7 @@ class ValidateAttribute(object):
         manifest_col: pd.core.series.Series,
         target_column: pd.core.series.Series,
     ) -> tuple([float, List]):
-        """ Run cross manifest validation from a source manifest, across all relevant target manifests, based on scope. Output start time and validation outputs..
+        """Run cross manifest validation from a source manifest, across all relevant target manifests, based on scope. Output start time and validation outputs..
         Args:
             project_scope, Optional[list]: Projects to limit the scope of cross manifest validation to.
             rule_scope, ScopeTypes: The scope of the rule, taken from validation rule
@@ -1358,8 +1368,8 @@ class ValidateAttribute(object):
             manifest_col, pd.core.series.Series: Source manifest column for a given source component
             target_column, pd.core.series.Series: Empty target_column to fill out in this function
         Returns:
-            start_time, float: start time in fractional seconds 
-            validation_store, Union[List[{}, [], {}], List[{},{},{}]]: validation outputs, exact types depend on scope, 
+            start_time, float: start time in fractional seconds
+            validation_store, Union[List[{}, [], {}], List[{},{},{}]]: validation outputs, exact types depend on scope,
         """
         # Initialize variables
         present_manifest_log = []
@@ -1394,7 +1404,7 @@ class ValidateAttribute(object):
             entity = synStore.getDatasetManifest(
                 datasetId=target_dataset_ID, downloadFile=True
             )
-            # Load manifest 
+            # Load manifest
             target_manifest = pd.read_csv(entity.path)
 
             # Get manifest column names
@@ -1449,10 +1459,7 @@ class ValidateAttribute(object):
             )
             validation_store = [missing_values, duplicated_values, repeat_values]
 
-        return (
-            start_time,
-            validation_store
-        )
+        return (start_time, validation_store)
 
     def cross_validation(
         self,
@@ -1511,8 +1518,6 @@ class ValidateAttribute(object):
                 dmge=dmge,
             )
 
-        logger.debug(
-            f"cross manifest validation time {perf_counter()-start_time}"
-        )
+        logger.debug(f"cross manifest validation time {perf_counter()-start_time}")
 
         return errors, warnings

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -365,10 +365,10 @@ class GenerateError:
         val_rule: str,
         attribute_name: str,
         dmge: DataModelGraphExplorer,
-        matching_manifests:list=[],
-        manifest_id:list=None,
-        invalid_entry:list=None,
-        row_num:list=None,
+        matching_manifests: list = [],
+        manifest_id: list = None,
+        invalid_entry: list = None,
+        row_num: list = None,
     ) -> List[str]:
         """
         Purpose:
@@ -380,7 +380,7 @@ class GenerateError:
             dmge: DataModelGraphExplorer object
             matching_manifests: list of manifests with all values in the target attribute present
             manifest_id: list, synID of the target manifest missing the source value
-            
+
             invalid_entry: list, value present in source manifest that is missing in the target
             row_num: list, row in source manifest with value missing in target manifests
         Returns:
@@ -427,8 +427,10 @@ class GenerateError:
                 cross_error_str = f"Value(s) {invalid_entry} from row(s) {row_num} of the attribute {attribute_name} in the source manifest are not present in only one other manifest. "
 
         elif "matchNone" in val_rule:
-            cross_error_str = f"Value(s) {invalid_entry} from row(s) {row_num} for the attribute {attribute_name} "
+            cross_error_str = f(
+                "Value(s) {invalid_entry} from row(s) {row_num} for the attribute {attribute_name} "
                 f"in the source manifest are not unique."
+            )
             cross_error_str += (
                 f" Manifest(s) {manifest_id} contain duplicate values."
                 if manifest_id
@@ -959,7 +961,9 @@ class ValidateAttribute(object):
                                 warnings.append(vr_warnings)
         return errors, warnings
 
-    def _parse_validation_log(validation_log: Dict[str, pd.core.series.Series]) -> tuple([[], [], []]):
+    def _parse_validation_log(
+        validation_log: Dict[str, pd.core.series.Series]
+    ) -> tuple([[], [], []]):
         """Parse validation log, so values can be used to raise warnings/errors
         Args:
             validation_log, Dict[str, pd.core.series.Series]:
@@ -984,7 +988,9 @@ class ValidateAttribute(object):
 
         return invalid_rows, invalid_entries, manifest_ids
 
-    def _merge_format_invalid_rows_values(series_1:pd.core.series.Series, series_2:pd.core.series.Series) -> tuple([[], []]):
+    def _merge_format_invalid_rows_values(
+        series_1: pd.core.series.Series, series_2: pd.core.series.Series
+    ) -> tuple([[], []]):
         """Merge two series to identify gather all invalid values, and parse out invalid rows and entries
         Args:
             series_1, pd.core.series.Series: first set of invalid values to extract
@@ -1032,7 +1038,7 @@ class ValidateAttribute(object):
     def _gather_set_warnings_errors(
         val_rule: str,
         source_attribute: str,
-        set_validation_store: list[{},[],{}],
+        set_validation_store: list[{}, [], {}],
         dmge: DataModelGraphExplorer,
     ) -> tuple([[], []]):
         """Based on the cross manifest validation rule, and in set rule scope, pass variables to _get_cross_errors_warnings
@@ -1146,7 +1152,7 @@ class ValidateAttribute(object):
     def _gather_value_warnings_errors(
         val_rule: str,
         source_attribute: str,
-        value_validation_store: list[{},{},{}],
+        value_validation_store: list[{}, {}, {}],
         dmge: DataModelGraphExplorer,
     ) -> tuple([[], []]):
         """For value rule scope, find invalid rows and entries, and generate appropriate errors and warnings
@@ -1202,7 +1208,7 @@ class ValidateAttribute(object):
 
     def _run_validation_across_targets_set(
         val_rule: str,
-        column_names: Dict[str,str],
+        column_names: Dict[str, str],
         manifest_col: pd.core.series.Series,
         target_attribute: str,
         target_column: pd.core.series.Series,
@@ -1277,7 +1283,7 @@ class ValidateAttribute(object):
         Args:
             column_names, Dict: {stripped_col_name:original_column_name}
             target_attribute, str: current target attribute
-            concatenated_target_column, pd.core.series.Series: target column in the process of being built, possibly 
+            concatenated_target_column, pd.core.series.Series: target column in the process of being built, possibly
                 passed through this function multiple times based on the number of manifests
             target_manifest, pd.core.series.Series: current target manifest
         Returns:
@@ -1316,7 +1322,7 @@ class ValidateAttribute(object):
             manifest_col, pd.core.series.Series: Current source manifest column
             concatenated_target_column, pd.core.series.Series: All target columns concatenated into a single column
         Returns:
-            missing_values, pd.core.series.Series: values that are present in the source manifest, but not present 
+            missing_values, pd.core.series.Series: values that are present in the source manifest, but not present
                 in the target manifest
             duplicated_values, pd.core.series.Series: values that duplicated in the concatenated target column, and
                 also present in the source manifest column
@@ -1338,7 +1344,7 @@ class ValidateAttribute(object):
 
         return missing_values, duplicated_values, repeat_values
 
-    def _get_column_names(target_manifest: pd.core.series.Series) -> Dict[str,str]:
+    def _get_column_names(target_manifest: pd.core.series.Series) -> Dict[str, str]:
         """Convert manifest column names into validation rule input format
         Args:
             target_manifest, pd.core.series.Series: Current target manifest
@@ -1423,7 +1429,7 @@ class ValidateAttribute(object):
                 target_manifest=target_manifest
             )
 
-            # Read each target manifest and run validation of current manifest column (set) against each 
+            # Read each target manifest and run validation of current manifest column (set) against each
             # manifest individually, gather results
             if "set" in rule_scope:
                 (

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -182,6 +182,10 @@ class ValidateManifest(object):
 
         t_err = perf_counter()
         regex_re = re.compile("regex.*")
+
+        # Instantiate Validate Attribute
+        validate_attribute = ValidateAttribute(dmge=dmge)
+
         for col in manifest.columns:
             # remove trailing/leading whitespaces from manifest
             manifest.map(lambda x: x.strip() if isinstance(x, str) else x)
@@ -218,31 +222,24 @@ class ValidateManifest(object):
 
                     t_indiv_rule = perf_counter()
                     # Validate for each individual validation rule.
-                    try:
-                        validation_method = getattr(
-                            ValidateAttribute, validation_types[validation_type]["type"]
-                        )
-                    except:
-                        breakpoint()
+                    validation_method = getattr(
+                        validate_attribute, validation_types[validation_type]["type"]
+                    )
 
                     if validation_type == "list":
                         vr_errors, vr_warnings, manifest_col = validation_method(
-                            self,
                             rule,
                             manifest[col],
-                            dmge,
                         )
                         manifest[col] = manifest_col
                     elif validation_type.lower().startswith("match"):
                         vr_errors, vr_warnings = validation_method(
-                            self, rule, manifest[col], project_scope, dmge, access_token
+                            rule, manifest[col], project_scope, access_token
                         )
                     else:
                         vr_errors, vr_warnings = validation_method(
-                            self,
                             rule,
                             manifest[col],
-                            dmge,
                         )
                     # Check for validation rule errors and add them to other errors.
                     if vr_errors:

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -116,7 +116,7 @@ class ValidateManifest(object):
             "regex.*",
             "matchAtLeastOne.*",
             "matchExactlyOne.*",
-            "matchNone.*"
+            "matchNone.*",
         ]
 
         in_house_rules = [
@@ -129,7 +129,7 @@ class ValidateManifest(object):
             "list",
             "matchAtLeastOne.*",
             "matchExactlyOne.*",
-            "matchNone.*"
+            "matchNone.*",
         ]
 
         # initialize error and warning handling lists.

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -116,6 +116,7 @@ class ValidateManifest(object):
             "regex.*",
             "matchAtLeastOne.*",
             "matchExactlyOne.*",
+            "matchUnique.*"
         ]
 
         in_house_rules = [
@@ -128,6 +129,7 @@ class ValidateManifest(object):
             "list",
             "matchAtLeastOne.*",
             "matchExactlyOne.*",
+            "matchUnique.*"
         ]
 
         # initialize error and warning handling lists.
@@ -216,9 +218,12 @@ class ValidateManifest(object):
 
                     t_indiv_rule = perf_counter()
                     # Validate for each individual validation rule.
-                    validation_method = getattr(
-                        ValidateAttribute, validation_types[validation_type]["type"]
-                    )
+                    try:
+                        validation_method = getattr(
+                            ValidateAttribute, validation_types[validation_type]["type"]
+                        )
+                    except:
+                        breakpoint()
 
                     if validation_type == "list":
                         vr_errors, vr_warnings, manifest_col = validation_method(

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -116,7 +116,7 @@ class ValidateManifest(object):
             "regex.*",
             "matchAtLeastOne.*",
             "matchExactlyOne.*",
-            "matchUnique.*"
+            "matchNone.*"
         ]
 
         in_house_rules = [
@@ -129,7 +129,7 @@ class ValidateManifest(object):
             "list",
             "matchAtLeastOne.*",
             "matchExactlyOne.*",
-            "matchUnique.*"
+            "matchNone.*"
         ]
 
         # initialize error and warning handling lists.

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -106,6 +106,7 @@ def validation_rule_info() -> dict[str, Rule]:
             "type": "cross_validation",
             "complementary_rules": None,
             "default_message_level": "warning",
+            "fixed_arg": None,
         },
         "recommended": {
             "arguments": (1, 0),

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -83,6 +83,12 @@ def validation_rule_info() -> (
             "complementary_rules": None,
             "default_message_level": "warning",
         },
+        "matchUnique": {
+            "arguments": (3, 2),
+            "type": "cross_validation",
+            "complementary_rules": None,
+            "default_message_level": "warning",
+        },
         "recommended": {
             "arguments": (1, 0),
             "type": "content_validation",

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -83,7 +83,7 @@ def validation_rule_info() -> (
             "complementary_rules": None,
             "default_message_level": "warning",
         },
-        "matchUnique": {
+        "matchNone": {
             "arguments": (3, 2),
             "type": "cross_validation",
             "complementary_rules": None,

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -19,7 +19,7 @@ CRAM,,,"Genome Build, Genome FASTA",,FALSE,ValidValue,,,
 CSV/TSV,,,Genome Build,,FALSE,ValidValue,,,
 Genome Build,,"GRCh37, GRCh38, GRCm38, GRCm39",,,TRUE,DataProperty,,,
 Genome FASTA,,,,,TRUE,DataProperty,,,
-MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Regex Integer, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Recommended, Check Ages, Check Unique, Check Range, Check Date, Check NA",,FALSE,DataType,,,
+MockComponent,,,"Component, Check List, Check Regex List, Check Regex Single, Check Regex Format, Check Regex Integer, Check Num, Check Float, Check Int, Check String, Check URL,Check Match at Least, Check Match at Least values, Check Match Exactly, Check Match Exactly values, Check Match None, Check Match None values, Check Recommended, Check Ages, Check Unique, Check Range, Check Date, Check NA",,FALSE,DataType,,,
 Check List,,"ab, cd, ef, gh",,,TRUE,DataProperty,,,list strict 
 Check Regex List,,,,,TRUE,DataProperty,,,list strict::regex match [a-f]
 Check Regex Single,,,,,TRUE,DataProperty,,,regex search [a-f]
@@ -32,8 +32,10 @@ Check String,,,,,TRUE,DataProperty,,,str
 Check URL,,,,,TRUE,DataProperty,,,url
 Check Match at Least,,,,,TRUE,DataProperty,,,matchAtLeastOne Patient.PatientID set
 Check Match Exactly,,,,,TRUE,DataProperty,,,matchExactlyOne MockComponent.checkMatchExactly set
+Check Match None,,,,,TRUE,DataProperty,,,matchNone MockComponent.checkMatchNone set error
 Check Match at Least values,,,,,TRUE,DataProperty,,,matchAtLeastOne MockComponent.checkMatchatLeastvalues value
 Check Match Exactly values,,,,,TRUE,DataProperty,,,matchExactlyOne MockComponent.checkMatchExactlyvalues value
+Check Match None values,,,,,TRUE,DataProperty,,,matchNone MockComponent.checkMatchNonevalues value error
 Check Recommended,,,,,FALSE,DataProperty,,,recommended
 Check Ages,,,,,TRUE,DataProperty,,,protectAges
 Check Unique,,,,,TRUE,DataProperty,,,unique error

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -920,6 +920,12 @@
                     "@id": "bts:CheckMatchExactlyvalues"
                 },
                 {
+                    "@id": "bts:CheckMatchNone"
+                },
+                {
+                    "@id": "bts:CheckMatchNonevalues"
+                },
+                {
                     "@id": "bts:CheckRecommended"
                 },
                 {
@@ -1219,6 +1225,44 @@
             "sms:required": "sms:true",
             "sms:validationRules": [
                 "matchExactlyOne MockComponent.checkMatchExactlyvalues value"
+            ]
+        },
+        {
+            "@id": "bts:CheckMatchNone",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckMatchNone",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Match None",
+            "sms:required": "sms:true",
+            "sms:validationRules": [
+                "matchNone MockComponent.checkMatchNone set error"
+            ]
+        },
+        {
+            "@id": "bts:CheckMatchNonevalues",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "CheckMatchNonevalues",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:DataProperty"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "Check Match None values",
+            "sms:required": "sms:true",
+            "sms:validationRules": [
+                "matchNone MockComponent.checkMatchNonevalues value error"
             ]
         },
         {

--- a/tests/data/mock_manifests/Invalid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Invalid_Test_Manifest.csv
@@ -1,5 +1,4 @@
-Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Regex Integer,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
-MockComponent,"ab,cd","ab,cd,ef",a,a,5.4,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,,6549,str1,70,32-984,7
-MockComponent,invalid list values,ab cd ef,q,m,0,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,,32851,str1,30,notADate,9.5
-MockComponent,"ab,cd","ab,cd,ef",b,b,683902,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,210065,,6550,str1,90,84-43-094,Not Applicable
-,,,,,,,,,,,,,,,,,,,
+Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Regex Integer,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Match None,Check Match None values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
+MockComponent,"ab,cd","ab,cd,ef",a,a,5.4,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,1911,334,,6549,str1,70,32-984,7
+MockComponent,invalid list values,ab cd ef,q,m,0,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,123,717,,32851,str1,30,notADate,9.5
+MockComponent,"ab,cd","ab,cd,ef",b,b,683902,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,210065,1427,123,,6550,str1,90,84-43-094,Not Applicable

--- a/tests/data/mock_manifests/Invalid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Invalid_Test_Manifest.csv
@@ -2,3 +2,4 @@ Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Chec
 MockComponent,"ab,cd","ab,cd,ef",a,a,5.4,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,98085,1911,334,,6549,str1,70,32-984,7
 MockComponent,invalid list values,ab cd ef,q,m,0,c,99,5.63,94,http://googlef.com/,7163,51100,9965,71738,123,717,,32851,str1,30,notADate,9.5
 MockComponent,"ab,cd","ab,cd,ef",b,b,683902,6.5,62.3,2,valid,https://github.com/Sage-Bionetworks/schematic,8085,8085,1738,210065,1427,123,,6550,str1,90,84-43-094,Not Applicable
+,,,,,,,,,,,,,,,,,,,,,

--- a/tests/data/mock_manifests/Valid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Valid_Test_Manifest.csv
@@ -2,4 +2,4 @@ Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Chec
 MockComponent,"ab,cd","a,c,f",a,a,0,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,1911,334,,6571,str1,75,10/21/2022,Not Applicable
 MockComponent,"ab,cd","a,c,f",e,b,1234,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,1655,717,,6571,str2,80,October 21 2022,8
 MockComponent,"ab,cd","b,d,f",b,c,683902,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,1427,206,present,32849,str3,95,10/21/2022,Not Applicable
-MockComponent,"ab,cd","b,d,f",b,c,0,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,,,32849,str4,55,21/10/2022,695
+MockComponent,"ab,cd","b,d,f",b,c,0,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,6635,608,,32849,str4,55,21/10/2022,695

--- a/tests/data/mock_manifests/Valid_Test_Manifest.csv
+++ b/tests/data/mock_manifests/Valid_Test_Manifest.csv
@@ -1,5 +1,5 @@
-Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Regex Integer,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
-MockComponent,"ab,cd","a,c,f",a,a,0,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,,6571,str1,75,10/21/2022,Not Applicable
-MockComponent,"ab,cd","a,c,f",e,b,1234,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,,6571,str2,80,October 21 2022,8
-MockComponent,"ab,cd","b,d,f",b,c,683902,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,present,32849,str3,95,10/21/2022,Not Applicable
-MockComponent,"ab,cd","b,d,f",b,c,0,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,32849,str4,55,21/10/2022,695
+Component,Check List,Check Regex List,Check Regex Single,Check Regex Format,Check Regex Integer,Check Num,Check Float,Check Int,Check String,Check URL,Check Match at Least,Check Match at Least values,Check Match Exactly,Check Match Exactly values,Check Match None,Check Match None values,Check Recommended,Check Ages,Check Unique,Check Range,Check Date,Check NA
+MockComponent,"ab,cd","a,c,f",a,a,0,6,99.65,7,valid,https://www.google.com/,1738,1738,8085,8085,1911,334,,6571,str1,75,10/21/2022,Not Applicable
+MockComponent,"ab,cd","a,c,f",e,b,1234,71,58.4,3,valid,https://www.google.com/,9965,9965,9965,9965,1655,717,,6571,str2,80,October 21 2022,8
+MockComponent,"ab,cd","b,d,f",b,c,683902,6.5,62.3,2,valid,https://www.google.com/,8085,8085,1738,1738,1427,206,present,32849,str3,95,10/21/2022,Not Applicable
+MockComponent,"ab,cd","b,d,f",b,c,0,6.5,62.3,2,valid,https://www.google.com/,79,79,7,7,,,,32849,str4,55,21/10/2022,695

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -250,7 +250,7 @@ class TestManifestValidation:
                 row_num=["3"],
                 attribute_name="Check Match at Least",
                 invalid_entry=["7163"],
-                missing_manifest_ID=["syn27600110", "syn29381803"],
+                manifest_ID=["syn27600110", "syn29381803"],
                 dmge=dmge,
             )[1]
             in warnings
@@ -424,7 +424,7 @@ class TestManifestValidation:
                 row_num=["3"],
                 attribute_name="Check Match at Least",
                 invalid_entry=["7163"],
-                missing_manifest_ID=["syn27600110", "syn29381803"],
+                manifest_ID=["syn27600110", "syn29381803"],
                 dmge=dmge,
             )[1]
             in warnings

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -235,6 +235,18 @@ class TestManifestValidation:
              in errors
         )
 
+        assert (
+            GenerateError.generate_cross_warning(
+                val_rule="matchNone value error",
+                row_num=["4"],
+                attribute_name="Check Match None values",
+                invalid_entry=["123"],
+                dmge=dmge,
+            )[0]
+             in errors
+        )
+
+
         # check warnings
         assert (
             GenerateError.generate_content_error(
@@ -318,8 +330,6 @@ class TestManifestValidation:
             restrict_rules=True,
             project_scope=["syn54126707"],
         )
-
-        #syn23643250
 
         # Check errors
         assert (
@@ -430,6 +440,29 @@ class TestManifestValidation:
                 dmge=dmge,
             )[0]
             in errors
+        )
+
+        assert (
+            GenerateError.generate_cross_warning(
+                val_rule="matchNone error",
+                row_num=["3"],
+                attribute_name="Check Match None",
+                manifest_ID=["syn54126950"],
+                invalid_entry=["123"],
+                dmge=dmge,
+            )[0]
+             in errors
+        )
+
+        assert (
+            GenerateError.generate_cross_warning(
+                val_rule="matchNone value error",
+                row_num=["4"],
+                attribute_name="Check Match None values",
+                invalid_entry=["123"],
+                dmge=dmge,
+            )[0]
+             in errors
         )
 
         # Check Warnings

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -228,7 +228,7 @@ class TestManifestValidation:
                 val_rule="matchNone error",
                 row_num=["3"],
                 attribute_name="Check Match None",
-                manifest_ID=["syn54126950"],
+                manifest_id=["syn54126950"],
                 invalid_entry=["123"],
                 dmge=dmge,
             )[0]
@@ -274,7 +274,7 @@ class TestManifestValidation:
                 row_num=["3"],
                 attribute_name="Check Match at Least",
                 invalid_entry=["7163"],
-                manifest_ID=["syn54126997", "syn54127001"],
+                manifest_id=["syn54126997", "syn54127001"],
                 dmge=dmge,
             )[1]
             in warnings
@@ -447,7 +447,7 @@ class TestManifestValidation:
                 val_rule="matchNone error",
                 row_num=["3"],
                 attribute_name="Check Match None",
-                manifest_ID=["syn54126950"],
+                manifest_id=["syn54126950"],
                 invalid_entry=["123"],
                 dmge=dmge,
             )[0]
@@ -472,7 +472,7 @@ class TestManifestValidation:
                 row_num=["3"],
                 attribute_name="Check Match at Least",
                 invalid_entry=["7163"],
-                manifest_ID=["syn54126997", "syn54127001"],
+                manifest_id=["syn54126997", "syn54127001"],
                 dmge=dmge,
             )[1]
             in warnings

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -62,7 +62,7 @@ class TestManifestValidation:
         errors, warnings = metadataModel.validateModelManifest(
             manifestPath=manifestPath,
             rootNode=rootNode,
-            project_scope=["syn23643250"],
+            project_scope=["syn54126707"],
         )
 
         assert errors == []
@@ -75,7 +75,7 @@ class TestManifestValidation:
         errors, warnings = metadataModel.validateModelManifest(
             manifestPath=manifestPath,
             rootNode=rootNode,
-            project_scope=["syn23643250"],
+            project_scope=["syn54126707"],
         )
 
         # Check errors
@@ -223,6 +223,18 @@ class TestManifestValidation:
             in errors
         )
 
+        assert (
+            GenerateError.generate_cross_warning(
+                val_rule="matchNone error",
+                row_num=["3"],
+                attribute_name="Check Match None",
+                manifest_ID=["syn54126950"],
+                invalid_entry=["123"],
+                dmge=dmge,
+            )[0]
+             in errors
+        )
+
         # check warnings
         assert (
             GenerateError.generate_content_error(
@@ -250,7 +262,7 @@ class TestManifestValidation:
                 row_num=["3"],
                 attribute_name="Check Match at Least",
                 invalid_entry=["7163"],
-                manifest_ID=["syn27600110", "syn29381803"],
+                manifest_ID=["syn54126997", "syn54127001"],
                 dmge=dmge,
             )[1]
             in warnings
@@ -271,14 +283,14 @@ class TestManifestValidation:
             GenerateError.generate_cross_warning(
                 val_rule="matchExactlyOne",
                 attribute_name="Check Match Exactly",
-                matching_manifests=["syn29862078", "syn27648165"],
+                matching_manifests=["syn54126950", "syn54127008"],
                 dmge=dmge,
             )[1]
             in warnings
             or GenerateError.generate_cross_warning(
                 val_rule="matchExactlyOne",
                 attribute_name="Check Match Exactly",
-                matching_manifests=["syn29862066", "syn27648165"],
+                matching_manifests=["syn54127702", "syn54127008"],
                 dmge=dmge,
             )[1]
             in warnings
@@ -291,6 +303,7 @@ class TestManifestValidation:
             invalid_entry=["71738", "98085", "210065"],
             dmge=dmge,
         )[1]
+
         warning_in_list = [cross_warning[1] in warning for warning in warnings]
         assert any(warning_in_list)
 
@@ -303,8 +316,10 @@ class TestManifestValidation:
             manifestPath=manifestPath,
             rootNode=rootNode,
             restrict_rules=True,
-            project_scope=["syn23643250"],
+            project_scope=["syn54126707"],
         )
+
+        #syn23643250
 
         # Check errors
         assert (
@@ -424,7 +439,7 @@ class TestManifestValidation:
                 row_num=["3"],
                 attribute_name="Check Match at Least",
                 invalid_entry=["7163"],
-                manifest_ID=["syn27600110", "syn29381803"],
+                manifest_ID=["syn54126997", "syn54127001"],
                 dmge=dmge,
             )[1]
             in warnings
@@ -445,14 +460,14 @@ class TestManifestValidation:
             GenerateError.generate_cross_warning(
                 val_rule="matchExactlyOne",
                 attribute_name="Check Match Exactly",
-                matching_manifests=["syn29862078", "syn27648165"],
+                matching_manifests=["syn54126950", "syn54127008"],
                 dmge=dmge,
             )[1]
             in warnings
             or GenerateError.generate_cross_warning(
                 val_rule="matchExactlyOne",
                 attribute_name="Check Match Exactly",
-                matching_manifests=["syn29862066", "syn27648165"],
+                matching_manifests=["syn54127702", "syn54127008"],
                 dmge=dmge,
             )[1]
             in warnings
@@ -468,6 +483,7 @@ class TestManifestValidation:
             )[1]
             in warnings
         )
+
 
     @pytest.mark.parametrize(
         "manifest_path",


### PR DESCRIPTION
### About this PR

This PR addresses [FDS-1766](https://sagebionetworks.jira.com/browse/FDS-1766).

The new rule works as follows:

- Format: 
   - `matchNone <targetComponent>.<targetAttribute> <scope> <raised message level>`
   - Will check that values of the specified attribute are not present in other manifests
   - Attribute will be invalid if the values are found in any other manifest
   - Default behavior: raises `warning`
- Example: 
   - matchNone Patient.PatientID set

      - Will check that the complete set of values from the specified attribute (that this rule is applied to), in the manifest that is currently being submitted for validation, is not present in any existing (target) Patient manifests that contains the PatientID attribute. This could be used to confirm that any set of  PatientIDs are not repeated in other manifest, for example.

   - matchNone Patient.PatientID value

      - Will check that each individual value from the specified attribute (that this rule is applied to), in the manifest that is currently being submitted for validation, is not present in any existing (target) Patient manifests that contains the PatientID attribute. This could be used to confirm that any PatientIDs are not repeated in other manifest, for example.


New CheckNone attributes and rules have been added to the `example.model.csv` for use in unit tests to confirm the rules are working as expected.

The new attributes have been added to the Synapse test files, and all cross manifest validation files have been relocated to the synapse project: [Schematic Cross Manifest Validation Testing,](https://www.synapse.org/#!Synapse:syn54126707/wiki/626665) to reduce testing time.

This PR also includes a minor refactor of the cross manifest validation portion of `validate_attribute` to avoid code duplication with addition of this new rule, and for code clarity and maintenance..

[FDS-1766]: https://sagebionetworks.jira.com/browse/FDS-1766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

--------------

### Testing this PR

This PR can be tested by making a copy of `tests/data/mock_manifests/Valid_Test_Manifest.csv`.
In `config.yml` set `master_fileview_id: "syn54126711"`

Run validation as follows:
```
schematic model -c config.yml validate -mp tests/data/mock_manifests/Valid_Test_Manifest_Copy.csv -dt MockComponent -ps syn54126707
```

Validation should pass.

Next, to make validation fail, change one of the values (column `checkMatchNone`)in your test manifest to `123`.

```
error: Value(s) ['123'] from row(s) ['3'] for the attribute Check Match None in the source manifest are not unique. Manifest(s) ['syn54126950'] contain duplicate values.
```

Additional  Potential Testing:

- Can do variations of this on your own, the goal to failure would be to make values in the original `Valid_Test_Manifest.csv`  columns `checkMatchNone` and `checkMatchNonevalues` overlap values in the Synapse test manifests: `[syn54126950, syn54127702, syn54127008]`
- Can also go into example data model `example.model.csv` and add new versions of the checkNone rule (change scope or error level).
   - Then, either convert to JSONLD or update the path to the data model in the config to the CSV.
- Can also run with parameters like `-rr` which goes through a separate initial process when forcing all the rules to be applied with `in house validation rules`.
- Test via API and CLI