### PR TITLE
[FDS-2294] Run schematic_api tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,7 @@ jobs:
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
         run: >
           source .venv/bin/activate;
-          pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
+          pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov=schematic/
           -m "not (rule_benchmark or table_operations)" --reruns 2 -n auto
 
 
@@ -132,3 +132,46 @@ jobs:
           path: htmlcov
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
+      - name: Upload XML coverage report
+        id: upload_coverage_report
+        uses: actions/upload-artifact@v4
+        # Only upload a single python version to pass along to sonarcloud
+        if: ${{ contains(fromJSON('["3.10"]'), matrix.python-version) && always() }}
+        with:
+          name: coverage-report
+          path: coverage.xml
+
+  sonarcloud:
+    needs: [test]
+    if: ${{ always() && !cancelled()}}
+    name: SonarCloud
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Check coverage-report artifact existence
+        id: check_coverage_report
+        uses: LIT-Protocol/artifact-exists-action@v0
+        with:
+          name: "coverage-report"
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        if: steps.check_coverage_report.outputs.exists == 'true'
+        with:
+          name: coverage-report
+      - name: Check coverage.xml file existence
+        id: check_coverage_xml
+        uses: andstor/file-existence-action@v3
+        with:
+          files: "coverage.xml"
+        # This is a workaround described in https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
+      - name: Override Coverage Source Path for Sonar
+        if: steps.check_coverage_xml.outputs.files_exists == 'true'
+        run: sed -i "s/<source>\/home\/runner\/work\/schematic\/schematic\/schematic<\/source>/<source>\/github\/workspace\/schematic<\/source>/g" coverage.xml
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        if: ${{ always() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,15 +119,10 @@ jobs:
         env:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
-        # run: >
-        #   source .venv/bin/activate;
-        #   pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
-        #   -m "not (table_operations or rule_benchmark)" --reruns 2 -n auto
-        #   -m "not (schematic_api or table_operations or rule_benchmark)" --reruns 2 -n auto
         run: >
           source .venv/bin/activate;
           pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
-          -m "schematic_api and not (rule_benchmark)" --reruns 2 -n auto
+          -m "not (rule_benchmark or table_operations)" --reruns 2 -n auto
 
 
       - name: Upload pytest test results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,12 +122,12 @@ jobs:
         # run: >
         #   source .venv/bin/activate;
         #   pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
-        #   -m "not (table_operations)" --reruns 2 -n auto
-        #   -m "not (schematic_api or table_operations)" --reruns 2 -n auto
+        #   -m "not (table_operations or rule_benchmark)" --reruns 2 -n auto
+        #   -m "not (schematic_api or table_operations or rule_benchmark)" --reruns 2 -n auto
         run: >
           source .venv/bin/activate;
           pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
-          -m "schematic_api" --reruns 2 -n auto
+          -m "schematic_api and not (rule_benchmark)" --reruns 2 -n auto
 
 
       - name: Upload pytest test results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,10 +119,16 @@ jobs:
         env:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
+        # run: >
+        #   source .venv/bin/activate;
+        #   pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
+        #   -m "not (table_operations)" --reruns 2 -n auto
+        #   -m "not (schematic_api or table_operations)" --reruns 2 -n auto
         run: >
           source .venv/bin/activate;
           pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov=schematic/
-          -m "not (schematic_api or table_operations)" --reruns 2 -n auto
+          -m "schematic_api" --reruns 2 -n auto
+
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v2

--- a/schematic/visualization/tangled_tree.py
+++ b/schematic/visualization/tangled_tree.py
@@ -3,10 +3,10 @@
 # pylint: disable=logging-fstring-interpolation
 # pylint: disable=too-many-lines
 
+import ast
 import json
 import logging
 import os
-import re
 from io import StringIO
 from os import path
 from typing import Literal, Optional, TypedDict, Union
@@ -243,25 +243,6 @@ class TangledTree:  # pylint: disable=too-many-instance-attributes
             cond_req = cond_req_new.replace("If", "").lstrip().rstrip()
         return cond_req
 
-    def _extract_content_within_quotes(self, strings: list[str]) -> list[str]:
-        """
-        Extract content within quotes from a list of strings.
-
-        Args:
-            strings (list): list of strings
-
-        Returns:
-            list: list of strings with content within single quotes
-        """
-        pattern = r"\'(.*?)\'"
-        extracted_content = []
-
-        for string in strings:
-            matches = re.findall(pattern, string)
-            extracted_content.extend(matches)
-
-        return extracted_content
-
     def _get_ca_alias(self, conditional_requirements: list[str]) -> dict[str, str]:
         """Get the alias for each conditional attribute.
 
@@ -277,9 +258,11 @@ class TangledTree:  # pylint: disable=too-many-instance-attributes
                 value: attribute
         """
         ca_alias: dict[str, str] = {}
-        extracted_conditional_requirements = self._extract_content_within_quotes(
-            conditional_requirements
-        )
+        extracted_conditional_requirements = []
+        for conditional_requirement in conditional_requirements:
+            extracted_conditional_requirements.extend(
+                ast.literal_eval(node_or_string=conditional_requirement)
+            )
 
         # clean up conditional requirements
         conditional_requirements = [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=Sage-Bionetworks_schematic
+sonar.organization=sage-bionetworks
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.sources=schematic
+sonar.tests=tests

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1276,6 +1276,80 @@ class TestSchemaVisualization:
 
         assert response.status_code == 200
 
+        response_data = json.loads(response.data)
+
+        if figure_type == "component":
+            assert len(response_data) == 3
+            for data_list in response_data:
+                for data_point in data_list:
+                    assert data_point in [
+                        {
+                            "id": "Patient",
+                            "parents": [],
+                            "direct_children": ["Biospecimen"],
+                            "children": ["Biospecimen", "BulkRNA-seqAssay"],
+                        },
+                        {
+                            "id": "Biospecimen",
+                            "parents": ["Patient"],
+                            "direct_children": ["BulkRNA-seqAssay"],
+                            "children": ["BulkRNA-seqAssay"],
+                        },
+                        {
+                            "id": "BulkRNA-seqAssay",
+                            "parents": ["Biospecimen"],
+                            "direct_children": [],
+                            "children": [],
+                        },
+                    ]
+        elif figure_type == "dependency":
+            assert len(response_data) == 3
+            for data_list in response_data:
+                for data_point in data_list:
+                    assert data_point in [
+                        {
+                            "id": "BulkRNA-seqAssay",
+                            "parents": [],
+                            "direct_children": ["SampleID", "Filename", "FileFormat"],
+                            "children": [],
+                        },
+                        {
+                            "id": "SampleID",
+                            "parents": ["BulkRNA-seqAssay"],
+                            "direct_children": [],
+                            "children": [],
+                        },
+                        {
+                            "id": "FileFormat",
+                            "parents": ["BulkRNA-seqAssay"],
+                            "direct_children": [
+                                "GenomeBuild",
+                                "GenomeBuild",
+                                "GenomeBuild",
+                                "GenomeFASTA",
+                            ],
+                            "children": [],
+                        },
+                        {
+                            "id": "Filename",
+                            "parents": ["BulkRNA-seqAssay"],
+                            "direct_children": [],
+                            "children": [],
+                        },
+                        {
+                            "id": "GenomeBuild",
+                            "parents": ["FileFormat", "FileFormat", "FileFormat"],
+                            "direct_children": [],
+                            "children": [],
+                        },
+                        {
+                            "id": "GenomeFASTA",
+                            "parents": ["FileFormat"],
+                            "direct_children": [],
+                            "children": [],
+                        },
+                    ]
+
     @pytest.mark.parametrize(
         "component, response_text",
         [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -773,9 +773,9 @@ class TestManifestOperation:
 
         # make sure Filename, entityId, and component get filled with correct value
         assert google_sheet_df["Filename"].to_list() == [
-            "TestDataset-Annotations-v3/Sample_A.txt",
-            "TestDataset-Annotations-v3/Sample_B.txt",
-            "TestDataset-Annotations-v3/Sample_C.txt",
+            "schematic - main/TestDataset-Annotations-v3/Sample_A.txt",
+            "schematic - main/TestDataset-Annotations-v3/Sample_B.txt",
+            "schematic - main/TestDataset-Annotations-v3/Sample_C.txt",
         ]
         assert google_sheet_df["entityId"].to_list() == [
             "syn25614636",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1280,75 +1280,89 @@ class TestSchemaVisualization:
 
         if figure_type == "component":
             assert len(response_data) == 3
+            expected_data = [
+                {
+                    "id": "Patient",
+                    "parents": [],
+                    "direct_children": ["Biospecimen"],
+                    "children": ["Biospecimen", "BulkRNA-seqAssay"],
+                },
+                {
+                    "id": "Biospecimen",
+                    "parents": ["Patient"],
+                    "direct_children": ["BulkRNA-seqAssay"],
+                    "children": ["BulkRNA-seqAssay"],
+                },
+                {
+                    "id": "BulkRNA-seqAssay",
+                    "parents": ["Biospecimen"],
+                    "direct_children": [],
+                    "children": [],
+                },
+            ]
             for data_list in response_data:
                 for data_point in data_list:
-                    assert data_point in [
-                        {
-                            "id": "Patient",
-                            "parents": [],
-                            "direct_children": ["Biospecimen"],
-                            "children": ["Biospecimen", "BulkRNA-seqAssay"],
-                        },
-                        {
-                            "id": "Biospecimen",
-                            "parents": ["Patient"],
-                            "direct_children": ["BulkRNA-seqAssay"],
-                            "children": ["BulkRNA-seqAssay"],
-                        },
-                        {
-                            "id": "BulkRNA-seqAssay",
-                            "parents": ["Biospecimen"],
-                            "direct_children": [],
-                            "children": [],
-                        },
-                    ]
+                    assert any(
+                        data_point["id"] == expected["id"]
+                        and data_point["parents"] == expected["parents"]
+                        and data_point["direct_children"] == expected["direct_children"]
+                        and set(data_point["children"]) == set(expected["children"])
+                        for expected in expected_data
+                    )
         elif figure_type == "dependency":
             assert len(response_data) == 3
+            expected_data = [
+                {
+                    "id": "BulkRNA-seqAssay",
+                    "parents": [],
+                    "direct_children": ["SampleID", "Filename", "FileFormat"],
+                    "children": [],
+                },
+                {
+                    "id": "SampleID",
+                    "parents": ["BulkRNA-seqAssay"],
+                    "direct_children": [],
+                    "children": [],
+                },
+                {
+                    "id": "FileFormat",
+                    "parents": ["BulkRNA-seqAssay"],
+                    "direct_children": [
+                        "GenomeBuild",
+                        "GenomeBuild",
+                        "GenomeBuild",
+                        "GenomeFASTA",
+                    ],
+                    "children": [],
+                },
+                {
+                    "id": "Filename",
+                    "parents": ["BulkRNA-seqAssay"],
+                    "direct_children": [],
+                    "children": [],
+                },
+                {
+                    "id": "GenomeBuild",
+                    "parents": ["FileFormat", "FileFormat", "FileFormat"],
+                    "direct_children": [],
+                    "children": [],
+                },
+                {
+                    "id": "GenomeFASTA",
+                    "parents": ["FileFormat"],
+                    "direct_children": [],
+                    "children": [],
+                },
+            ]
             for data_list in response_data:
                 for data_point in data_list:
-                    assert data_point in [
-                        {
-                            "id": "BulkRNA-seqAssay",
-                            "parents": [],
-                            "direct_children": ["SampleID", "Filename", "FileFormat"],
-                            "children": [],
-                        },
-                        {
-                            "id": "SampleID",
-                            "parents": ["BulkRNA-seqAssay"],
-                            "direct_children": [],
-                            "children": [],
-                        },
-                        {
-                            "id": "FileFormat",
-                            "parents": ["BulkRNA-seqAssay"],
-                            "direct_children": [
-                                "GenomeBuild",
-                                "GenomeBuild",
-                                "GenomeBuild",
-                                "GenomeFASTA",
-                            ],
-                            "children": [],
-                        },
-                        {
-                            "id": "Filename",
-                            "parents": ["BulkRNA-seqAssay"],
-                            "direct_children": [],
-                            "children": [],
-                        },
-                        {
-                            "id": "GenomeBuild",
-                            "parents": ["FileFormat", "FileFormat", "FileFormat"],
-                            "direct_children": [],
-                            "children": [],
-                        },
-                        {
-                            "id": "GenomeFASTA",
-                            "parents": ["FileFormat"],
-                            "direct_children": [],
-                            "children": [],
-                        },
-                    ]
+                    assert any(
+                        data_point["id"] == expected["id"]
+                        and data_point["parents"] == expected["parents"]
+                        and data_point["direct_children"] == expected["direct_children"]
+                        and set(data_point["children"]) == set(expected["children"])
+                        for expected in expected_data
+                    )
 
     @pytest.mark.parametrize(
         "component, response_text",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1379,7 +1379,7 @@ class TestValidationBenchmark:
 
         # Log and check time and ensure successful response
         logger.warning(
-            f"validation endpiont response time {round(response_time,2)} seconds."
+            f"validation endpoint response time {round(response_time,2)} seconds."
         )
         assert response.status_code == 200
         assert response_time < 5.00

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,9 +1,9 @@
-from io import StringIO
 import json
-import os
-import pandas as pd
 import logging
+import os
+from io import StringIO
 
+import pandas as pd
 import pytest
 
 from schematic.visualization.attributes_explorer import AttributesExplorer
@@ -123,6 +123,31 @@ class TestVisualization:
         # Check the extracted text matches expected text.
         assert actual_patient_text == expected_patient_text
         assert actual_Biospecimen_text == expected_Biospecimen_text
+
+    @pytest.mark.parametrize(
+        "conditional_requirements, expected",
+        [
+            # Test case 1: Multiple file formats
+            (
+                [
+                    "['File Format is \"BAM\"', 'File Format is \"CRAM\"', 'File Format is \"CSV/TSV\"']"
+                ],
+                {"BAM": "FileFormat", "CRAM": "FileFormat", "CSV/TSV": "FileFormat"},
+            ),
+            # Test case 2: Single file format
+            (["['File Format is \"CRAM\"']"], {"CRAM": "FileFormat"}),
+            # Test case 3: with "OR" keyword
+            (
+                ['[\'File Format is "BAM" OR "CRAM" OR "CSV/TSV"\']'],
+                {"BAM": "File Format", "CRAM": "File Format", "CSV/TSV": "File Format"},
+            ),
+        ],
+    )
+    def test_get_ca_alias(
+        self, helpers, tangled_tree, conditional_requirements, expected
+    ):
+        ca_alias = tangled_tree._get_ca_alias(conditional_requirements)
+        assert ca_alias == expected
 
     def test_layers(self, helpers, tangled_tree):
         layers_str = tangled_tree.get_tangled_tree_layers(save_file=False)[0]


### PR DESCRIPTION
**Problem:**

1. `schematic_api` tests were being ignored.
2. One of the integration tests was out of date for the new logic.
3. There are issues with the `tangled_tree` logic that was causing test failures. It was tracked down, context was added to the comment: https://github.com/Sage-Bionetworks/schematic/pull/1476#discussion_r1733406612

**Solution:**

1. unignore `schematic_api` tests
2. Ignore the benchmark tests which are long-running tests that should not really be included with the normal integration test runs
3. Update the logic around `tangled_tree`.

**Testing:**

1. I verified the logic with the return of the API data as well as manually via breakpoints and inspecting the data.
2. Will wait for a fully passing integration test suite.


![image](https://github.com/user-attachments/assets/58d8a293-7acb-479d-8dd7-e59657727caf)

Related to this ticket: FDS-2294
