### PR TITLE
fix: check existing great expectation suite before adding a new one

### DIFF
--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -152,17 +152,24 @@ class GreatExpectationsHelpers(object):
             saves expectation suite and identifier to self
         """
         self.expectation_suite_name = "Manifest_test_suite"
+        # Get a list of all expectation suites
         suite_names = self.context.list_expectation_suite_names()
-        if self.expectation_suite_name not in suite_names:
-            self.suite = self.context.add_expectation_suite(
-                expectation_suite_name=self.expectation_suite_name,
-            )
-        # in gh actions, sometimes the suite has already been added.
-        # if that's the case, get the existing one
-        else:
-            self.suite = self.context.get_expectation_suite(
-                expectation_suite_name=self.expectation_suite_name
-            )
+        # Get a list of all checkpoints
+        all_checkpoints = self.context.list_checkpoints()
+
+        # if the suite exists, delete it
+        if self.expectation_suite_name in suite_names:
+            self.context.delete_expectation_suite(self.expectation_suite_name)
+
+            # also delete all the checkpoints associated with the suite
+            if all_checkpoints:
+                for checkpoint_name in all_checkpoints:
+                    self.context.delete_checkpoint(checkpoint_name)
+
+        self.suite = self.context.add_expectation_suite(
+            expectation_suite_name=self.expectation_suite_name,
+        )
+
         return self.suite
 
     def build_expectation_suite(

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -12,6 +12,7 @@ from urllib.request import HTTPDefaultErrorHandler, OpenerDirector, Request, url
 
 import numpy as np
 from attr import attr
+from great_expectations.core import ExpectationSuite
 from great_expectations.core.expectation_configuration import ExpectationConfiguration
 from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
@@ -142,7 +143,7 @@ class GreatExpectationsHelpers(object):
         # self.context.test_yaml_config(yaml.dump(datasource_config))
         self.context.add_datasource(**datasource_config)
 
-    def add_expectation_suite_if_not_exists(self):
+    def add_expectation_suite_if_not_exists(self) -> ExpectationSuite:
         """
         Purpose:
             Add expectation suite if it does not exist

--- a/schematic/models/GE_Helpers.py
+++ b/schematic/models/GE_Helpers.py
@@ -152,7 +152,6 @@ class GreatExpectationsHelpers(object):
         """
         self.expectation_suite_name = "Manifest_test_suite"
         suite_names = self.context.list_expectation_suite_names()
-        print("suite name", suite_names)
         if self.expectation_suite_name not in suite_names:
             self.suite = self.context.add_expectation_suite(
                 expectation_suite_name=self.expectation_suite_name,

--- a/tests/test_ge_helpers.py
+++ b/tests/test_ge_helpers.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from schematic.models.GE_Helpers import GreatExpectationsHelpers
+
+
+@pytest.fixture(scope="class")
+def mock_ge_helpers(helpers):
+    dmge = helpers.get_data_model_graph_explorer(path="example.model.jsonld")
+    unimplemented_expectations = ["url"]
+    test_manifest_path = helpers.get_data_path("mock_manifests/Valid_Test_Manifest.csv")
+    manifest = pd.read_csv(test_manifest_path)
+
+    ge_helpers = GreatExpectationsHelpers(
+        dmge=dmge,
+        unimplemented_expectations=unimplemented_expectations,
+        manifest=manifest,
+        manifestPath=test_manifest_path,
+    )
+    yield ge_helpers
+
+
+class TestGreatExpectationsHelpers:
+    def test_add_expectation_suite_if_not_exists_does_not_exist(self, mock_ge_helpers):
+        # mock context provided by ge_helpers
+        mock_ge_helpers.context = MagicMock()
+        mock_ge_helpers.context.list_expectation_suite_names.return_value = []
+
+        # Call the method
+        result = mock_ge_helpers.add_expectation_suite_if_not_exists()
+
+        # Make sure the method of creating expectation suites if it doesn't exist
+        mock_ge_helpers.context.list_expectation_suite_names.assert_called_once()
+        mock_ge_helpers.context.add_expectation_suite.assert_called_once_with(
+            expectation_suite_name="Manifest_test_suite"
+        )
+
+    def test_add_expectation_suite_if_not_exists_does_exist(self, mock_ge_helpers):
+        # mock context provided by ge_helpers
+        mock_ge_helpers.context = MagicMock()
+        mock_ge_helpers.context.list_expectation_suite_names.return_value = [
+            "Manifest_test_suite"
+        ]
+
+        # Call the method
+        result = mock_ge_helpers.add_expectation_suite_if_not_exists()
+
+        # Make sure the method of getting existing suites gets called
+        mock_ge_helpers.context.list_expectation_suite_names.assert_called_once()
+        mock_ge_helpers.context.get_expectation_suite.assert_called_once_with(
+            expectation_suite_name="Manifest_test_suite"
+        )

--- a/tests/test_ge_helpers.py
+++ b/tests/test_ge_helpers.py
@@ -54,12 +54,19 @@ class TestGreatExpectationsHelpers:
         mock_ge_helpers.context.list_expectation_suite_names.return_value = [
             "Manifest_test_suite"
         ]
+        mock_ge_helpers.context.list_checkpoints.return_value = ["test_checkpoint"]
 
         # Call the method
         result = mock_ge_helpers.add_expectation_suite_if_not_exists()
 
-        # Make sure the method of getting existing suites gets called
+        # Make sure the method of deleting suites gets called
         mock_ge_helpers.context.list_expectation_suite_names.assert_called_once()
-        mock_ge_helpers.context.get_expectation_suite.assert_called_once_with(
+        mock_ge_helpers.context.delete_expectation_suite.assert_called_once_with(
+            "Manifest_test_suite"
+        )
+        mock_ge_helpers.context.add_expectation_suite.assert_called_once_with(
             expectation_suite_name="Manifest_test_suite"
+        )
+        mock_ge_helpers.context.delete_checkpoint.assert_called_once_with(
+            "test_checkpoint"
         )

--- a/tests/test_ge_helpers.py
+++ b/tests/test_ge_helpers.py
@@ -1,13 +1,18 @@
+from typing import Generator
 from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 
 from schematic.models.GE_Helpers import GreatExpectationsHelpers
+from tests.conftest import Helpers
 
 
 @pytest.fixture(scope="class")
-def mock_ge_helpers(helpers):
+def mock_ge_helpers(
+    helpers: Helpers,
+) -> Generator[GreatExpectationsHelpers, None, None]:
+    """Fixture for creating a GreatExpectationsHelpers object"""
     dmge = helpers.get_data_model_graph_explorer(path="example.model.jsonld")
     unimplemented_expectations = ["url"]
     test_manifest_path = helpers.get_data_path("mock_manifests/Valid_Test_Manifest.csv")
@@ -23,7 +28,10 @@ def mock_ge_helpers(helpers):
 
 
 class TestGreatExpectationsHelpers:
-    def test_add_expectation_suite_if_not_exists_does_not_exist(self, mock_ge_helpers):
+    def test_add_expectation_suite_if_not_exists_does_not_exist(
+        self, mock_ge_helpers: Generator[GreatExpectationsHelpers, None, None]
+    ) -> None:
+        """test add_expectation_suite_if_not_exists method when the expectation suite does not exists"""
         # mock context provided by ge_helpers
         mock_ge_helpers.context = MagicMock()
         mock_ge_helpers.context.list_expectation_suite_names.return_value = []
@@ -37,7 +45,10 @@ class TestGreatExpectationsHelpers:
             expectation_suite_name="Manifest_test_suite"
         )
 
-    def test_add_expectation_suite_if_not_exists_does_exist(self, mock_ge_helpers):
+    def test_add_expectation_suite_if_not_exists_does_exist(
+        self, mock_ge_helpers: Generator[GreatExpectationsHelpers, None, None]
+    ) -> None:
+        """test add_expectation_suite_if_not_exists method when the expectation suite does exists"""
         # mock context provided by ge_helpers
         mock_ge_helpers.context = MagicMock()
         mock_ge_helpers.context.list_expectation_suite_names.return_value = [

--- a/tests/test_ge_helpers.py
+++ b/tests/test_ge_helpers.py
@@ -16,7 +16,7 @@ def mock_ge_helpers(
     dmge = helpers.get_data_model_graph_explorer(path="example.model.jsonld")
     unimplemented_expectations = ["url"]
     test_manifest_path = helpers.get_data_path("mock_manifests/Valid_Test_Manifest.csv")
-    manifest = pd.read_csv(test_manifest_path)
+    manifest = helpers.get_data_frame(test_manifest_path)
 
     ge_helpers = GreatExpectationsHelpers(
         dmge=dmge,


### PR DESCRIPTION
Related to: https://sagebionetworks.jira.com/browse/FDS-2155

## Problem
Sometimes our GH workflows failed with great expectation suite error: 
```
(1424 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================== short test summary info ============================
FAILED tests/test_validation.py::TestManifestValidation::test_rule_combinations[int-IsNA] - great_expectations.exceptions.exceptions.ExpectationSuiteError: An ExpectationSuite named Manifest_test_suite already exists.
====== 1 failed, 715 passed, 691 warnings, 4 rerun in 1449.84s (0:24:09) =======
```
I think this problem occurred because the code adds an expectation suite without checking if it exists or not. See the original code below: 
```
self.suite = self.context.add_expectation_suite(
            expectation_suite_name=self.expectation_suite_name,
        )
```

Link of failed GH action: https://github.com/Sage-Bionetworks/schematic/actions/runs/9893404399/attempts/1


## Solution
Check if an expectation suite already exists before adding a new expectation suite. Based on the documentation [here](https://docs.greatexpectations.io/docs/oss/guides/expectations/how_to_create_and_edit_expectations_with_instant_feedback_from_a_sample_batch_of_data/#create-a-validator), you could use function `list_expectation_suite_name` to check if an expectation suite has been created. If it does, then we could retrieve the current suite (see documentation [here](https://docs.greatexpectations.io/docs/oss/guides/expectations/how_to_edit_an_existing_expectationsuite/#retrieve-an-existing-expectation-suite)) 