### PR TITLE
fix: used environment variable to control tracing which allows tracing to be off during pytest run and normal API run 

### DIFF
--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -75,13 +75,14 @@ class FileSpanExporter(ConsoleSpanExporter):
                 f.write(span_json_one_line)
 
 
-def set_up_tracing():
+def set_up_tracing() -> None:
     """Set up tracing for the API."""
     tracing_export = os.environ.get("TRACING_EXPORT_FORMAT", None)
     if tracing_export == "otlp":
         trace.get_tracer_provider().add_span_processor(
             BatchSpanProcessor(OTLPSpanExporter())
         )
+        print("going through here")
     elif tracing_export == "file":
         timestamp_millis = int(time.time() * 1000)
         file_name = f"otel_spans_integration_testing_{timestamp_millis}.ndjson"

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -82,7 +82,6 @@ def set_up_tracing() -> None:
         trace.get_tracer_provider().add_span_processor(
             BatchSpanProcessor(OTLPSpanExporter())
         )
-        print("going through here")
     elif tracing_export == "file":
         timestamp_millis = int(time.time() * 1000)
         file_name = f"otel_spans_integration_testing_{timestamp_millis}.ndjson"

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -77,7 +77,7 @@ class FileSpanExporter(ConsoleSpanExporter):
 
 def set_up_tracing():
     """Set up tracing for the API."""
-    tracing_export = os.environ.get("TRACING_EXPORT", None)
+    tracing_export = os.environ.get("TRACING_EXPORT_FORMAT", None)
     if tracing_export == "otlp":
         trace.get_tracer_provider().add_span_processor(
             BatchSpanProcessor(OTLPSpanExporter())


### PR DESCRIPTION
## Context
Related to: https://sagebionetworks.jira.com/browse/FDS-2177
Also related to: https://github.com/Sage-Bionetworks/schematic/pull/1430

## Changes
used environment variable to control tracing which allows tracing to be off during pytest run and normal API run
Note: The code was partly borrowed from synapse python client. See original code here: https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/tests/integration/conftest.py


## Tests
When I did `pytest -m "table_operations"` or `pytest -s tests/test_manifest.py::TestManifestGenerator`, I am no longer seeing the warnings related to opentelemetry