### PR TITLE
fix: added project scope parameter in test_api.py

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1086,7 +1086,7 @@ class TestManifestOperation:
             elif python_version == "3.9":
                 dataset_id = "syn52656104"
 
-            specific_params = {"asset_view": "syn23643253", "dataset_id": dataset_id}
+            specific_params = {"asset_view": "syn23643253", "dataset_id": dataset_id, "project_scope":["syn54126707"]}
 
         params.update(specific_params)
 


### PR DESCRIPTION
## Cause: 
This is related to cross manifest validation, and this manifest: [syn27600110](https://www.synapse.org/#!Synapse:syn27600110)  does not have an “Id” column

More context in: https://sagebionetworks.jira.com/browse/FDS-1965

## Solution
Since after [Pull Request #1387](https://github.com/Sage-Bionetworks/schematic/pull/1387), we moved cross manifest validation to separate folder, submission test in `test_api.py` should also be given a proper project scope. 