### PR TITLE
Add codeowners so PR's are automatically tagged with reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @Sage-Bionetworks/fair-data
+* @Sage-Bionetworks/python-client-developers


### PR DESCRIPTION
**Problem**
Code reviewers have to be assigned manually per PR.

**Solution**
Add codeowners so PR's are automatically tagged with reviewers