### PR TITLE
fix: created decorator that works for async function

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -348,6 +348,7 @@ class SynapseStorage(BaseStorage):
                     return None
                 else:
                     raise ex
+
         return wrapper
 
     def getStorageFileviewTable(self):
@@ -1720,16 +1721,16 @@ class SynapseStorage(BaseStorage):
                         entity_id = annos_dict["id"]
                         logger.info(f"Successfully stored annotations for {entity_id}")
                     else:
-                        if annos: 
+                        if annos:
                             entity_id = annos["EntityId"]
                             logger.info(
                                 f"Obtained and processed annotations for {entity_id} entity"
                             )
                             requests.add(
-                                    asyncio.create_task(
-                                        self.store_async_annotation(annotation_dict=annos)
-                                    )
+                                asyncio.create_task(
+                                    self.store_async_annotation(annotation_dict=annos)
                                 )
+                            )
                 except Exception as e:
                     raise RuntimeError(f"failed with { repr(e) }.") from e
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1,78 +1,71 @@
 """Synapse storage class"""
 
+import asyncio
 import atexit
-from copy import deepcopy
-from dataclasses import dataclass
 import logging
-import numpy as np
-import pandas as pd
 import os
 import re
 import secrets
 import shutil
-import synapseclient
-from synapseclient.api import get_entity_id_bundle2
 import uuid  # used to generate unique names for entities
-
-from tenacity import (
-    retry,
-    stop_after_attempt,
-    wait_chain,
-    wait_fixed,
-    retry_if_exception_type,
-)
+from copy import deepcopy
+from dataclasses import asdict, dataclass
 from time import sleep
 
 # allows specifying explicit variable types
-from typing import Dict, List, Tuple, Sequence, Union, Optional, Any, Set
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
+import numpy as np
+import pandas as pd
+import synapseclient
+import synapseutils
+from opentelemetry import trace
+from schematic_db.rdb.synapse_database import SynapseDatabase
 from synapseclient import (
-    Synapse,
-    File,
-    Folder,
-    Table,
-    Schema,
+    Column,
     EntityViewSchema,
     EntityViewType,
-    Column,
+    File,
+    Folder,
+    Schema,
+    Synapse,
+    Table,
     as_table_columns,
 )
-from synapseclient.entity import File
-from synapseclient.table import CsvFileTable, build_table, Schema
+from synapseclient.api import get_entity_id_bundle2
 from synapseclient.core.exceptions import (
-    SynapseHTTPError,
     SynapseAuthenticationError,
-    SynapseUnmetAccessRestrictions,
     SynapseHTTPError,
+    SynapseUnmetAccessRestrictions,
 )
-import synapseutils
+from synapseclient.entity import File
+from synapseclient.models.annotations import Annotations
+from synapseclient.table import CsvFileTable, Schema, build_table
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_chain,
+    wait_fixed,
+)
 
-from schematic_db.rdb.synapse_database import SynapseDatabase
-
+from schematic.configuration.configuration import CONFIG
+from schematic.exceptions import AccessCredentialsError
 from schematic.schemas.data_model_graph import DataModelGraphExplorer
-
-from schematic.utils.df_utils import update_df, load_df, col_in_dataframe
-from schematic.utils.validate_utils import comma_separated_list_regex, rule_in_rule_list
+from schematic.store.base import BaseStorage
+from schematic.utils.df_utils import col_in_dataframe, load_df, update_df
 
 # entity_type_mapping, get_dir_size, create_temp_folder, check_synapse_cache_size, and clear_synapse_cache functions are used for AWS deployment
 # Please do not remove these import statements
 from schematic.utils.general import (
-    entity_type_mapping,
-    get_dir_size,
-    create_temp_folder,
     check_synapse_cache_size,
     clear_synapse_cache,
+    create_temp_folder,
+    entity_type_mapping,
+    get_dir_size,
 )
-
 from schematic.utils.schema_utils import get_class_label_from_display_name
-
-from schematic.store.base import BaseStorage
-from schematic.exceptions import AccessCredentialsError
-from schematic.configuration.configuration import CONFIG
-from synapseclient.models.annotations import Annotations
-import asyncio
-from dataclasses import asdict
-from opentelemetry import trace
+from schematic.utils.validate_utils import comma_separated_list_regex, rule_in_rule_list
 
 logger = logging.getLogger("Synapse storage")
 
@@ -1409,7 +1402,12 @@ class SynapseStorage(BaseStorage):
 
     @async_missing_entity_handler
     async def format_row_annotations(
-        self, dmge, row, entityId: str, hideBlanks: bool, annotation_keys: str
+        self,
+        dmge: DataModelGraphExplorer,
+        row: pd.Series,
+        entityId: str,
+        hideBlanks: bool,
+        annotation_keys: str,
     ):
         # prepare metadata for Synapse storage (resolve display name into a name that Synapse annotations support (e.g no spaces, parenthesis)
         # note: the removal of special characters, will apply only to annotation keys; we are not altering the manifest

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1738,6 +1738,7 @@ class SynapseStorage(BaseStorage):
                         entity_id = annos_dict["id"]
                         logger.info(f"Successfully stored annotations for {entity_id}")
                     else:
+                        # store annotations if they are not None
                         if annos:
                             entity_id = annos["EntityId"]
                             logger.info(

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -338,7 +338,9 @@ class SynapseStorage(BaseStorage):
         return wrapper
 
     def async_missing_entity_handler(method):
-        async def wrapper(*args, **kwargs):
+        """Decorator to handle missing entities in async methods."""
+
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
             try:
                 return await method(*args, **kwargs)
             except SynapseHTTPError as ex:

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1409,15 +1409,20 @@ class SynapseStorage(BaseStorage):
 
     @async_missing_entity_handler
     async def format_row_annotations(
-        self, dmge:DataModelGraphExplorer, row:pd.Series, entityId:str, hideBlanks: bool, annotation_keys: str
-    ) -> Union[None, Dict[str,Any]]:
-        """Format row annotations 
+        self,
+        dmge: DataModelGraphExplorer,
+        row: pd.Series,
+        entityId: str,
+        hideBlanks: bool,
+        annotation_keys: str,
+    ) -> Union[None, Dict[str, Any]]:
+        """Format row annotations
 
         Args:
             dmge (DataModelGraphExplorer): data moodel graph explorer object
-            row (pd.Series): row of the manifest 
+            row (pd.Series): row of the manifest
             entityId (str): entity id of the manifest
-            hideBlanks (bool): when true, does not upload annotation keys with blank values. When false, upload Annotation keys with empty string values 
+            hideBlanks (bool): when true, does not upload annotation keys with blank values. When false, upload Annotation keys with empty string values
             annotation_keys (str): display_label/class_label
 
         Returns:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -463,7 +463,12 @@ class TestSynapseStorage:
         ],
     )
     async def test_format_row_annotations_entity_id_trash_can(
-        self, caplog:pytest.LogCaptureFixture, dmge: DataModelGraph, synapse_store: SynapseStorage, hideBlanks: bool, annotation_keys: str
+        self,
+        caplog: pytest.LogCaptureFixture,
+        dmge: DataModelGraph,
+        synapse_store: SynapseStorage,
+        hideBlanks: bool,
+        annotation_keys: str,
     ):
         """make sure that missing_entity_handler gets triggered when entity is in the trash can"""
         with patch(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -671,6 +671,25 @@ class TestSynapseStorage:
             await synapse_store._process_store_annos(new_tasks)
             mock_store_async2.assert_called_once()
 
+    async def test_process_store_annos_get_annos_empty(
+        self, synapse_store: SynapseStorage
+    ) -> None:
+        """ "test _process_store_annos function and make sure that task of storing annotations wont be triggered when annotations are empty"""
+
+        # make sure that the else statement is working
+        # and that the task of storing annotations is not triggered when annotations are empty
+        async def mock_success_coro():
+            return None
+
+        with patch(
+            "schematic.store.synapse.SynapseStorage.store_async_annotation",
+            new_callable=AsyncMock,
+        ) as mock_store_async:
+            new_tasks = set()
+            new_tasks.add(asyncio.create_task(mock_success_coro()))
+            await synapse_store._process_store_annos(new_tasks)
+            mock_store_async.assert_not_called()
+
 
 class TestDatasetFileView:
     def test_init(self, dataset_id, dataset_fileview, synapse_store):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -463,7 +463,7 @@ class TestSynapseStorage:
         ],
     )
     async def test_format_row_annotations_entity_id_trash_can(
-        self, caplog, dmge, synapse_store, hideBlanks, annotation_keys
+        self, caplog:pytest.LogCaptureFixture, dmge: DataModelGraph, synapse_store: SynapseStorage, hideBlanks: bool, annotation_keys: str
     ):
         """make sure that missing_entity_handler gets triggered when entity is in the trash can"""
         with patch(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -469,7 +469,7 @@ class TestSynapseStorage:
         synapse_store: SynapseStorage,
         hideBlanks: bool,
         annotation_keys: str,
-    ):
+    ) -> None:
         """make sure that missing_entity_handler gets triggered when entity is in the trash can"""
         with patch(
             "schematic.store.synapse.SynapseStorage.get_async_annotation",
@@ -683,7 +683,7 @@ class TestSynapseStorage:
 
         # make sure that the else statement is working
         # and that the task of storing annotations is not triggered when annotations are empty
-        async def mock_success_coro():
+        async def mock_success_coro() -> None:
             return None
 
         with patch(


### PR DESCRIPTION
## Context
Related to this issue: https://sagebionetworks.jira.com/browse/FDS-2181

## Changes: 
* created the decorator that works for async format_row_annotation to accommodate the current expected behavior: when trying to add annotations to an entity id, and that entity id is in the trash can, return a warning instead of an error. 
* added unit tests for the following: 
1) added a test for `format_row_annotation` to make sure that when entity id is in trash can, the function would return None and a warning will be logged. This is the current behavior. If not followed, integration test: test_upsertTable would fail. 
2) added a test for `process_store_annos` to make sure that storing annotations is not triggered when annotations are empty

Note:  format_row_annotations is still under tested because of technical debt in previous development of schematic (independent of async). Please see FDS 2138 for further testing and refactoring this function 