### PR TITLE
Convert nans in manifest to empty strings just prior to JSON Schema Validation

### DIFF
--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -292,6 +292,9 @@ class ValidateManifest(object):
         warnings = []
         col_attr = {}  # save the mapping between column index and attribute name
 
+        # Replace nans with empty strings so jsonschema
+        manifest = manifest.replace({np.nan: ""})
+
         # numerical values need to be type string for the jsonValidator
         for col in manifest.select_dtypes(
             include=[int, np.int64, float, np.float64]


### PR DESCRIPTION
Fixes bug that was causing jsonschema valdiation not to work properly. 

Will create another ticket to create more JSON Schema tests to catch this in the future.