### PR TITLE
FDS-511 removed typing extensions lock

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4862,4 +4862,4 @@ aws = ["uWSGI"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<3.11"
-content-hash = "579cc5febc6a29624324ab5845a8ee9a50b9fc8e2f1bdb987b24a7acdb4b7479"
+content-hash = "5bf0c831977694ea541db24481181ec1980ec9589a2adbd9f30ed0fe7f2b2742"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ dateparser = "^1.1.4"
 pandarallel = "^1.6.4"
 schematic-db = {version = "0.0.41", extras = ["synapse"]}
 pyopenssl = {version = "^23.0.0", optional = true}
-typing-extensions = "<4.6.0"
 dataclasses-json = "^0.6.1"
 pydantic = "^1.10.4"
 connexion = {extras = ["swagger-ui"], version = "^2.8.0", optional = true}


### PR DESCRIPTION
- Fixes [FDS-511]
- Removes typing-extensions lock

[FDS-511]: https://sagebionetworks.jira.com/browse/FDS-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ