### PR TITLE
TechDebt: FDS-1148 remove uneeded parameter from submit_metadata_manifest

### DIFF
--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -170,7 +170,6 @@ def submit_manifest(
     )
 
     manifest_id = metadata_model.submit_metadata_manifest(
-        path_to_json_ld=jsonld,
         manifest_path=manifest_path,
         dataset_id=dataset_id,
         validate_component=validate_component,

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -395,35 +395,58 @@ class MetadataModel(object):
                 access_token=access_token,
             )
 
-            if val_errors != []:
+            # if there are no errors in validation process
+            if val_errors == []:
+                # upload manifest file from `manifest_path` path to entity with Syn ID `dataset_id`
+                if os.path.exists(censored_manifest_path):
+                    syn_store.associateMetadataWithFiles(
+                        dmge=self.dmge,
+                        metadataManifestPath=censored_manifest_path,
+                        datasetId=dataset_id,
+                        manifest_record_type=manifest_record_type,
+                        hideBlanks=hide_blanks,
+                        table_manipulation=table_manipulation,
+                        table_column_names=table_column_names,
+                        annotation_keys=annotation_keys,
+                        file_annotations_upload=file_annotations_upload,
+                    )
+                    restrict_maniest = True
+
+                manifest_id = syn_store.associateMetadataWithFiles(
+                    dmge=self.dmge,
+                    metadataManifestPath=manifest_path,
+                    datasetId=dataset_id,
+                    manifest_record_type=manifest_record_type,
+                    hideBlanks=hide_blanks,
+                    restrict_manifest=restrict_maniest,
+                    table_manipulation=table_manipulation,
+                    table_column_names=table_column_names,
+                    annotation_keys=annotation_keys,
+                    file_annotations_upload=file_annotations_upload,
+                )
+
+                logger.info("No validation errors occured during validation.")
+                return manifest_id
+
+            else:
                 raise ValidationError(
                     "Manifest could not be validated under provided data model. "
                     f"Validation failed with the following errors: {val_errors}"
                 )
 
-            # if there are no errors in validation process
-            # upload manifest file from `manifest_path` path to entity with Syn ID `dataset_id`
-            if os.path.exists(censored_manifest_path):
-                restrict_maniest = True
-
-            manifest_id = syn_store.associateMetadataWithFiles(
+        # no need to perform validation, just submit/associate the metadata manifest file
+        if os.path.exists(censored_manifest_path):
+            syn_store.associateMetadataWithFiles(
                 dmge=self.dmge,
-                metadataManifestPath=manifest_path,
+                metadataManifestPath=censored_manifest_path,
                 datasetId=dataset_id,
                 manifest_record_type=manifest_record_type,
                 hideBlanks=hide_blanks,
-                restrict_manifest=restrict_maniest,
                 table_manipulation=table_manipulation,
                 table_column_names=table_column_names,
                 annotation_keys=annotation_keys,
                 file_annotations_upload=file_annotations_upload,
             )
-
-            logger.info("No validation errors occured during validation.")
-            return manifest_id
-
-        # no need to perform validation, just submit/associate the metadata manifest file
-        if os.path.exists(censored_manifest_path):
             restrict_maniest = True
 
         manifest_id = syn_store.associateMetadataWithFiles(

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -53,7 +53,9 @@ class MetadataModel(object):
             f"Initializing DataModelGraphExplorer object from {inputMModelLocation} schema."
         )
 
+        # self.inputMModelLocation remains for backwards compatibility
         self.inputMModelLocation = inputMModelLocation
+        self.path_to_json_ld = inputMModelLocation
 
         data_model_parser = DataModelParser(path_to_data_model=self.inputMModelLocation)
         # Parse Model
@@ -315,10 +317,9 @@ class MetadataModel(object):
             manifestPath, emptyManifestURL, return_excel=return_excel, title=title
         )
 
-    def submit_metadata_manifest(
+    def submit_metadata_manifest(  # pylint: disable=too-many-arguments, too-many-locals
         self,
         manifest_path: str,
-        path_to_json_ld: str,
         dataset_id: str,
         manifest_record_type: str,
         restrict_rules: bool,
@@ -326,25 +327,41 @@ class MetadataModel(object):
         validate_component: Optional[str] = None,
         file_annotations_upload: bool = True,
         hide_blanks: bool = False,
-        project_scope: List = None,
+        project_scope: Optional[list] = None,
         table_manipulation: str = "replace",
         table_column_names: str = "class_label",
         annotation_keys: str = "class_label",
     ) -> str:
-        """Wrap methods that are responsible for validation of manifests for a given component, and association of the
-        same manifest file with a specified dataset.
+        """
+        Wrap methods that are responsible for validation of manifests for a given component,
+          and association of the same manifest file with a specified dataset.
+
         Args:
-            manifest_path: Path to the manifest file, which contains the metadata.
-            dataset_id: Synapse ID of the dataset on Synapse containing the metadata manifest file.
-            validate_component: Component from the schema.org schema based on which the manifest template has been generated.
-            file_annotations_upload (bool): Default to True. If false, do not add annotations to files.
-        Returns:
-            Manifest ID: If both validation and association were successful.
-        Exceptions:
+            manifest_path (str): Path to the manifest file, which contains the metadata.
+            dataset_id (str): Synapse ID of the dataset on Synapse containing the
+              metadata manifest file.
+            manifest_record_type (str): How the manifest is stored in Synapse
+            restrict_rules (bool):
+              If True: bypass great expectations and restrict rule options to
+                those implemented in house
+            access_token (Optional[str], optional): Defaults to None.
+            validate_component (Optional[str], optional): Component from the schema.org
+              schema based on which the manifest template has been generated.
+            file_annotations_upload (bool, optional): Default to True. If false, do
+              not add annotations to files. Defaults to True.
+            hide_blanks (bool, optional): Defaults to False.
+            project_scope (Optional[list], optional): Defaults to None.
+            table_manipulation (str, optional): Defaults to "replace".
+            table_column_names (str, optional): Defaults to "class_label".
+            annotation_keys (str, optional): Defaults to "class_label".
+
+        Raises:
             ValueError: When validate_component is provided, but it cannot be found in the schema.
             ValidationError: If validation against data model was not successful.
-        """
 
+        Returns:
+            str: If both validation and association were successful.
+        """
         # TODO: avoid explicitly exposing Synapse store functionality
         # just instantiate a Store class and let it decide at runtime/config
         # the store type
@@ -352,25 +369,25 @@ class MetadataModel(object):
             access_token=access_token, project_scope=project_scope
         )
         manifest_id = None
-        censored_manifest_id = None
         restrict_maniest = False
         censored_manifest_path = manifest_path.replace(".csv", "_censored.csv")
         # check if user wants to perform validation or not
         if validate_component is not None:
             try:
-                # check if the component ("class" in schema) passed as argument is valid (present in schema) or not
+                # check if the component ("class" in schema) passed as argument is valid
+                # (present in schema) or not
                 self.dmge.is_class_in_schema(validate_component)
-            except:
-                # a KeyError exception is raised when validate_component fails in the try-block above
-                # here, we are suppressing the KeyError exception and replacing it with a more
-                # descriptive ValueError exception
+            except Exception as exc:
+                # a KeyError exception is raised when validate_component fails in the
+                # try-block above here, we are suppressing the KeyError exception and
+                # replacing it with a more descriptive ValueError exception
                 raise ValueError(
                     f"The component '{validate_component}' could not be found "
-                    f"in the schema here '{path_to_json_ld}'"
-                )
+                    f"in the schema here '{self.path_to_json_ld}'"
+                ) from exc
 
             # automatic JSON schema generation and validation with that JSON schema
-            val_errors, val_warnings = self.validateModelManifest(
+            val_errors, _ = self.validateModelManifest(
                 manifestPath=manifest_path,
                 rootNode=validate_component,
                 restrict_rules=restrict_rules,
@@ -378,58 +395,35 @@ class MetadataModel(object):
                 access_token=access_token,
             )
 
-            # if there are no errors in validation process
-            if val_errors == []:
-                # upload manifest file from `manifest_path` path to entity with Syn ID `dataset_id`
-                if os.path.exists(censored_manifest_path):
-                    censored_manifest_id = syn_store.associateMetadataWithFiles(
-                        dmge=self.dmge,
-                        metadataManifestPath=censored_manifest_path,
-                        datasetId=dataset_id,
-                        manifest_record_type=manifest_record_type,
-                        hideBlanks=hide_blanks,
-                        table_manipulation=table_manipulation,
-                        table_column_names=table_column_names,
-                        annotation_keys=annotation_keys,
-                        file_annotations_upload=file_annotations_upload,
-                    )
-                    restrict_maniest = True
-
-                manifest_id = syn_store.associateMetadataWithFiles(
-                    dmge=self.dmge,
-                    metadataManifestPath=manifest_path,
-                    datasetId=dataset_id,
-                    manifest_record_type=manifest_record_type,
-                    hideBlanks=hide_blanks,
-                    restrict_manifest=restrict_maniest,
-                    table_manipulation=table_manipulation,
-                    table_column_names=table_column_names,
-                    annotation_keys=annotation_keys,
-                    file_annotations_upload=file_annotations_upload,
-                )
-
-                logger.info(f"No validation errors occured during validation.")
-                return manifest_id
-
-            else:
+            if val_errors != []:
                 raise ValidationError(
                     "Manifest could not be validated under provided data model. "
                     f"Validation failed with the following errors: {val_errors}"
                 )
 
-        # no need to perform validation, just submit/associate the metadata manifest file
-        if os.path.exists(censored_manifest_path):
-            censored_manifest_id = syn_store.associateMetadataWithFiles(
+            # if there are no errors in validation process
+            # upload manifest file from `manifest_path` path to entity with Syn ID `dataset_id`
+            if os.path.exists(censored_manifest_path):
+                restrict_maniest = True
+
+            manifest_id = syn_store.associateMetadataWithFiles(
                 dmge=self.dmge,
-                metadataManifestPath=censored_manifest_path,
+                metadataManifestPath=manifest_path,
                 datasetId=dataset_id,
                 manifest_record_type=manifest_record_type,
                 hideBlanks=hide_blanks,
+                restrict_manifest=restrict_maniest,
                 table_manipulation=table_manipulation,
                 table_column_names=table_column_names,
                 annotation_keys=annotation_keys,
                 file_annotations_upload=file_annotations_upload,
             )
+
+            logger.info("No validation errors occured during validation.")
+            return manifest_id
+
+        # no need to perform validation, just submit/associate the metadata manifest file
+        if os.path.exists(censored_manifest_path):
             restrict_maniest = True
 
         manifest_id = syn_store.associateMetadataWithFiles(

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -439,7 +439,6 @@ def submit_manifest_route(
     access_token = get_access_token()
 
     manifest_id = metadata_model.submit_metadata_manifest(
-        path_to_json_ld=data_model,
         manifest_path=temp_path,
         dataset_id=dataset_id,
         validate_component=validate_component,

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -150,10 +150,8 @@ class TestMetadataModel:
                 return_value="mock manifest id",
             ):
                 mock_manifest_path = test_bulkrnaseq
-                data_model_jsonld = helpers.get_data_path("example.model.jsonld")
                 mock_manifest_id = meta_data_model.submit_metadata_manifest(
                     manifest_path=mock_manifest_path,
-                    path_to_json_ld=data_model_jsonld,
                     validate_component=validate_component,
                     dataset_id="mock dataset id",
                     manifest_record_type="file_only",


### PR DESCRIPTION
- fixes [FDS-1148]
- `schematic.models.metadata.Metadata.submit_metadata_manifest` `path_to_json_ld` parameter removed and is now using instance variable
-  `schematic.models.metadata.Metadata.submit_metadata_manifest` pylinted

[FDS-1148]: https://sagebionetworks.jira.com/browse/FDS-1148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ