### PR TITLE
[FDS-2294] Prevent including project name twice in walked path

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -547,7 +547,8 @@ class SynapseStorage(BaseStorage):
         Raises:
             ValueError: Dataset ID not found.
         """
-        # select all files within a given storage dataset folder (top level folder in a Synapse storage project or folder marked with contentType = 'dataset')
+        # select all files within a given storage dataset folder (top level folder in
+        # a Synapse storage project or folder marked with contentType = 'dataset')
         walked_path = synapseutils.walk(
             self.syn, datasetId, includeTypes=["folder", "file"]
         )
@@ -557,25 +558,36 @@ class SynapseStorage(BaseStorage):
         file_list = []
 
         # iterate over all results
-        for dirpath, dirname, filenames in walked_path:
+        for dirpath, _, path_filenames in walked_path:
             # iterate over all files in a folder
-            for filename in filenames:
-                if (not "manifest" in filename[0] and not fileNames) or (
-                    fileNames and filename[0] in fileNames
+            for path_filename in path_filenames:
+                if ("manifest" not in path_filename[0] and not fileNames) or (
+                    fileNames and path_filename[0] in fileNames
                 ):
-                    # don't add manifest to list of files unless it is specified in the list of specified fileNames; return all found files
+                    # don't add manifest to list of files unless it is specified in the
+                    # list of specified fileNames; return all found files
                     # except the manifest if no fileNames have been specified
                     # TODO: refactor for clarity/maintainability
 
                     if fullpath:
                         # append directory path to filename
-                        filename = (
-                            project_name + "/" + dirpath[0] + "/" + filename[0],
-                            filename[1],
-                        )
+                        if dirpath[0].startswith(f"{project_name}/"):
+                            path_filename = (
+                                dirpath[0] + "/" + path_filename[0],
+                                path_filename[1],
+                            )
+                        else:
+                            path_filename = (
+                                project_name
+                                + "/"
+                                + dirpath[0]
+                                + "/"
+                                + path_filename[0],
+                                path_filename[1],
+                            )
 
                     # add file name file id tuple, rearranged so that id is first and name follows
-                    file_list.append(filename[::-1])
+                    file_list.append(path_filename[::-1])
 
         return file_list
 
@@ -655,8 +667,8 @@ class SynapseStorage(BaseStorage):
                 manifest_data = ManifestDownload.download_manifest(
                     md, newManifestName=newManifestName, manifest_df=manifest
                 )
-                ## TO DO: revisit how downstream code handle manifest_data. If the downstream code would break when manifest_data is an empty string,
-                ## then we should catch the error here without returning an empty string.
+                # TO DO: revisit how downstream code handle manifest_data. If the downstream code would break when manifest_data is an empty string,
+                # then we should catch the error here without returning an empty string.
                 if not manifest_data:
                     logger.debug(
                         f"No manifest data returned. Please check if you have successfully downloaded manifest: {manifest_syn_id}"
@@ -3024,6 +3036,8 @@ class DatasetFileView:
         for col in int_columns:
             # Coercing to string because NaN is a floating point value
             # and cannot exist alongside integers in a column
-            to_int_fn = lambda x: "" if np.isnan(x) else str(int(x))
+            def to_int_fn(x):
+                return "" if np.isnan(x) else str(int(x))
+
             self.table[col] = self.table[col].apply(to_int_fn)
         return self.table

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -586,7 +586,7 @@ def get_storage_projects_datasets(asset_view, project_id):
 
 
 def get_files_storage_dataset(
-    asset_view, dataset_id, full_path, file_names=None
+    asset_view: str, dataset_id: str, full_path: bool, file_names: List[str] = None
 ) -> List[Tuple[str, str]]:
     # Access token now stored in request header
     access_token = get_access_token()

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import pathlib
@@ -8,12 +7,10 @@ import tempfile
 import time
 import urllib.request
 from functools import wraps
-from json.decoder import JSONDecodeError
-from typing import Any, List, Optional
+from typing import List, Tuple
 
 import connexion
 import pandas as pd
-from connexion.decorators.uri_parsing import Swagger2URIParser
 from flask import current_app as app
 from flask import request, send_from_directory
 from flask_cors import cross_origin
@@ -28,14 +25,6 @@ from opentelemetry.sdk.trace.export import (
     Span,
 )
 from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
-from synapseclient.core.exceptions import (
-    SynapseAuthenticationError,
-    SynapseHTTPError,
-    SynapseNoCredentialsError,
-    SynapseTimeoutError,
-    SynapseUnmetAccessRestrictions,
-)
-from werkzeug.debug import DebuggedApplication
 
 from schematic.configuration.configuration import CONFIG
 from schematic.manifest.generator import ManifestGenerator
@@ -457,7 +446,7 @@ def validate_manifest_route(
     return res_dict
 
 
-#####profile validate manifest route function
+# profile validate manifest route function
 @trace_function_params()
 def submit_manifest_route(
     schema_url,
@@ -596,7 +585,9 @@ def get_storage_projects_datasets(asset_view, project_id):
     return sorted_dataset_lst
 
 
-def get_files_storage_dataset(asset_view, dataset_id, full_path, file_names=None):
+def get_files_storage_dataset(
+    asset_view, dataset_id, full_path, file_names=None
+) -> List[Tuple[str, str]]:
     # Access token now stored in request header
     access_token = get_access_token()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,35 +3,35 @@ import json
 import logging
 import os
 import re
-import time
 from math import ceil
 from time import perf_counter
+from typing import Dict, Generator, List, Tuple, Union
 
-import numpy as np
+import flask
 import pandas as pd  # third party library import
 import pytest
+from flask.testing import FlaskClient
 
 from schematic.configuration.configuration import Configuration
-from schematic.schemas.data_model_parser import DataModelParser
 from schematic.schemas.data_model_graph import DataModelGraph, DataModelGraphExplorer
-from schematic.schemas.data_model_relationships import DataModelRelationships
-
+from schematic.schemas.data_model_parser import DataModelParser
 from schematic_api.api import create_app
-
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+BENCHMARK_DATA_MODEL_JSON_LD = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.single_rule.model.jsonld"
+DATA_MODEL_JSON_LD = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld"
 
-## TO DO: Clean up url and use a global variable SERVER_URL
+
 @pytest.fixture(scope="class")
-def app():
+def app() -> flask.Flask:
     app = create_app()
-    yield app
+    return app
 
 
 @pytest.fixture(scope="class")
-def client(app):
+def client(app: flask.Flask) -> Generator[FlaskClient, None, None]:
     app.config["SCHEMATIC_CONFIG"] = None
 
     with app.test_client() as client:
@@ -39,62 +39,49 @@ def client(app):
 
 
 @pytest.fixture(scope="class")
-def test_manifest_csv(helpers):
+def test_manifest_csv(helpers) -> str:
     test_manifest_path = helpers.get_data_path("mock_manifests/Valid_Test_Manifest.csv")
-    yield test_manifest_path
+    return test_manifest_path
 
 
 @pytest.fixture(scope="class")
-def test_manifest_submit(helpers):
+def test_manifest_submit(helpers) -> str:
     test_manifest_path = helpers.get_data_path(
         "mock_manifests/example_biospecimen_test.csv"
     )
-    yield test_manifest_path
+    return test_manifest_path
 
 
 @pytest.fixture(scope="class")
-def test_invalid_manifest(helpers):
+def test_invalid_manifest(helpers) -> pd.DataFrame:
     test_invalid_manifest = helpers.get_data_frame(
         "mock_manifests/Invalid_Test_Manifest.csv", preserve_raw_input=False
     )
-    yield test_invalid_manifest
+    return test_invalid_manifest
 
 
 @pytest.fixture(scope="class")
-def test_upsert_manifest_csv(helpers):
+def test_upsert_manifest_csv(helpers) -> str:
     test_upsert_manifest_path = helpers.get_data_path(
         "mock_manifests/rdb_table_manifest.csv"
     )
-    yield test_upsert_manifest_path
+    return test_upsert_manifest_path
 
 
 @pytest.fixture(scope="class")
-def test_manifest_json(helpers):
+def test_manifest_json(helpers) -> str:
     test_manifest_path = helpers.get_data_path(
         "mock_manifests/Example.Patient.manifest.json"
     )
-    yield test_manifest_path
+    return test_manifest_path
 
 
-@pytest.fixture(scope="class")
-def data_model_jsonld():
-    data_model_jsonld = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld"
-    yield data_model_jsonld
-
-
-@pytest.fixture(scope="class")
-def benchmark_data_model_jsonld():
-    benchmark_data_model_jsonld = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.single_rule.model.jsonld"
-    yield benchmark_data_model_jsonld
-
-
-def get_MockComponent_attribute():
+def get_MockComponent_attribute() -> Generator[str, None, None]:
     """
     Yield all of the mock conponent attributes one at a time
     TODO: pull in jsonld from fixture
     """
-    schema_url = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.single_rule.model.jsonld"
-    data_model_parser = DataModelParser(path_to_data_model=schema_url)
+    data_model_parser = DataModelParser(path_to_data_model=BENCHMARK_DATA_MODEL_JSON_LD)
     # Parse Model
     parsed_data_model = data_model_parser.parse_model()
 
@@ -123,24 +110,26 @@ def syn_token(config: Configuration):
         token = os.environ["SYNAPSE_ACCESS_TOKEN"]
     else:
         token = config_parser["authentication"]["authtoken"]
-    yield token
+    return token
 
 
 @pytest.fixture
-def request_headers(syn_token):
+def request_headers(syn_token: str) -> Dict[str, str]:
     headers = {"Authorization": "Bearer " + syn_token}
-    yield headers
+    return headers
 
 
 @pytest.fixture
-def request_invalid_headers():
+def request_invalid_headers() -> Dict[str, str]:
     headers = {"Authorization": "Bearer invalid headers"}
-    yield headers
+    return headers
 
 
 @pytest.mark.schematic_api
 class TestSynapseStorage:
-    def test_invalid_authentication(self, client, request_invalid_headers):
+    def test_invalid_authentication(
+        self, client: FlaskClient, request_invalid_headers: Dict[str, str]
+    ) -> None:
         response = client.get(
             "http://localhost:3001/v1/storage/assets/tables",
             query_string={"asset_view": "syn23643253", "return_type": "csv"},
@@ -148,7 +137,9 @@ class TestSynapseStorage:
         )
         assert response.status_code == 401
 
-    def test_insufficent_auth(self, client, request_headers):
+    def test_insufficent_auth(
+        self, client: FlaskClient, request_headers: Dict[str, str]
+    ) -> None:
         response = client.get(
             "http://localhost:3001/v1/storage/assets/tables",
             query_string={"asset_view": "syn23643252", "return_type": "csv"},
@@ -158,7 +149,9 @@ class TestSynapseStorage:
 
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("return_type", ["json", "csv"])
-    def test_get_storage_assets_tables(self, client, return_type, request_headers):
+    def test_get_storage_assets_tables(
+        self, client: FlaskClient, return_type, request_headers: Dict[str, str]
+    ):
         params = {"asset_view": "syn23643253", "return_type": return_type}
 
         response = client.get(
@@ -186,7 +179,13 @@ class TestSynapseStorage:
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("full_path", [True, False])
     @pytest.mark.parametrize("file_names", [None, "Sample_A.txt"])
-    def test_get_dataset_files(self, full_path, file_names, request_headers, client):
+    def test_get_dataset_files(
+        self,
+        full_path: bool,
+        file_names: Union[str, None],
+        request_headers: Dict[str, str],
+        client: FlaskClient,
+    ) -> None:
         params = {
             "asset_view": "syn23643253",
             "dataset_id": "syn23643250",
@@ -203,7 +202,7 @@ class TestSynapseStorage:
         )
 
         assert response.status_code == 200
-        response_dt = json.loads(response.data)
+        response_dt: List[Tuple[str, str]] = json.loads(response.data)
 
         # would show full file path .txt in result
         if full_path:
@@ -238,13 +237,15 @@ class TestSynapseStorage:
                 ] not in response_dt
             else:
                 assert (
-                    ["syn23643256", "Sample_C.txt"]
-                    and ["syn24226530", "Sample_A.txt"]
+                    ["syn23643256", "Sample_C.txt"] in response_dt
+                    and ["syn24226530", "Sample_A.txt"] in response_dt
                     and ["syn24226531", "Sample_B.txt"] in response_dt
                 )
 
     @pytest.mark.synapse_credentials_needed
-    def test_get_storage_project_dataset(self, request_headers, client):
+    def test_get_storage_project_dataset(
+        self, request_headers: Dict[str, str], client: FlaskClient
+    ) -> None:
         params = {"asset_view": "syn23643253", "project_id": "syn26251192"}
 
         response = client.get(
@@ -257,7 +258,9 @@ class TestSynapseStorage:
         assert ["syn26251193", "Issue522"] in response_dt
 
     @pytest.mark.synapse_credentials_needed
-    def test_get_storage_project_manifests(self, request_headers, client):
+    def test_get_storage_project_manifests(
+        self, request_headers: Dict[str, str], client: FlaskClient
+    ) -> None:
         params = {"asset_view": "syn23643253", "project_id": "syn30988314"}
 
         response = client.get(
@@ -269,7 +272,9 @@ class TestSynapseStorage:
         assert response.status_code == 200
 
     @pytest.mark.synapse_credentials_needed
-    def test_get_storage_projects(self, request_headers, client):
+    def test_get_storage_projects(
+        self, request_headers: Dict[str, str], client: FlaskClient
+    ) -> None:
         params = {"asset_view": "syn23643253"}
 
         response = client.get(
@@ -282,7 +287,9 @@ class TestSynapseStorage:
 
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("entity_id", ["syn34640850", "syn23643253", "syn24992754"])
-    def test_get_entity_type(self, request_headers, client, entity_id):
+    def test_get_entity_type(
+        self, request_headers: Dict[str, str], client: FlaskClient, entity_id: str
+    ) -> None:
         params = {"asset_view": "syn23643253", "entity_id": entity_id}
         response = client.get(
             "http://localhost:3001/v1/storage/entity/type",
@@ -301,7 +308,9 @@ class TestSynapseStorage:
 
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.parametrize("entity_id", ["syn30988314", "syn27221721"])
-    def test_if_in_assetview(self, request_headers, client, entity_id):
+    def test_if_in_assetview(
+        self, request_headers: Dict[str, str], client: FlaskClient, entity_id: str
+    ) -> None:
         params = {"asset_view": "syn23643253", "entity_id": entity_id}
         response = client.get(
             "http://localhost:3001/v1/storage/if_in_asset_view",
@@ -320,9 +329,9 @@ class TestSynapseStorage:
 @pytest.mark.schematic_api
 class TestMetadataModelOperation:
     @pytest.mark.parametrize("as_graph", [True, False])
-    def test_component_requirement(self, client, data_model_jsonld, as_graph):
+    def test_component_requirement(self, client: FlaskClient, as_graph: bool) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "source_component": "BulkRNA-seqAssay",
             "as_graph": as_graph,
         }
@@ -347,7 +356,9 @@ class TestMetadataModelOperation:
 @pytest.mark.schematic_api
 class TestUtilsOperation:
     @pytest.mark.parametrize("strict_camel_case", [True, False])
-    def test_get_property_label_from_display_name(self, client, strict_camel_case):
+    def test_get_property_label_from_display_name(
+        self, client: FlaskClient, strict_camel_case: bool
+    ) -> None:
         params = {
             "display_name": "mocular entity",
             "strict_camel_case": strict_camel_case,
@@ -369,8 +380,8 @@ class TestUtilsOperation:
 
 @pytest.mark.schematic_api
 class TestDataModelGraphExplorerOperation:
-    def test_get_schema(self, client, data_model_jsonld):
-        params = {"schema_url": data_model_jsonld, "data_model_labels": "class_label"}
+    def test_get_schema(self, client: FlaskClient) -> None:
+        params = {"schema_url": DATA_MODEL_JSON_LD, "data_model_labels": "class_label"}
         response = client.get(
             "http://localhost:3001/v1/schemas/get/schema", query_string=params
         )
@@ -383,9 +394,9 @@ class TestDataModelGraphExplorerOperation:
         if os.path.exists(response_dt):
             os.remove(response_dt)
 
-    def test_if_node_required(test, client, data_model_jsonld):
+    def test_if_node_required(test, client: FlaskClient) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "node_display_name": "FamilyHistory",
             "data_model_labels": "class_label",
         }
@@ -397,9 +408,9 @@ class TestDataModelGraphExplorerOperation:
         assert response.status_code == 200
         assert response_dta == True
 
-    def test_get_node_validation_rules(test, client, data_model_jsonld):
+    def test_get_node_validation_rules(test, client: FlaskClient) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "node_display_name": "CheckRegexList",
         }
         response = client.get(
@@ -411,9 +422,9 @@ class TestDataModelGraphExplorerOperation:
         assert "list" in response_dta
         assert "regex match [a-f]" in response_dta
 
-    def test_get_nodes_display_names(test, client, data_model_jsonld):
+    def test_get_nodes_display_names(test, client: FlaskClient) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "node_list": ["FamilyHistory", "Biospecimen"],
         }
         response = client.get(
@@ -427,8 +438,8 @@ class TestDataModelGraphExplorerOperation:
     @pytest.mark.parametrize(
         "relationship", ["parentOf", "requiresDependency", "rangeValue", "domainValue"]
     )
-    def test_get_subgraph_by_edge(self, client, data_model_jsonld, relationship):
-        params = {"schema_url": data_model_jsonld, "relationship": relationship}
+    def test_get_subgraph_by_edge(self, client: FlaskClient, relationship: str) -> None:
+        params = {"schema_url": DATA_MODEL_JSON_LD, "relationship": relationship}
 
         response = client.get(
             "http://localhost:3001/v1/schemas/get/graph_by_edge_type",
@@ -439,10 +450,10 @@ class TestDataModelGraphExplorerOperation:
     @pytest.mark.parametrize("return_display_names", [True, False])
     @pytest.mark.parametrize("node_label", ["FamilyHistory", "TissueStatus"])
     def test_get_node_range(
-        self, client, data_model_jsonld, return_display_names, node_label
-    ):
+        self, client: FlaskClient, return_display_names: bool, node_label: str
+    ) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "return_display_names": return_display_names,
             "node_label": node_label,
         }
@@ -466,17 +477,16 @@ class TestDataModelGraphExplorerOperation:
     @pytest.mark.parametrize("source_node", ["Patient", "Biospecimen"])
     def test_node_dependencies(
         self,
-        client,
-        data_model_jsonld,
-        source_node,
-        return_display_names,
-        return_schema_ordered,
-    ):
+        client: FlaskClient,
+        source_node: str,
+        return_display_names: Union[bool, None],
+        return_schema_ordered: Union[bool, None],
+    ) -> None:
         return_display_names = True
         return_schema_ordered = False
 
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "source_node": source_node,
             "return_display_names": return_display_names,
             "return_schema_ordered": return_schema_ordered,
@@ -519,7 +529,7 @@ class TestDataModelGraphExplorerOperation:
 
 @pytest.mark.schematic_api
 class TestManifestOperation:
-    def ifExcelExists(self, response, file_name):
+    def ifExcelExists(self, response, file_name) -> None:
         # return one excel file
         d = response.headers["content-disposition"]
         fname = re.findall("filename=(.+)", d)[0]
@@ -543,13 +553,12 @@ class TestManifestOperation:
     )
     def test_generate_existing_manifest(
         self,
-        client,
-        data_model_jsonld,
-        data_type,
-        output_format,
-        caplog,
-        request_headers,
-    ):
+        client: FlaskClient,
+        data_type: str,
+        output_format: str,
+        caplog: pytest.LogCaptureFixture,
+        request_headers: Dict[str, str],
+    ) -> None:
         # set dataset
         if data_type == "Patient":
             dataset_id = ["syn51730545"]  # Mock Patient Manifest folder on synapse
@@ -561,7 +570,7 @@ class TestManifestOperation:
             dataset_id = None  # if "all manifests", dataset id is None
 
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "asset_view": "syn23643253",
             "title": "Example",
             "data_type": data_type,
@@ -627,15 +636,14 @@ class TestManifestOperation:
     )
     def test_generate_new_manifest(
         self,
-        caplog,
-        client,
-        data_model_jsonld,
-        data_type,
-        output_format,
-        request_headers,
-    ):
+        caplog: pytest.LogCaptureFixture,
+        client: FlaskClient,
+        data_type: str,
+        output_format: str,
+        request_headers: Dict[str, str],
+    ) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "asset_view": "syn23643253",
             "title": "Example",
             "data_type": data_type,
@@ -731,10 +739,10 @@ class TestManifestOperation:
         ],
     )
     def test_generate_manifest_file_based_annotations(
-        self, client, use_annotations, expected, data_model_jsonld
-    ):
+        self, client: FlaskClient, use_annotations: bool, expected: list[str]
+    ) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "data_type": "BulkRNA-seqAssay",
             "dataset_id": "syn25614635",
             "asset_view": "syn51707141",
@@ -781,10 +789,10 @@ class TestManifestOperation:
     # test case: generate a manifest with annotations when use_annotations is set to True for a component that is not file-based
     # the dataset folder does not contain an existing manifest
     def test_generate_manifest_not_file_based_with_annotations(
-        self, client, data_model_jsonld
-    ):
+        self, client: FlaskClient
+    ) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "data_type": "Patient",
             "dataset_id": "syn25614635",
             "asset_view": "syn51707141",
@@ -816,9 +824,9 @@ class TestManifestOperation:
             ]
         )
 
-    def test_generate_manifest_data_type_not_found(self, client, data_model_jsonld):
+    def test_generate_manifest_data_type_not_found(self, client: FlaskClient) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "data_type": "wrong data type",
             "use_annotations": False,
         }
@@ -829,13 +837,15 @@ class TestManifestOperation:
         assert response.status_code == 500
         assert "LookupError" in str(response.data)
 
-    def test_populate_manifest(self, client, data_model_jsonld, test_manifest_csv):
+    def test_populate_manifest(
+        self, client: FlaskClient, test_manifest_csv: str
+    ) -> None:
         # test manifest
         test_manifest_data = open(test_manifest_csv, "rb")
 
         params = {
             "data_type": "MockComponent",
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "title": "Example",
             "csv_file": test_manifest_data,
         }
@@ -861,14 +871,13 @@ class TestManifestOperation:
     )
     def test_validate_manifest(
         self,
-        data_model_jsonld,
-        client,
-        json_str,
-        restrict_rules,
-        test_manifest_csv,
-        request_headers,
-    ):
-        params = {"schema_url": data_model_jsonld, "restrict_rules": restrict_rules}
+        client: FlaskClient,
+        json_str: Union[str, None],
+        restrict_rules: Union[bool, None],
+        test_manifest_csv: str,
+        request_headers: Dict[str, str],
+    ) -> None:
+        params = {"schema_url": DATA_MODEL_JSON_LD, "restrict_rules": restrict_rules}
 
         if json_str:
             params["json_str"] = json_str
@@ -908,7 +917,9 @@ class TestManifestOperation:
         assert "warnings" in response_dt.keys()
 
     @pytest.mark.synapse_credentials_needed
-    def test_get_datatype_manifest(self, client, request_headers):
+    def test_get_datatype_manifest(
+        self, client: FlaskClient, request_headers: Dict[str, str]
+    ) -> None:
         params = {"asset_view": "syn23643253", "manifest_id": "syn27600110"}
 
         response = client.get(
@@ -944,14 +955,14 @@ class TestManifestOperation:
     def test_manifest_download(
         self,
         config: Configuration,
-        client,
-        request_headers,
-        manifest_id,
-        new_manifest_name,
-        as_json,
-        expected_component,
-        expected_file_name,
-    ):
+        client: FlaskClient,
+        request_headers: Dict[str, str],
+        manifest_id: str,
+        new_manifest_name: str,
+        as_json: Union[bool, None],
+        expected_component: str,
+        expected_file_name: str,
+    ) -> None:
         params = {
             "manifest_id": manifest_id,
             "new_manifest_name": new_manifest_name,
@@ -1006,7 +1017,9 @@ class TestManifestOperation:
 
     @pytest.mark.synapse_credentials_needed
     # test downloading a manifest with access restriction and see if the correct error message got raised
-    def test_download_access_restricted_manifest(self, client, request_headers):
+    def test_download_access_restricted_manifest(
+        self, client: FlaskClient, request_headers: Dict[str, str]
+    ) -> None:
         params = {"manifest_id": "syn29862078"}
 
         response = client.get(
@@ -1023,8 +1036,12 @@ class TestManifestOperation:
     @pytest.mark.parametrize("as_json", [None, True, False])
     @pytest.mark.parametrize("new_manifest_name", [None, "Test"])
     def test_dataset_manifest_download(
-        self, client, as_json, request_headers, new_manifest_name
-    ):
+        self,
+        client: FlaskClient,
+        as_json: Union[bool, None],
+        request_headers: Dict[str, str],
+        new_manifest_name: Union[str, None],
+    ) -> None:
         params = {
             "asset_view": "syn28559058",
             "dataset_id": "syn28268700",
@@ -1056,11 +1073,14 @@ class TestManifestOperation:
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.submission
     def test_submit_manifest_table_and_file_replace(
-        self, client, request_headers, data_model_jsonld, test_manifest_submit
-    ):
+        self,
+        client: FlaskClient,
+        request_headers: Dict[str, str],
+        test_manifest_submit: str,
+    ) -> None:
         """Testing submit manifest in a csv format as a table and a file. Only replace the table"""
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "data_type": "Biospecimen",
             "restrict_rules": False,
             "hide_blanks": False,
@@ -1092,16 +1112,15 @@ class TestManifestOperation:
     def test_submit_manifest_file_only_replace(
         self,
         helpers,
-        client,
-        request_headers,
-        data_model_jsonld,
-        data_type,
-        manifest_path_fixture,
-        request,
-    ):
+        client: FlaskClient,
+        request_headers: Dict[str, str],
+        data_type: str,
+        manifest_path_fixture: str,
+        request: pytest.FixtureRequest,
+    ) -> None:
         """Testing submit manifest in a csv format as a file"""
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "data_type": data_type,
             "restrict_rules": False,
             "manifest_record_type": "file_only",
@@ -1144,12 +1163,12 @@ class TestManifestOperation:
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.submission
     def test_submit_manifest_json_str_replace(
-        self, client, request_headers, data_model_jsonld
-    ):
+        self, client: FlaskClient, request_headers: Dict[str, str]
+    ) -> None:
         """Submit json str as a file"""
         json_str = '[{"Sample ID": 123, "Patient ID": 1,"Tissue Status": "Healthy","Component": "Biospecimen"}]'
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "data_type": "Biospecimen",
             "json_str": json_str,
             "restrict_rules": False,
@@ -1172,10 +1191,13 @@ class TestManifestOperation:
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.submission
     def test_submit_manifest_w_file_and_entities(
-        self, client, request_headers, data_model_jsonld, test_manifest_submit
-    ):
+        self,
+        client: FlaskClient,
+        request_headers: Dict[str, str],
+        test_manifest_submit: str,
+    ) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "data_type": "Biospecimen",
             "restrict_rules": False,
             "manifest_record_type": "file_and_entities",
@@ -1200,13 +1222,12 @@ class TestManifestOperation:
     @pytest.mark.submission
     def test_submit_manifest_table_and_file_upsert(
         self,
-        client,
-        request_headers,
-        data_model_jsonld,
-        test_upsert_manifest_csv,
-    ):
+        client: FlaskClient,
+        request_headers: Dict[str, str],
+        test_upsert_manifest_csv: str,
+    ) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "data_type": "MockRDB",
             "restrict_rules": False,
             "manifest_record_type": "table_and_file",
@@ -1214,7 +1235,8 @@ class TestManifestOperation:
             "dataset_id": "syn51514551",
             "table_manipulation": "upsert",
             "data_model_labels": "class_label",
-            "table_column_names": "display_name",  # have to set table_column_names to display_name to ensure upsert feature works
+            # have to set table_column_names to display_name to ensure upsert feature works
+            "table_column_names": "display_name",
         }
 
         # test uploading a csv file
@@ -1229,8 +1251,8 @@ class TestManifestOperation:
 
 @pytest.mark.schematic_api
 class TestSchemaVisualization:
-    def test_visualize_attributes(self, client, data_model_jsonld):
-        params = {"schema_url": data_model_jsonld}
+    def test_visualize_attributes(self, client: FlaskClient) -> None:
+        params = {"schema_url": DATA_MODEL_JSON_LD}
 
         response = client.get(
             "http://localhost:3001/v1/visualize/attributes", query_string=params
@@ -1240,10 +1262,10 @@ class TestSchemaVisualization:
 
     @pytest.mark.parametrize("figure_type", ["component", "dependency"])
     def test_visualize_tangled_tree_layers(
-        self, client, figure_type, data_model_jsonld
-    ):
+        self, client: FlaskClient, figure_type: str
+    ) -> None:
         # TODO: Determine a 2nd data model to use for this test, test both models sequentially, add checks for content of response
-        params = {"schema_url": data_model_jsonld, "figure_type": figure_type}
+        params = {"schema_url": DATA_MODEL_JSON_LD, "figure_type": figure_type}
 
         response = client.get(
             "http://localhost:3001/v1/visualize/tangled_tree/layers",
@@ -1260,10 +1282,10 @@ class TestSchemaVisualization:
         ],
     )
     def test_visualize_component(
-        self, client, data_model_jsonld, component, response_text
-    ):
+        self, client: FlaskClient, component: str, response_text: str
+    ) -> None:
         params = {
-            "schema_url": data_model_jsonld,
+            "schema_url": DATA_MODEL_JSON_LD,
             "component": component,
             "include_index": False,
             "data_model_labels": "class_label",
@@ -1288,11 +1310,10 @@ class TestValidationBenchmark:
     def test_validation_performance(
         self,
         helpers,
-        benchmark_data_model_jsonld,
-        client,
-        test_invalid_manifest,
-        MockComponent_attribute,
-    ):
+        client: FlaskClient,
+        test_invalid_manifest: pd.DataFrame,
+        MockComponent_attribute: Generator[str, None, None],
+    ) -> None:
         """
         Test to benchamrk performance of validation rules on large manifests
         Test loads the invalid_test_manifest.csv and isolates one attribute at a time
@@ -1309,7 +1330,7 @@ class TestValidationBenchmark:
 
         # Set paramters for endpoint
         params = {
-            "schema_url": benchmark_data_model_jsonld,
+            "schema_url": BENCHMARK_DATA_MODEL_JSON_LD,
             "data_type": "MockComponent",
         }
         headers = {"Content-Type": "multipart/form-data", "Accept": "application/json"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -209,10 +209,12 @@ class TestSynapseStorage:
             if file_names:
                 assert (
                     ["syn23643255", "schematic - main/DataTypeX/Sample_A.txt"]
+                    in response_dt
                     and [
                         "syn24226530",
                         "schematic - main/TestDatasets/TestDataset-Annotations/Sample_A.txt",
                     ]
+                    in response_dt
                     and [
                         "syn25057024",
                         "schematic - main/TestDatasets/TestDataset-Annotations-v2/Sample_A.txt",
@@ -227,11 +229,11 @@ class TestSynapseStorage:
         else:
             if file_names:
                 assert (
-                    ["syn23643255", "Sample_A.txt"]
-                    and ["syn24226530", "Sample_A.txt"]
+                    ["syn23643255", "Sample_A.txt"] in response_dt
+                    and ["syn24226530", "Sample_A.txt"] in response_dt
                     and ["syn25057024", "Sample_A.txt"] in response_dt
                 )
-                assert ["syn23643256", "Sample_C.txt"] and [
+                assert ["syn23643256", "Sample_C.txt"] not in response_dt and [
                     "syn24226531",
                     "Sample_B.txt",
                 ] not in response_dt

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -392,7 +392,10 @@ class TestSynapseStorage:
                 [("test_file", "syn126")],
             ),
             (
-                (os.path.join("parent_folder", "test_folder"), "syn124"),
+                (
+                    os.path.join("schematic - main", "parent_folder", "test_folder"),
+                    "syn124",
+                ),
                 [],
                 [("test_file_2", "syn125")],
             ),


### PR DESCRIPTION
**Problem:**

1. When the project structure was being walked the name of the project was being included twice: `schematic - main/schematic - main/DataTypeX/Sample_A.txt`
2. Lots of small issues flagged by sonar

**Solution:**

1. Add in a small check to determine if the project name is already being included in the directory structure, and not include the duplicated data if it's the case. I was not certain if I could totally remove adding the project name manually, so that is why I made the check in this way.

**Testing:**

1. I verified I could run the tests in question around this logic (Note: This does not contain all of the tests noted in the jira, just a few):
![image](https://github.com/user-attachments/assets/42e05039-665a-4c0b-8189-4537465b1d22)
