### PR TITLE
fix: updated test after updating to synapse python client 4.4.0 and updated test after test resources get updated on synapse

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
         run: >
           source .venv/bin/activate;
           pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
-          -m "not (schematic_api or table_operations)" --reruns 2 -n auto
+          -m "not (schematic_api or table_operations)" --reruns 2
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
         run: >
           source .venv/bin/activate;
           pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
-          -m "not (schematic_api or table_operations)" --reruns 2
+          -m "not (schematic_api or table_operations)" --reruns 2 -n auto
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v2

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -798,4 +798,4 @@ class TestManifestGenerator:
             assert n_rows == 4
         elif component == "BulkRNA-seqAssay":
             assert filename_in_manifest_columns
-            assert n_rows == 3
+            assert n_rows == 4

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -641,7 +641,7 @@ class TestSynapseStorage:
         ) as mock_store_async:
             result = await synapse_store.store_async_annotation(annos_dict)
 
-            mock_store_async.assert_called_once_with(synapse_store.syn)
+            mock_store_async.assert_called_once_with(synapse_client=synapse_store.syn)
             assert result == expected_dict
             assert isinstance(result, Annotations)
 


### PR DESCRIPTION
## Problem: 
I noticed the following test failed in develop: 
```
FAILED tests/test_store.py::TestSynapseStorage::test_store_async_annotation - AssertionError: expected call not found.
```
And also this test failed: 
```
FAILED tests/test_manifest.py::TestManifestGenerator::test_get_manifest_with_files[File based] 
```
Related to: https://sagebionetworks.jira.com/browse/FDS-2304

## Reason 
left over from: https://github.com/Sage-Bionetworks/schematic/pull/1468. After updating to synapse python client, this test needs to be updated

And also the following tests were skipped in github action [run](https://github.com/Sage-Bionetworks/schematic/actions/runs/10550260545/job/29226221198): 
```
[gw0] [ 86%] SKIPPED tests/test_store.py::TestSynapseStorage::test_format_row_annotations_entity_id_trash_can[True-display_label] 
tests/test_store.py::TestSynapseStorage::test_format_row_annotations_entity_id_trash_can[False-display_label] 
[gw0] [ 86%] SKIPPED tests/test_store.py::TestSynapseStorage::test_format_row_annotations_entity_id_trash_can[False-display_label] 
tests/test_store.py::TestSynapseStorage::test_format_row_annotations_entity_id_trash_can[True-class_label] 
[gw0] [ 86%] SKIPPED tests/test_store.py::TestSynapseStorage::test_format_row_annotations_entity_id_trash_can[True-class_label] 
tests/test_store.py::TestSynapseStorage::test_format_row_annotations_entity_id_trash_can[False-class_label] 
[gw0] [ 86%] SKIPPED tests/test_store.py::TestSynapseStorage::test_format_row_annotations_entity_id_trash_can[False-class_label] 
tests/test_store.py::TestSynapseStorage::test_get_files_metadata_from_dataset 
[gw0] [ 86%] PASSED tests/test_store.py::TestSynapseStorage::test_get_files_metadata_from_dataset 
tests/test_store.py::TestSynapseStorage::test_get_async_annotation 
[gw0] [ 87%] SKIPPED tests/test_store.py::TestSynapseStorage::test_get_async_annotation 
tests/test_store.py::TestSynapseStorage::test_store_async_annotation 
[gw0] [ 87%] SKIPPED tests/test_store.py::TestSynapseStorage::test_store_async_annotation 
tests/test_store.py::TestSynapseStorage::test_process_store_annos_failure 
[gw0] [ 87%] SKIPPED tests/test_store.py::TestSynapseStorage::test_process_store_annos_failure 
tests/test_store.py::TestSynapseStorage::test_process_store_annos_success_store 
[gw0] [ 87%] SKIPPED tests/test_store.py::TestSynapseStorage::test_process_store_annos_success_store 
tests/test_store.py::TestSynapseStorage::test_process_store_annos_success_get 
[gw0] [ 87%] SKIPPED tests/test_store.py::TestSynapseStorage::test_process_store_annos_success_get 
tests/test_store.py::TestSynapseStorage::test_process_store_annos_success_get_entity_id_variants 
[gw0] [ 87%] SKIPPED tests/test_store.py::TestSynapseStorage::test_process_store_annos_success_get_entity_id_variants 
tests/test_store.py::TestSynapseStorage::test_process_store_annos_get_annos_empty 
[gw0] [ 87%] SKIPPED tests/test_store.py::TestSynapseStorage::test_process_store_annos_get_annos_empty 
tests/test_store.py::TestDatasetFileView::test_init 
```

## Solution
* update the test to use the new method from synapse python client
* investigate why the tests were skipped will be in a separate ticket: FDS 2305