### PR TITLE
Fix FDS-2251 NF annotation upload

### DIFF
--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -784,12 +784,19 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         """
         if not node_label:
             assert node_display_name is not None
-            node_label = self.get_node_label(node_display_name)
+            try:
+                node_label = self.get_node_label(node_display_name)
+            except KeyError as exc:
+                raise ValueError(
+                    f"The source node {node_label} does not exist in the graph. "
+                    "Please use a different node or check the attribute label."
+                ) from exc
 
         if not node_label:
             return []
 
-        node_validation_rules = self.graph.nodes[node_label]["validationRules"]
+        node = self.graph.node.get(node_label)
+        node_validation_rules = node.get("validationRules")
 
         return node_validation_rules
 

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -784,19 +784,12 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         """
         if not node_label:
             assert node_display_name is not None
-            try:
-                node_label = self.get_node_label(node_display_name)
-            except KeyError as exc:
-                raise ValueError(
-                    f"The source node {node_label} does not exist in the graph. "
-                    "Please use a different node or check the attribute label."
-                ) from exc
+            node_label = self.get_node_label(node_display_name)
 
         if not node_label:
             return []
 
-        node = self.graph.node.get(node_label)
-        node_validation_rules = node.get("validationRules")
+        node_validation_rules = self.graph.nodes[node_label]["validationRules"]
 
         return node_validation_rules
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1404,11 +1404,14 @@ class SynapseStorage(BaseStorage):
                 elif (
                     isinstance(anno_v, str)
                     and re.fullmatch(csv_list_regex, anno_v)
-                    and rule_in_rule_list(
-                        "list", dmge.get_node_validation_rules(anno_k)
-                    )
                 ):
-                    annos[anno_k] = anno_v.split(",")
+                    rule_list = []
+                    if annotation_keys == "class_label":
+                        rule_list = dmge.get_node_validation_rules(node_label=anno_k)
+                    else:
+                        rule_list = dmge.get_node_validation_rules(node_display_name=anno_k)
+                    if rule_in_rule_list("list", rule_list):
+                        annos[anno_k] = anno_v.split(",")
                 else:
                     annos[anno_k] = anno_v
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1367,7 +1367,7 @@ class SynapseStorage(BaseStorage):
         blacklist_chars = ["(", ")", ".", " ", "-"]
 
         for k, v in row.to_dict().items():
-            keySyn = None
+            keySyn = str(k)
             if annotation_keys == "display_label":
                 keySyn = str(k).translate({ord(x): "" for x in blacklist_chars})
             elif annotation_keys == "class_label":

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1367,16 +1367,16 @@ class SynapseStorage(BaseStorage):
         blacklist_chars = ["(", ")", ".", " ", "-"]
 
         for k, v in row.to_dict().items():
-            keySyn = str(k)
+            keysyn = str(k)
             if annotation_keys == "display_label":
-                keySyn = str(k).translate({ord(x): "" for x in blacklist_chars})
+                kesSyn = str(k).translate({ord(x): "" for x in blacklist_chars})
             elif annotation_keys == "class_label":
-                keySyn = get_class_label_from_display_name(str(k)).translate(
+                keysyn = get_class_label_from_display_name(str(k)).translate(
                     {ord(x): "" for x in blacklist_chars}
                 )
 
             # Skip `Filename` and `ETag` columns when setting annotations
-            if keySyn in ["Filename", "ETag", "eTag"]:
+            if keysyn in ["Filename", "ETag", "eTag"]:
                 continue
 
             # truncate annotation values to 500 characters if the
@@ -1387,7 +1387,7 @@ class SynapseStorage(BaseStorage):
             if isinstance(v, str) and len(v) >= 500:
                 v = v[0:472] + "[truncatedByDataCuratorApp]"
 
-            metadataSyn[keySyn] = v
+            metadataSyn[keysyn] = v
         # set annotation(s) for the various objects/items in a dataset on Synapse
         annos = self.syn.get_annotations(entityId)
         csv_list_regex = comma_separated_list_regex()
@@ -1642,9 +1642,11 @@ class SynapseStorage(BaseStorage):
             dmge: DataModelGraphExplorer object,
             row: current row of manifest being processed
             entityId (str): synapseId of entity to add annotations to
-            hideBlanks: Boolean flag that does not upload annotation keys with blank values when true. Uploads Annotation keys with empty string values when false.
-            annotation_keys:  (str) display_label/class_label(default), Determines labeling syle for annotation keys. class_label will format the display
-                name as upper camelcase, and strip blacklisted characters, display_label will strip blacklisted characters including spaces, to retain
+            hideBlanks: Boolean flag that does not upload annotation keys with blank values when true.
+                Uploads Annotation keys with empty string values when false.
+            annotation_keys:  (str) display_label/class_label(default), Determines labeling syle for annotation keys.
+                class_label will format the display name as upper camelcase, and strip blacklisted characters,
+                display_label will strip blacklisted characters including spaces, to retain
                 display label formatting while ensuring the label is formatted properly for Synapse annotations.
         Returns:
             Annotations are added to entities in Synapse, no return.
@@ -1693,19 +1695,23 @@ class SynapseStorage(BaseStorage):
         Args:
             dmge: DataModelGraphExplorer Object
             manifest (pd.DataFrame): loaded df containing user supplied data.
-            manifest_record_type: valid values are 'entity', 'table' or 'both'. Specifies whether to create entity ids and folders for each row in a manifest, a Synapse table to house the entire manifest or do both.
+            manifest_record_type: valid values are 'entity', 'table' or 'both'. Specifies whether to create entity ids
+            and folders for each row in a manifest, a Synapse table to house the entire manifest or do both.
             datasetId (str): synapse ID of folder containing the dataset
-            hideBlanks (bool): Default is false -Boolean flag that does not upload annotation keys with blank values when true. Uploads Annotation keys with empty string values when false.
+            hideBlanks (bool): Default is false -Boolean flag that does not upload annotation keys with blank values
+                when true. Uploads Annotation keys with empty string values when false.
             manifest_synapse_table_id (str): Default is an empty string ''.
-            annotation_keys: (str) display_label/class_label(default), Determines labeling syle for annotation keys. class_label will format the display
-                name as upper camelcase, and strip blacklisted characters, display_label will strip blacklisted characters including spaces, to retain
+            annotation_keys: (str) display_label/class_label(default), Determines labeling syle for annotation keys.
+                class_label will format the display name as upper camelcase, and strip blacklisted characters,
+                display_label will strip blacklisted characters including spaces, to retain
                 display label formatting while ensuring the label is formatted properly for Synapse annotations.
         Returns:
             manifest (pd.DataFrame): modified to add entitiyId as appropriate
 
         """
 
-        # Expected behavior is to annotate files if `Filename` is present and if file_annotations_upload is set to True regardless of `-mrt` setting
+        # Expected behavior is to annotate files if `Filename` is present and if file_annotations_upload is set
+        # to True regardless of `-mrt` setting
         if "filename" in [col.lower() for col in manifest.columns]:
             # get current list of files and store as dataframe
             dataset_files = self.getFilesInStorageDataset(datasetId)

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1367,6 +1367,7 @@ class SynapseStorage(BaseStorage):
         blacklist_chars = ["(", ")", ".", " ", "-"]
 
         for k, v in row.to_dict().items():
+            keySyn = None
             if annotation_keys == "display_label":
                 keySyn = str(k).translate({ord(x): "" for x in blacklist_chars})
             elif annotation_keys == "class_label":

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -1402,15 +1402,14 @@ class SynapseStorage(BaseStorage):
             else:
                 if isinstance(anno_v, float) and np.isnan(anno_v):
                     annos[anno_k] = ""
-                elif (
-                    isinstance(anno_v, str)
-                    and re.fullmatch(csv_list_regex, anno_v)
-                ):
+                elif isinstance(anno_v, str) and re.fullmatch(csv_list_regex, anno_v):
                     rule_list = []
                     if annotation_keys == "class_label":
                         rule_list = dmge.get_node_validation_rules(node_label=anno_k)
                     else:
-                        rule_list = dmge.get_node_validation_rules(node_display_name=anno_k)
+                        rule_list = dmge.get_node_validation_rules(
+                            node_display_name=anno_k
+                        )
                     if rule_in_rule_list("list", rule_list):
                         annos[anno_k] = anno_v.split(",")
                 else:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1014,7 +1014,13 @@ class TestManifestUpload:
                         "IsImportantText": "FALSE",
                     },
                 ]
-            )
+            ),
+            pd.DataFrame.from_records([
+                {"Check List": "a,b,c"},
+                {"CheckList": "a,b,c"},
+                {"CheckListLike": "a,b,c"},
+                {"checklist": "a,b,c"},
+            ])
         ]
     )
     def test_format_row_annotations(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -989,37 +989,11 @@ class TestManifestUpload:
     @pytest.mark.parametrize(
         "row",
         [
-            pd.DataFrame.from_records(
-                [
-                    {
-                        "Filename": "TestDataset-Annotations-v3/Sample_A.txt",
-                        "author": "bruno, milen, sujay",
-                        "impact": "42.9",
-                        "confidence": "high",
-                        "FileFormat": "txt",
-                        "YearofBirth": "1980",
-                        "IsImportantBool": "True",
-                        "IsImportantText": "TRUE",
-                    },
-                    {
-                        "Filename": "TestDataset-Annotations-v3/Sample_B.txt",
-                        "confidence": "low",
-                        "FileFormat": "csv",
-                        "date": "2020-02-01",
-                    },
-                    {
-                        "Filename": "TestDataset-Annotations-v3/Sample_C.txt",
-                        "FileFormat": "fastq",
-                        "IsImportantBool": "False",
-                        "IsImportantText": "FALSE",
-                    },
-                ]
-            ),
             pd.DataFrame.from_records([
-                {"Check List": "a,b,c"},
-                {"CheckList": "a,b,c"},
-                {"CheckListLike": "a,b,c"},
-                {"checklist": "a,b,c"},
+                {"Check List": "a,b,c",
+                "CheckList": "a,b,c",
+                "CheckListLike": "a,b,c",
+                "checklist": "a,b,c"}
             ])
         ]
     )
@@ -1034,6 +1008,7 @@ class TestManifestUpload:
         annos = synapse_store.format_row_annotations(
             dmge, row=row, annotation_keys=annotation_keys, hideBlanks=True, entityId="syn52786042"
         )
+        assert annos.get("Check List") == {0: 'a,b,c'}
 
     @pytest.mark.parametrize(
         "mock_manifest_file_path",

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -931,6 +931,13 @@ class TestManifestUpload:
             ),
         ],
     )
+    @pytest.mark.parametrize(
+        "annotation_keys",
+        [
+          "class_label",
+          "display_label"
+        ]
+    )
     def test_add_annotations_to_entities_files(
         self,
         synapse_store: SynapseStorage,
@@ -939,6 +946,7 @@ class TestManifestUpload:
         files_in_dataset: str,
         expected_filenames: list[str],
         expected_entity_ids: list[str],
+        annotation_keys: str
     ) -> None:
         """test adding annotations to entities files
 
@@ -963,6 +971,7 @@ class TestManifestUpload:
                 manifest_record_type="entity",
                 datasetId="mock id",
                 hideBlanks=True,
+                annotation_keys=annotation_keys
             )
             file_names_lst = new_df["Filename"].tolist()
             entity_ids_lst = new_df["entityId"].tolist()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -958,6 +958,7 @@ class TestManifestUpload:
             files_in_dataset (str): mock entityid and file name returned by getFilesInStorageDataset function
             expected_filenames (list(str)): expected list of file names
             expected_entity_ids (list(str)): expected list of entity ids
+            annotation_keys (str): class_label or display_label
         """
         with patch(
             "schematic.store.synapse.SynapseStorage.getFilesInStorageDataset",
@@ -981,6 +982,52 @@ class TestManifestUpload:
             assert "Id" in new_df.columns
             assert file_names_lst == expected_filenames
             assert entity_ids_lst == expected_entity_ids
+
+    @pytest.mark.parametrize(
+        "annotation_keys", "['class_label', 'display_label']"
+    )
+    @pytest.mark.parametrize(
+        "row",
+        [
+            pd.DataFrame.from_records(
+                [
+                    {
+                        "Filename": "TestDataset-Annotations-v3/Sample_A.txt",
+                        "author": "bruno, milen, sujay",
+                        "impact": "42.9",
+                        "confidence": "high",
+                        "FileFormat": "txt",
+                        "YearofBirth": "1980",
+                        "IsImportantBool": "True",
+                        "IsImportantText": "TRUE",
+                    },
+                    {
+                        "Filename": "TestDataset-Annotations-v3/Sample_B.txt",
+                        "confidence": "low",
+                        "FileFormat": "csv",
+                        "date": "2020-02-01",
+                    },
+                    {
+                        "Filename": "TestDataset-Annotations-v3/Sample_C.txt",
+                        "FileFormat": "fastq",
+                        "IsImportantBool": "False",
+                        "IsImportantText": "FALSE",
+                    },
+                ]
+            )
+        ]
+    )
+    def test_format_row_annotations(
+        self,
+        helpers: Helpers,
+        synapse_store: SynapseStorage,
+        dmge: DataModelGraphExplorer,
+        row,
+        annotation_keys: str
+    ) -> dict:
+        annos = synapse_store.format_row_annotations(
+            dmge, row=row, annotation_keys=annotation_keys, hideBlanks=True, entityId="syn52786042"
+        )
 
     @pytest.mark.parametrize(
         "mock_manifest_file_path",

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1017,6 +1017,7 @@ class TestManifestUpload:
             "mock_manifests/test_mock_manifest_censored.csv",
         ],
     )
+
     def test_upload_manifest_file(
         self,
         helpers: Helpers,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1017,7 +1017,6 @@ class TestManifestUpload:
             "mock_manifests/test_mock_manifest_censored.csv",
         ],
     )
-
     def test_upload_manifest_file(
         self,
         helpers: Helpers,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -931,13 +931,7 @@ class TestManifestUpload:
             ),
         ],
     )
-    @pytest.mark.parametrize(
-        "annotation_keys",
-        [
-          "class_label",
-          "display_label"
-        ]
-    )
+    @pytest.mark.parametrize("annotation_keys", ["class_label", "display_label"])
     def test_add_annotations_to_entities_files(
         self,
         synapse_store: SynapseStorage,
@@ -946,7 +940,7 @@ class TestManifestUpload:
         files_in_dataset: str,
         expected_filenames: list[str],
         expected_entity_ids: list[str],
-        annotation_keys: str
+        annotation_keys: str,
     ) -> None:
         """test adding annotations to entities files
 
@@ -972,7 +966,7 @@ class TestManifestUpload:
                 manifest_record_type="entity",
                 datasetId="mock id",
                 hideBlanks=True,
-                annotation_keys=annotation_keys
+                annotation_keys=annotation_keys,
             )
             file_names_lst = new_df["Filename"].tolist()
             entity_ids_lst = new_df["entityId"].tolist()
@@ -983,19 +977,21 @@ class TestManifestUpload:
             assert file_names_lst == expected_filenames
             assert entity_ids_lst == expected_entity_ids
 
-    @pytest.mark.parametrize(
-        "annotation_keys", "['class_label', 'display_label']"
-    )
+    @pytest.mark.parametrize("annotation_keys", "['class_label', 'display_label']")
     @pytest.mark.parametrize(
         "row",
         [
-            pd.DataFrame.from_records([
-                {"Check List": "a,b,c",
-                "CheckList": "a,b,c",
-                "CheckListLike": "a,b,c",
-                "checklist": "a,b,c"}
-            ])
-        ]
+            pd.DataFrame.from_records(
+                [
+                    {
+                        "Check List": "a,b,c",
+                        "CheckList": "a,b,c",
+                        "CheckListLike": "a,b,c",
+                        "checklist": "a,b,c",
+                    }
+                ]
+            )
+        ],
     )
     def test_format_row_annotations(
         self,
@@ -1003,12 +999,16 @@ class TestManifestUpload:
         synapse_store: SynapseStorage,
         dmge: DataModelGraphExplorer,
         row,
-        annotation_keys: str
+        annotation_keys: str,
     ) -> dict:
         annos = synapse_store.format_row_annotations(
-            dmge, row=row, annotation_keys=annotation_keys, hideBlanks=True, entityId="syn52786042"
+            dmge,
+            row=row,
+            annotation_keys=annotation_keys,
+            hideBlanks=True,
+            entityId="syn52786042",
         )
-        assert annos.get("Check List") == {0: 'a,b,c'}
+        assert annos.get("Check List") == {0: "a,b,c"}
 
     @pytest.mark.parametrize(
         "mock_manifest_file_path",


### PR DESCRIPTION
This fixes a bug described in FDS-2251. The user was trying to submit with `annotation_keys=display_label` and got `keyError` errors. 

The solution is to update `format_row_annotations` to call `get_node_validation_rules` with `node_label` when `annotation_keys=class_label` and `node_display_name` when `annotation_keys=display_label`.

This PR also fixes an issue discovered during testing where the annotation key, `keySyn` does not get assigned and `metadataSyn[keySyn] = v` fails.

Tests for `format_row_annotations` are added to test/test_store.py.