### PR TITLE
Fds 1796 schema convert export pickle

### DIFF
--- a/schematic/help.py
+++ b/schematic/help.py
@@ -203,9 +203,7 @@ schema_commands = {
             "output_jsonld": (
                 "Path to where the generated JSON-LD file needs to be outputted."
             ),
-            "output_type": (
-                "Output format to export the schema."
-            ),
+            "output_type": ("Output format to export the schema."),
             "data_model_labels": DATA_MODEL_LABELS_HELP,
         }
     }

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -203,8 +203,8 @@ schema_commands = {
             "output_jsonld": (
                 "Path to where the generated JSON-LD file needs to be outputted."
             ),
-            "export_as_graph": (
-                "Export the graph as a pickle file."
+            "output_type": (
+                "Output format to export the schema."
             ),
             "data_model_labels": DATA_MODEL_LABELS_HELP,
         }

--- a/schematic/help.py
+++ b/schematic/help.py
@@ -203,6 +203,9 @@ schema_commands = {
             "output_jsonld": (
                 "Path to where the generated JSON-LD file needs to be outputted."
             ),
+            "export_as_graph": (
+                "Export the graph as a pickle file."
+            ),
             "data_model_labels": DATA_MODEL_LABELS_HELP,
         }
     }

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -60,11 +60,13 @@ def schema():  # use as `schematic model ...`
 @click.option(
     "--output_type",
     "-ot",
-    type=click.Choice(['jsonld', 'graph', 'all'], case_sensitive=False),
+    type=click.Choice(["jsonld", "graph", "all"], case_sensitive=False),
     default="jsonld",
     help=query_dict(schema_commands, ("schema", "convert", "output_type")),
 )
-def convert(schema: str, data_model_labels:str, output_jsonld:str, output_type:str) -> str:
+def convert(
+    schema: str, data_model_labels: str, output_jsonld: str, output_type: str
+) -> str:
     """
     Running CLI to convert data model specification in CSV format to
     data model in JSON-LD format.
@@ -130,9 +132,7 @@ def convert(schema: str, data_model_labels:str, output_jsonld:str, output_type:s
         try:
             with open(output_graph, "wb") as file:
                 pickle.dump(graph_data_model, file)
-            click.echo(
-                f"The graph was created and saved to '{output_graph}'."
-            )
+            click.echo(f"The graph was created and saved to '{output_graph}'.")
         except SystemExit as e:
             click.echo(
                 f"The graph failed to save to '{output_graph}'. Please check your file path again."

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -64,7 +64,7 @@ def schema():  # use as `schematic model ...`
     default="jsonld",
     help=query_dict(schema_commands, ("schema", "convert", "output_type")),
 )
-def convert(schema, data_model_labels, output_jsonld, output_type):
+def convert(schema: str, data_model_labels:str, output_jsonld:str, output_type:str) -> str:
     """
     Running CLI to convert data model specification in CSV format to
     data model in JSON-LD format.
@@ -112,18 +112,18 @@ def convert(schema, data_model_labels, output_jsonld, output_type):
             elif isinstance(war, list):
                 for w in war:
                     logger.warning(w)
-    
+
     if output_jsonld is None:
         output_file_no_ext = re.sub("[.](jsonld|csv)$", "", schema)
     else:
         output_file_no_ext = re.sub("[.](jsonld|csv)$", "", output_jsonld)
-    
+
     logger.info(
         "By default, the JSON-LD output will be stored alongside the first "
         f"input CSV or JSON-LD file. In this case, it will appear here: '{output_jsonld}'. "
         "You can use the `--output_jsonld` argument to specify another file path."
     )
-        
+
     if output_type in ["graph", "all"]:
         logger.info("Export graph to pickle if requested")
         output_graph = output_file_no_ext + ".pickle"
@@ -133,10 +133,11 @@ def convert(schema, data_model_labels, output_jsonld, output_type):
             click.echo(
                 f"The graph was created and saved to '{output_graph}'."
             )
-        except:
+        except SystemExit as e:
             click.echo(
                 f"The graph failed to save to '{output_graph}'. Please check your file path again."
             )
+            raise e
 
     if output_type == "graph":
         return output_graph

--- a/schematic/schemas/commands.py
+++ b/schematic/schemas/commands.py
@@ -61,7 +61,7 @@ def schema():  # use as `schematic model ...`
     "--export_as_graph",
     "-eag",
     is_flag=True,
-    help="Export the graph as a pickle file"
+    help=query_dict(schema_commands, ("schema", "convert", "export_as_graph")),
 )
 def convert(schema, data_model_labels, output_jsonld, export_as_graph):
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@ import os
 import pytest
 import pickle
 import json
-import tempfile
 
 from click.testing import CliRunner
 
@@ -27,14 +26,6 @@ def data_model_jsonld(helpers):
 
 
 class TestSchemaCli:
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
-        self.temp_file = tempfile.NamedTemporaryFile(dir=self.temp_dir)
-
-    def tearDown(self):
-        self.temp_file.close()
-        os.rmdir(self.temp_dir())
-
     def assert_expected_file(self, result, output_path):
         extension = os.path.splitext(output_path)[-1].lower()
 
@@ -60,12 +51,6 @@ class TestSchemaCli:
         ("tests/data/example.model.csv", "tests/data/example.model.jsonld", 0)
     ])
     def test_schema_convert_cli(self, runner, helpers, model, output, expected):
-        #data_model_path = helpers.get_data_path(model)
-        #data_model_pickle_path = helpers.get_data_path("example.model.pickle")
-        #data_model_jsonld_path = helpers.get_data_path("example.model.jsonld")
-
-        #output_path = helpers.get_data_path(output)
-
         label_type = 'class_label'
 
         result = runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,15 +46,26 @@ class TestSchemaCli:
         except:
             pass
 
-    @pytest.mark.parametrize("model, output, expected", [
-        ("tests/data/example.model.csv", "tests/data/example.model.pickle", 0),
-        ("tests/data/example.model.csv", "tests/data/example.model.jsonld", 0)
-    ])
+    @pytest.mark.parametrize(
+        "model, output, expected",
+        [
+            ("tests/data/example.model.csv", "tests/data/example.model.pickle", 0),
+            ("tests/data/example.model.csv", "tests/data/example.model.jsonld", 0),
+        ],
+    )
     def test_schema_convert_cli(self, runner, helpers, model, output, expected):
-        label_type = 'class_label'
+        label_type = "class_label"
 
         result = runner.invoke(
-            schema, ["convert", model, "--output_jsonld", output, "--data_model_labels", label_type]
+            schema,
+            [
+                "convert",
+                model,
+                "--output_jsonld",
+                output,
+                "--data_model_labels",
+                label_type,
+            ],
         )
 
         assert result.exit_code == expected

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,15 @@ class TestSchemaCli:
         assert type(all_pickle).__name__.lower() == 'multidigraph'
         os.remove(data_model_pickle_path)
 
+        no_ot = runner.invoke(
+            schema, ["convert", data_model_csv_path]
+        )
+        assert no_ot.exit_code == 0
+        with open(data_model_jsonld_path, 'r') as file:
+            no_ot_json = json.load(file)
+        assert '@context' in list(no_ot_json)
+        os.remove(data_model_jsonld_path)
+
     # get manifest by default
     # by default this should download the manifest as a CSV file
     @pytest.mark.google_credentials_needed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 import pickle
+import json
 
 from click.testing import CliRunner
 
@@ -83,10 +84,18 @@ class TestSchemaCli:
         )
 
         assert jsonld_export.exit_code == 0
+        with open(data_model_jsonld_path, 'r') as file:
+            json_jsonld = json.load(file)
+        assert '@context' in list(json_jsonld)
+        os.remove(data_model_jsonld_path)
 
         all_export = runner.invoke(
             schema, ["convert", data_model_csv_path, "--output_type", "all"]
         )
+        with open(data_model_jsonld_path, 'r') as file:
+            all_jsonld = json.load(file)
+        assert '@context' in list(all_jsonld)
+        os.remove(data_model_jsonld_path)
 
         assert all_export.exit_code == 0
         with open(data_model_pickle_path, 'rb') as file:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,12 @@ class TestSchemaCli:
 
         assert expected_substr in result.output
 
+        graph_export = runner.invoke(
+            schema, ["convert", data_model_csv_path, "--export_as_graph"]
+        )
+
+        assert graph_export.exit_code == 0
+
     # get manifest by default
     # by default this should download the manifest as a CSV file
     @pytest.mark.google_credentials_needed


### PR DESCRIPTION
The intent of this PR is to allow the `convert` CLI command to export the graph. It creates a new option, `output_type` with the values `jsonld`, `graph`, or `all`. `graph` exports the graph as a pickle, `jsonld` exports schema as a jsonld, and `all` does both.

Updated the CLI tests to ensure the file written by `convert` is read correctly.