### PR TITLE
fix: added black compatibility to isort 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,4 @@ repos:
       - id: isort
         name: isort (python)
         files: ^(tests|schematic|schematic_api)/
+        args: ["--profile", "black", "--filter-files"]


### PR DESCRIPTION
## Context
isort and black both modify files. To make sure that they work well together, I noticed that I have to add "black compatibility" to pre-commit

## Reference
https://pycqa.github.io/isort/docs/configuration/black_compatibility.html