### PR TITLE
Bug Fix: Fix failing test to conform to data model updates

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -383,7 +383,7 @@ class TestDataModelGraphExplorerOperation:
         )
         response_dta = json.loads(response.data)
         assert response.status_code == 200
-        assert "list strict" in response_dta
+        assert "list" in response_dta
         assert "regex match [a-f]" in response_dta
 
     def test_get_nodes_display_names(test, client, data_model_jsonld):


### PR DESCRIPTION
The data model was updated so "Check Regex List" no longer has the list strict validation rule, so the API test was failing when it was looking for the validation rules. 
Changed the expectation so now the test will pass.