### PR TITLE
feat/technical debt: added trivy code scan to schematic repo

### DIFF
--- a/.github/workflows/scan_repo.yml
+++ b/.github/workflows/scan_repo.yml
@@ -25,7 +25,7 @@ jobs:
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
           limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/scan_repo.yml
+++ b/.github/workflows/scan_repo.yml
@@ -1,0 +1,32 @@
+# borrowed from mono repo: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/.github/workflows/scan-repo.yml
+name: Scan Git repo
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+  workflow_dispatch: 
+
+jobs:
+  trivy:
+    name: Trivy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: Git Repository

--- a/.github/workflows/scan_repo.yml
+++ b/.github/workflows/scan_repo.yml
@@ -1,4 +1,4 @@
-# borrowed from mono repo: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/.github/workflows/scan-repo.yml
+# Modified from mono repo: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/.github/workflows/scan-repo.yml
 name: Scan Git repo
 on:
   push:
@@ -22,7 +22,7 @@ jobs:
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          severity: 'CRITICAL,HIGH,MEDIUM'
           limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/scan_repo.yml
+++ b/.github/workflows/scan_repo.yml
@@ -1,4 +1,5 @@
 # Modified from mono repo: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/.github/workflows/scan-repo.yml
+# Also, reference: https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#using-trivy-to-scan-your-git-repo
 name: Scan Git repo
 on:
   push:
@@ -18,7 +19,9 @@ jobs:
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@master
         with:
+          # the scan targets the file system.
           scan-type: 'fs'
+          # it will ignore vulnerabilities without a fix.
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'

--- a/.github/workflows/scan_repo.yml
+++ b/.github/workflows/scan_repo.yml
@@ -26,7 +26,7 @@ jobs:
           limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: Git Repository


### PR DESCRIPTION
## Context
Schematic in the past used github dependabot to scan security vulnerabilities but it is not working well because poetry version was overwritten in the toml file: 

<img width="1390" alt="Screenshot 2024-06-25 at 1 02 03 PM" src="https://github.com/Sage-Bionetworks/schematic/assets/55448354/f78db136-0f62-4269-9f1f-6d2289854ada">

This is a known issue: https://github.com/dependabot/dependabot-core/issues/1556 

To make sure that we follow Sage's [SLDC process](https://sagebionetworks.jira.com/wiki/spaces/SISP/pages/831127563/Software+Development+Lifecycle+Standard), we are thinking of using an alternative way to scan security risks. 

Please also note that Vulnerabilities should be managed based on the documentation here: [Atlassian Cloud](https://sagebionetworks.jira.com/wiki/spaces/SISP/pages/831193216/Vulnerability+Management+Process)


## Changes 
* Borrowed the trivy scan workflow from mono repo and added it for schematic
*  updated to use codeql-action v3 because v2 will be deprecated end of 2024: https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2