### PR TITLE
Change how dataset to validate against is specified for `filenameExists` rule

### DIFF
--- a/schematic/help.py
+++ b/schematic/help.py
@@ -3,9 +3,9 @@
 #!/usr/bin/env python3
 
 from typing import get_args
+
 from schematic.utils.schema_utils import DisplayLabelType
 from schematic.visualization.tangled_tree import FigureType, TextType
-
 
 DATA_MODEL_LABELS_DICT = {
     "display_label": "use the display name as a label, if it is valid (contains no blacklisted characters) otherwise will default to class_label.",
@@ -199,6 +199,9 @@ model_commands = {
             ),
             "project_scope": (
                 "Specify a comma-separated list of projects to search through for cross manifest validation."
+            ),
+            "dataset_scope": (
+                "Specify a dataset to validate against for filename validation."
             ),
             "data_model_labels": DATA_MODEL_LABELS_HELP,
         },

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -4,7 +4,7 @@ import logging
 import sys
 from gc import callbacks
 from time import perf_counter
-from typing import get_args
+from typing import Optional, get_args
 
 import click
 import click_log
@@ -148,19 +148,19 @@ def model(ctx, config):  # use as `schematic model ...`
 @click.pass_obj
 def submit_manifest(
     ctx,
-    manifest_path,
-    dataset_id,
-    validate_component,
-    manifest_record_type,
-    hide_blanks,
-    restrict_rules,
-    project_scope,
-    dataset_scope,
-    table_manipulation,
-    data_model_labels,
-    table_column_names,
-    annotation_keys,
-    file_annotations_upload: bool,
+    manifest_path: str,
+    dataset_id: str,
+    validate_component: Optional[str],
+    manifest_record_type: Optional[str],
+    hide_blanks: Optional[bool],
+    restrict_rules: Optional[bool],
+    project_scope: Optional[list[str]],
+    dataset_scope: Optional[str],
+    table_manipulation: Optional[str],
+    data_model_labels: Optional[str],
+    table_column_names: Optional[str],
+    annotation_keys: Optional[str],
+    file_annotations_upload: Optional[bool],
 ):
     """
     Running CLI with manifest validation (optional) and submission options.
@@ -243,19 +243,20 @@ def submit_manifest(
 @click.option(
     "--data_model_labels",
     "-dml",
-    is_flag=True,
+    default="class_label",
+    type=click.Choice(list(get_args(DisplayLabelType)), case_sensitive=True),
     help=query_dict(model_commands, ("model", "validate", "data_model_labels")),
 )
 @click.pass_obj
 def validate_manifest(
     ctx,
-    manifest_path,
-    data_type,
-    json_schema,
-    restrict_rules,
-    project_scope,
-    dataset_scope,
-    data_model_labels,
+    manifest_path: str,
+    data_type: Optional[list[str]],
+    json_schema: Optional[str],
+    restrict_rules: Optional[bool],
+    project_scope: Optional[list[str]],
+    dataset_scope: Optional[str],
+    data_model_labels: Optional[str],
 ):
     """
     Running CLI for manifest validation.

--- a/schematic/models/commands.py
+++ b/schematic/models/commands.py
@@ -1,26 +1,25 @@
 #!/usr/bin/env python3
 
-from typing import get_args
-from gc import callbacks
 import logging
 import sys
+from gc import callbacks
 from time import perf_counter
+from typing import get_args
 
 import click
 import click_log
-
 from jsonschema import ValidationError
 
+from schematic.configuration.configuration import CONFIG
+from schematic.exceptions import MissingConfigValueError
+from schematic.help import model_commands
 from schematic.models.metadata import MetadataModel
 from schematic.utils.cli_utils import (
     log_value_from_config,
-    query_dict,
-    parse_syn_ids,
     parse_comma_str_to_list,
+    parse_syn_ids,
+    query_dict,
 )
-from schematic.help import model_commands
-from schematic.exceptions import MissingConfigValueError
-from schematic.configuration.configuration import CONFIG
 from schematic.utils.schema_utils import DisplayLabelType
 
 logger = logging.getLogger("schematic")
@@ -111,6 +110,12 @@ def model(ctx, config):  # use as `schematic model ...`
     help=query_dict(model_commands, ("model", "validate", "project_scope")),
 )
 @click.option(
+    "-ds",
+    "--dataset_scope",
+    default=None,
+    help=query_dict(model_commands, ("model", "validate", "dataset_scope")),
+)
+@click.option(
     "--table_manipulation",
     "-tm",
     default="replace",
@@ -150,6 +155,7 @@ def submit_manifest(
     hide_blanks,
     restrict_rules,
     project_scope,
+    dataset_scope,
     table_manipulation,
     data_model_labels,
     table_column_names,
@@ -177,6 +183,7 @@ def submit_manifest(
         restrict_rules=restrict_rules,
         hide_blanks=hide_blanks,
         project_scope=project_scope,
+        dataset_scope=dataset_scope,
         table_manipulation=table_manipulation,
         table_column_names=table_column_names,
         annotation_keys=annotation_keys,
@@ -228,6 +235,12 @@ def submit_manifest(
     help=query_dict(model_commands, ("model", "validate", "project_scope")),
 )
 @click.option(
+    "-ds",
+    "--dataset_scope",
+    default=None,
+    help=query_dict(model_commands, ("model", "validate", "dataset_scope")),
+)
+@click.option(
     "--data_model_labels",
     "-dml",
     is_flag=True,
@@ -241,6 +254,7 @@ def validate_manifest(
     json_schema,
     restrict_rules,
     project_scope,
+    dataset_scope,
     data_model_labels,
 ):
     """
@@ -276,6 +290,7 @@ def validate_manifest(
         jsonSchema=json_schema,
         restrict_rules=restrict_rules,
         project_scope=project_scope,
+        dataset_scope=dataset_scope,
     )
 
     if not errors:

--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -1,25 +1,24 @@
-import os
 import logging
-import networkx as nx
+import os
 from os.path import exists
-from jsonschema import ValidationError
 
 # allows specifying explicit variable types
-from typing import Any, Dict, Optional, Text, List
+from typing import Any, Dict, List, Optional, Text
+
+import networkx as nx
+from jsonschema import ValidationError
+from opentelemetry import trace
 
 from schematic.manifest.generator import ManifestGenerator
+from schematic.models.validate_manifest import validate_all
 from schematic.schemas.data_model_graph import DataModelGraph, DataModelGraphExplorer
-from schematic.schemas.data_model_parser import DataModelParser
 from schematic.schemas.data_model_json_schema import DataModelJSONSchema
+from schematic.schemas.data_model_parser import DataModelParser
 
 # TODO: This module should only be aware of the store interface
 # we shouldn't need to expose Synapse functionality explicitly
 from schematic.store.synapse import SynapseStorage
-
 from schematic.utils.df_utils import load_df
-
-from schematic.models.validate_manifest import validate_all
-from opentelemetry import trace
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +199,7 @@ class MetadataModel(object):
         restrict_rules: bool = False,
         jsonSchema: Optional[str] = None,
         project_scope: Optional[List] = None,
+        dataset_scope: Optional[str] = None,
         access_token: Optional[str] = None,
     ) -> tuple[list, list]:
         """Check if provided annotations manifest dataframe satisfies all model requirements.
@@ -287,6 +287,7 @@ class MetadataModel(object):
             jsonSchema=jsonSchema,
             restrict_rules=restrict_rules,
             project_scope=project_scope,
+            dataset_scope=dataset_scope,
             access_token=access_token,
         )
         return errors, warnings
@@ -332,6 +333,7 @@ class MetadataModel(object):
         file_annotations_upload: bool = True,
         hide_blanks: bool = False,
         project_scope: Optional[list] = None,
+        dataset_scope: Optional[str] = None,
         table_manipulation: str = "replace",
         table_column_names: str = "class_label",
         annotation_keys: str = "class_label",
@@ -396,6 +398,7 @@ class MetadataModel(object):
                 rootNode=validate_component,
                 restrict_rules=restrict_rules,
                 project_scope=project_scope,
+                dataset_scope=dataset_scope,
                 access_token=access_token,
             )
 

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -2028,6 +2028,12 @@ class ValidateAttribute(object):
             errors: list[str] Error details for further storage.
             warnings: list[str] Warning details for further storage.
         """
+
+        if dataset_scope is None:
+            raise ValueError(
+                "A dataset is required to be specified for filename validation"
+            )
+
         errors = []
         warnings = []
 

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -2013,8 +2013,8 @@ class ValidateAttribute(object):
         val_rule: str,
         manifest: pd.core.frame.DataFrame,
         access_token: str,
+        dataset_scope: str,
         project_scope: Optional[list] = None,
-        dataset_scope: Optional[str] = None,
     ):
         """
         Purpose:
@@ -2023,6 +2023,7 @@ class ValidateAttribute(object):
             val_rule: str, Validation rule for the component
             manifest: pd.core.frame.DataFrame, manifest
             access_token: str, Asset Store access token
+            dataset_scope: str, Dataset with files to validate against
             project_scope: Optional[list] = None: Projects to limit the scope of cross manifest validation to.
         Returns:
             errors: list[str] Error details for further storage.

--- a/schematic/models/validate_attribute.py
+++ b/schematic/models/validate_attribute.py
@@ -2014,6 +2014,7 @@ class ValidateAttribute(object):
         manifest: pd.core.frame.DataFrame,
         access_token: str,
         project_scope: Optional[list] = None,
+        dataset_scope: Optional[str] = None,
     ):
         """
         Purpose:
@@ -2031,9 +2032,8 @@ class ValidateAttribute(object):
         warnings = []
 
         where_clauses = []
-        rule_parts = val_rule.split(" ")
 
-        dataset_clause = f"parentId='{rule_parts[1]}'"
+        dataset_clause = f"parentId='{dataset_scope}'"
         where_clauses.append(dataset_clause)
 
         self._login(

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -105,6 +105,7 @@ class ValidateManifest(object):
         dmge: DataModelGraphExplorer,
         restrict_rules: bool,
         project_scope: list[str],
+        dataset_scope: Optional[str],
         access_token: Optional[str] = None,
     ) -> (pd.core.frame.DataFrame, list[list[str]]):
         """
@@ -272,7 +273,7 @@ class ValidateManifest(object):
                         )
                     elif validation_type == "filenameExists":
                         vr_errors, vr_warnings = validation_method(
-                            rule, manifest, access_token, project_scope
+                            rule, manifest, access_token, project_scope, dataset_scope
                         )
                     else:
                         vr_errors, vr_warnings = validation_method(
@@ -351,12 +352,13 @@ def validate_all(
     jsonSchema,
     restrict_rules,
     project_scope: List,
+    dataset_scope: List,
     access_token: str,
 ):
     # Run Validation Rules
     vm = ValidateManifest(errors, manifest, manifestPath, dmge, jsonSchema)
     manifest, vmr_errors, vmr_warnings = vm.validate_manifest_rules(
-        manifest, dmge, restrict_rules, project_scope, access_token
+        manifest, dmge, restrict_rules, project_scope, dataset_scope, access_token
     )
 
     if vmr_errors:

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -105,7 +105,7 @@ class ValidateManifest(object):
         dmge: DataModelGraphExplorer,
         restrict_rules: bool,
         project_scope: list[str],
-        dataset_scope: Optional[str],
+        dataset_scope: Optional[str] = None,
         access_token: Optional[str] = None,
     ) -> (pd.core.frame.DataFrame, list[list[str]]):
         """
@@ -352,7 +352,7 @@ def validate_all(
     jsonSchema,
     restrict_rules,
     project_scope: List,
-    dataset_scope: List,
+    dataset_scope: str,
     access_token: str,
 ):
     # Run Validation Rules

--- a/schematic/models/validate_manifest.py
+++ b/schematic/models/validate_manifest.py
@@ -273,7 +273,11 @@ class ValidateManifest(object):
                         )
                     elif validation_type == "filenameExists":
                         vr_errors, vr_warnings = validation_method(
-                            rule, manifest, access_token, project_scope, dataset_scope
+                            rule,
+                            manifest,
+                            access_token,
+                            dataset_scope,
+                            project_scope,
                         )
                     else:
                         vr_errors, vr_warnings = validation_method(

--- a/schematic/utils/cli_utils.py
+++ b/schematic/utils/cli_utils.py
@@ -4,10 +4,9 @@
 # pylint: disable=anomalous-backslash-in-string
 
 import logging
-
-from typing import Any, Mapping, Sequence, Union, Optional
-from functools import reduce
 import re
+from functools import reduce
+from typing import Any, Mapping, Optional, Sequence, Union
 
 logger = logging.getLogger(__name__)
 
@@ -69,13 +68,13 @@ def parse_syn_ids(
     if not syn_ids:
         return None
 
-    project_regex = re.compile("(syn\d+\,?)+")
-    valid = project_regex.fullmatch(syn_ids)
+    synID_regex = re.compile("(syn\d+\,?)+")
+    valid = synID_regex.fullmatch(syn_ids)
 
     if not valid:
         raise ValueError(
             f"The provided list of project synID(s): {syn_ids}, is not formatted correctly. "
-            "\nPlease check your list of projects for errors."
+            "\nPlease check your list of synIDs for errors."
         )
 
     return syn_ids.split(",")

--- a/schematic/utils/cli_utils.py
+++ b/schematic/utils/cli_utils.py
@@ -4,9 +4,10 @@
 # pylint: disable=anomalous-backslash-in-string
 
 import logging
-import re
+
+from typing import Any, Mapping, Sequence, Union, Optional
 from functools import reduce
-from typing import Any, Mapping, Optional, Sequence, Union
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -68,13 +69,13 @@ def parse_syn_ids(
     if not syn_ids:
         return None
 
-    synID_regex = re.compile("(syn\d+\,?)+")
-    valid = synID_regex.fullmatch(syn_ids)
+    project_regex = re.compile("(syn\d+\,?)+")
+    valid = project_regex.fullmatch(syn_ids)
 
     if not valid:
         raise ValueError(
             f"The provided list of project synID(s): {syn_ids}, is not formatted correctly. "
-            "\nPlease check your list of synIDs for errors."
+            "\nPlease check your list of projects for errors."
         )
 
     return syn_ids.split(",")

--- a/schematic/utils/validate_rules_utils.py
+++ b/schematic/utils/validate_rules_utils.py
@@ -150,7 +150,7 @@ def validation_rule_info() -> dict[str, Rule]:
             "fixed_arg": None,
         },
         "filenameExists": {
-            "arguments": (2, 1),
+            "arguments": (1, 1),
             "type": "filename_validation",
             "complementary_rules": None,
             "default_message_level": "error",

--- a/schematic_api/api/openapi/api.yaml
+++ b/schematic_api/api/openapi/api.yaml
@@ -303,6 +303,14 @@ paths:
           description: List, a subset of the projects contained within the asset view that are relevant for the current operation. Speeds up some operations that interact with Synapse. Relevant for validating manifests involving cross-manifest validation, but optional.
           example: ['syn23643250', 'syn47218127', 'syn47218347']
           required: false
+        - in: query
+          name: dataset_scope
+          schema:
+            type: string
+            nullable: true
+          description: Specify a dataset to validate against for filename validation.
+          example: 'syn61682648'
+          required: false
 
       operationId: schematic_api.api.routes.validate_manifest_route
       responses:
@@ -458,6 +466,14 @@ paths:
             nullable: false
           description: List, a subset of the projects contained within the asset view that are relevant for the current operation. Speeds up some operations that interact with Synapse.
           example: ['syn23643250', 'syn47218127', 'syn47218347']
+          required: false
+        - in: query
+          name: dataset_scope
+          schema:
+            type: string
+            nullable: true
+          description: Specify a dataset to validate against for filename validation.
+          example: 'syn61682648'
           required: false
       operationId: schematic_api.api.routes.submit_manifest_route
       responses:

--- a/schematic_api/api/routes.py
+++ b/schematic_api/api/routes.py
@@ -399,6 +399,7 @@ def validate_manifest_route(
     json_str=None,
     asset_view=None,
     project_scope=None,
+    dataset_scope=None,
 ):
     # Access token now stored in request header
     access_token = get_access_token()
@@ -439,6 +440,7 @@ def validate_manifest_route(
         restrict_rules=restrict_rules,
         project_scope=project_scope,
         access_token=access_token,
+        dataset_scope=dataset_scope,
     )
 
     res_dict = {"errors": errors, "warnings": warnings}
@@ -458,6 +460,7 @@ def submit_manifest_route(
     data_type=None,
     hide_blanks=False,
     project_scope=None,
+    dataset_scope=None,
     table_column_names=None,
     annotation_keys=None,
     file_annotations_upload: bool = True,
@@ -515,6 +518,7 @@ def submit_manifest_route(
         hide_blanks=hide_blanks,
         table_manipulation=table_manipulation,
         project_scope=project_scope,
+        dataset_scope=dataset_scope,
         table_column_names=table_column_names,
         annotation_keys=annotation_keys,
         file_annotations_upload=file_annotations_upload,

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -12,7 +12,7 @@ Biospecimen,,,"Sample ID, Patient ID, Tissue Status, Component",,FALSE,DataType,
 Sample ID,,,,,TRUE,DataProperty,,,
 Tissue Status,,"Healthy, Malignant",,,TRUE,DataProperty,,,
 Bulk RNA-seq Assay,,,"Filename, Sample ID, File Format, Component",,FALSE,DataType,Biospecimen,,
-Filename,,,,,TRUE,DataProperty,,,#MockFilename filenameExists syn61682648^^
+Filename,,,,,TRUE,DataProperty,,,#MockFilename filenameExists^^
 File Format,,"FASTQ, BAM, CRAM, CSV/TSV",,,TRUE,DataProperty,,,
 BAM,,,Genome Build,,FALSE,ValidValue,,,
 CRAM,,,"Genome Build, Genome FASTA",,FALSE,ValidValue,,,

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -615,7 +615,7 @@
             "sms:displayName": "Filename",
             "sms:required": "sms:true",
             "sms:validationRules": {
-                "MockFilename": "filenameExists syn61682648"
+                "MockFilename": "filenameExists"
             }
         },
         {

--- a/tests/data/mock_manifests/ValidFilenameManifest.csv
+++ b/tests/data/mock_manifests/ValidFilenameManifest.csv
@@ -1,5 +1,5 @@
-Component,Filename,entityId
-MockFilename,schematic - main/TestSubmitMockFilename/txt1.txt,syn62822369
-MockFilename,schematic - main/TestSubmitMockFilename/txt2.txt,syn62822368
-MockFilename,schematic - main/TestSubmitMockFilename/txt3.txt,syn62822366
-MockFilename,schematic - main/TestSubmitMockFilename/txt4.txt,syn62822364
+Component,Filename,Id,entityId
+MockFilename,schematic - main/TestSubmitMockFilename/txt1.txt,3c4c384b-5c49-4a7c-90a6-43f03a5ddbdc,syn62822369
+MockFilename,schematic - main/TestSubmitMockFilename/txt2.txt,3b45f5f3-408f-47ff-945e-9badf0a43195,syn62822368
+MockFilename,schematic - main/TestSubmitMockFilename/txt3.txt,2bbc898f-2651-4af3-834a-10c506de0fbd,syn62822366
+MockFilename,schematic - main/TestSubmitMockFilename/txt4.txt,5a2d3816-436e-458f-9887-cb8355518e23,syn62822364

--- a/tests/data/mock_manifests/ValidFilenameManifest.csv
+++ b/tests/data/mock_manifests/ValidFilenameManifest.csv
@@ -1,0 +1,5 @@
+Component,Filename,entityId
+MockFilename,schematic - main/TestSubmitMockFilename/txt1.txt,syn62822369
+MockFilename,schematic - main/TestSubmitMockFilename/txt2.txt,syn62822368
+MockFilename,schematic - main/TestSubmitMockFilename/txt3.txt,syn62822366
+MockFilename,schematic - main/TestSubmitMockFilename/txt4.txt,syn62822364

--- a/tests/integration/test_metadata_model.py
+++ b/tests/integration/test_metadata_model.py
@@ -1,6 +1,7 @@
 import logging
 from contextlib import nullcontext as does_not_raise
 
+import pytest
 from pytest_mock import MockerFixture
 
 from schematic.store.synapse import SynapseStorage
@@ -11,7 +12,26 @@ logger = logging.getLogger(__name__)
 
 
 class TestMetadataModel:
-    def test_submit_filebased_manifest(self, helpers, mocker: MockerFixture):
+    @pytest.mark.parametrize(
+        "manifest_path, dataset_id, validate_component, expected_manifest_id",
+        [
+            (
+                "mock_manifests/filepath_submission_test_manifest.csv",
+                "syn62276880",
+                None,
+                "syn62280543",
+            ),
+        ],
+    )
+    def test_submit_filebased_manifest(
+        self,
+        helpers,
+        manifest_path,
+        dataset_id,
+        validate_component,
+        expected_manifest_id,
+        mocker: MockerFixture,
+    ):
         # spys
         spy_upload_file_as_csv = mocker.spy(SynapseStorage, "upload_manifest_as_csv")
         spy_upload_file_as_table = mocker.spy(
@@ -26,24 +46,23 @@ class TestMetadataModel:
         meta_data_model = metadata_model(helpers, "class_label")
 
         # AND a filebased test manifset
-        manifest_path = helpers.get_data_path(
-            "mock_manifests/filepath_submission_test_manifest.csv"
-        )
+        manifest_path = helpers.get_data_path(manifest_path)
 
         # WHEN the manifest it submitted
         # THEN submission should complete without error
         with does_not_raise():
             manifest_id = meta_data_model.submit_metadata_manifest(
                 manifest_path=manifest_path,
-                dataset_id="syn62276880",
+                dataset_id=dataset_id,
                 manifest_record_type="file_and_entities",
                 restrict_rules=False,
                 file_annotations_upload=True,
                 hide_blanks=False,
+                validate_component=validate_component,
             )
 
             # AND the manifest should be submitted to the correct place
-            assert manifest_id == "syn62280543"
+            assert manifest_id == expected_manifest_id
 
             # AND the manifest should be uploaded as a CSV
             spy_upload_file_as_csv.assert_called_once()

--- a/tests/integration/test_metadata_model.py
+++ b/tests/integration/test_metadata_model.py
@@ -13,13 +13,21 @@ logger = logging.getLogger(__name__)
 
 class TestMetadataModel:
     @pytest.mark.parametrize(
-        "manifest_path, dataset_id, validate_component, expected_manifest_id",
+        "manifest_path, dataset_id, validate_component, expected_manifest_id, dataset_scope",
         [
             (
                 "mock_manifests/filepath_submission_test_manifest.csv",
                 "syn62276880",
                 None,
                 "syn62280543",
+                None,
+            ),
+            (
+                "mock_manifests/ValidFilenameManifest.csv",
+                "syn62822337",
+                "MockFilename",
+                "syn62822975",
+                "syn62822337",
             ),
         ],
     )
@@ -30,6 +38,7 @@ class TestMetadataModel:
         dataset_id,
         validate_component,
         expected_manifest_id,
+        dataset_scope,
         mocker: MockerFixture,
     ):
         # spys
@@ -59,6 +68,7 @@ class TestMetadataModel:
                 file_annotations_upload=True,
                 hide_blanks=False,
                 validate_component=validate_component,
+                dataset_scope=dataset_scope,
             )
 
             # AND the manifest should be submitted to the correct place

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -879,7 +879,11 @@ class TestManifestOperation:
         test_manifest_csv: str,
         request_headers: Dict[str, str],
     ) -> None:
-        params = {"schema_url": DATA_MODEL_JSON_LD, "restrict_rules": restrict_rules}
+        params = {
+            "schema_url": DATA_MODEL_JSON_LD,
+            "restrict_rules": restrict_rules,
+            "project_scope": "syn54126707",
+        }
 
         if json_str:
             params["json_str"] = json_str

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -923,6 +923,7 @@ class TestManifestOperation:
         # GIVEN a set of test prameters
         params = {
             "schema_url": DATA_MODEL_JSON_LD,
+            "asset_view": "syn23643253",
             "restrict_rules": restrict_rules,
             "project_scope": project_scope,
             "dataset_scope": dataset_scope,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,6 +45,14 @@ def valid_test_manifest_csv(helpers) -> str:
 
 
 @pytest.fixture(scope="class")
+def invalid_filename_manifest_csv(helpers) -> str:
+    test_manifest_path = helpers.get_data_path(
+        "mock_manifests/InvalidFilenameManifest.csv"
+    )
+    return test_manifest_path
+
+
+@pytest.fixture(scope="class")
 def test_manifest_submit(helpers) -> str:
     test_manifest_path = helpers.get_data_path(
         "mock_manifests/example_biospecimen_test.csv"
@@ -880,6 +888,14 @@ class TestManifestOperation:
                 None,
             ),
             ("patient_manifest_json_str", None, "Patient", False, None, None),
+            (
+                None,
+                "invalid_filename_manifest_csv",
+                "MockFilename",
+                True,
+                "syn23643250",
+                "syn61682648",
+            ),
         ],
     )
     @pytest.mark.parametrize("restrict_rules", [True, False, None])
@@ -896,7 +912,7 @@ class TestManifestOperation:
         request_headers: Dict[str, str],
         request: pytest.FixtureRequest,
     ) -> None:
-        # GIVEN a set of appropriate test prameters
+        # GIVEN a set of test prameters
         params = {
             "schema_url": DATA_MODEL_JSON_LD,
             "restrict_rules": restrict_rules,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -869,24 +869,24 @@ class TestManifestOperation:
         assert response_dt[0].startswith("https://docs.google.com/")
 
     @pytest.mark.parametrize(
-        "json_str_fixture,restrict_rules,data_type,update_headers,test_manifest_fixture",
+        "json_str_fixture,test_manifest_fixture,restrict_rules,data_type,update_headers",
         [
-            (None, False, "MockComponent", True, "valid_test_manifest_csv"),
-            (None, True, "MockComponent", True, "valid_test_manifest_csv"),
-            (None, None, "MockComponent", True, "valid_test_manifest_csv"),
-            ("patient_manifest_json_str", False, "Patient", False, None),
-            ("patient_manifest_json_str", True, "Patient", False, None),
-            ("patient_manifest_json_str", None, "Patient", False, None),
+            (None, "valid_test_manifest_csv", False, "MockComponent", True),
+            (None, "valid_test_manifest_csv", True, "MockComponent", True),
+            (None, "valid_test_manifest_csv", None, "MockComponent", True),
+            ("patient_manifest_json_str", None, False, "Patient", False),
+            ("patient_manifest_json_str", None, True, "Patient", False),
+            ("patient_manifest_json_str", None, None, "Patient", False),
         ],
     )
     def test_validate_manifest(
         self,
         client: FlaskClient,
         json_str_fixture: Union[str, None],
+        test_manifest_fixture: Union[str, None],
         restrict_rules: Union[bool, None],
         data_type: str,
         update_headers: bool,
-        test_manifest_fixture: str,
         request_headers: Dict[str, str],
         request: pytest.FixtureRequest,
     ) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,6 +45,14 @@ def valid_test_manifest_csv(helpers) -> str:
 
 
 @pytest.fixture(scope="class")
+def valid_filename_manifest_csv(helpers) -> str:
+    test_manifest_path = helpers.get_data_path(
+        "mock_manifests/ValidFilenameManifest.csv"
+    )
+    return test_manifest_path
+
+
+@pytest.fixture(scope="class")
 def invalid_filename_manifest_csv(helpers) -> str:
     test_manifest_path = helpers.get_data_path(
         "mock_manifests/InvalidFilenameManifest.csv"
@@ -1258,32 +1266,35 @@ class TestManifestOperation:
 
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.submission
-    def test_submit_manifest_table_and_file_upsert(
+    def test_submit_and_validate_filebased_manifest(
         self,
         client: FlaskClient,
         request_headers: Dict[str, str],
-        test_upsert_manifest_csv: str,
+        valid_filename_manifest_csv: str,
     ) -> None:
+        # GIVEN the appropriate upload parameters
         params = {
             "schema_url": DATA_MODEL_JSON_LD,
-            "data_type": "MockRDB",
+            "data_type": "MockFilename",
             "restrict_rules": False,
-            "manifest_record_type": "table_and_file",
-            "asset_view": "syn51514557",
-            "dataset_id": "syn51514551",
-            "table_manipulation": "upsert",
+            "manifest_record_type": "file_and_entities",
+            "asset_view": "syn23643253",
+            "dataset_id": "syn62822337",
+            "project_scope": "syn23643250",
+            "dataset_scope": "syn62822337",
             "data_model_labels": "class_label",
-            # have to set table_column_names to display_name to ensure upsert feature works
-            "table_column_names": "display_name",
+            "table_column_names": "class_label",
         }
 
-        # test uploading a csv file
+        # WHEN a filebased manifest is validated with the filenameExists rule and uploaded
         response_csv = client.post(
             "http://localhost:3001/v1/model/submit",
             query_string=params,
-            data={"file_name": (open(test_upsert_manifest_csv, "rb"), "test.csv")},
+            data={"file_name": (open(valid_filename_manifest_csv, "rb"), "test.csv")},
             headers=request_headers,
         )
+
+        # THEN the validation and submission should be successful
         assert response_csv.status_code == 200
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -933,14 +933,6 @@ class TestManifestOperation:
         assert "errors" in response_dt.keys()
         assert "warnings" in response_dt.keys()
 
-        # test uploading a json file
-        # change data type to patient since the testing json manifest is using Patient component
-        # WILL DEPRECATE uploading a json file for validation
-        # params["data_type"] = "Patient"
-        # response_json =  client.post('http://localhost:3001/v1/model/validate', query_string=params, data={"file_name": (open(test_manifest_json, 'rb'), "test.json")}, headers=headers)
-        # response_dt = json.loads(response_json.data)
-        # assert response_json.status_code == 200
-
     @pytest.mark.synapse_credentials_needed
     def test_get_datatype_manifest(
         self, client: FlaskClient, request_headers: Dict[str, str]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1267,6 +1267,36 @@ class TestManifestOperation:
 
     @pytest.mark.synapse_credentials_needed
     @pytest.mark.submission
+    def test_submit_manifest_table_and_file_upsert(
+        self,
+        client: FlaskClient,
+        request_headers: Dict[str, str],
+        test_upsert_manifest_csv: str,
+    ) -> None:
+        params = {
+            "schema_url": DATA_MODEL_JSON_LD,
+            "data_type": "MockRDB",
+            "restrict_rules": False,
+            "manifest_record_type": "table_and_file",
+            "asset_view": "syn51514557",
+            "dataset_id": "syn51514551",
+            "table_manipulation": "upsert",
+            "data_model_labels": "class_label",
+            # have to set table_column_names to display_name to ensure upsert feature works
+            "table_column_names": "display_name",
+        }
+
+        # test uploading a csv file
+        response_csv = client.post(
+            "http://localhost:3001/v1/model/submit",
+            query_string=params,
+            data={"file_name": (open(test_upsert_manifest_csv, "rb"), "test.csv")},
+            headers=request_headers,
+        )
+        assert response_csv.status_code == 200
+
+    @pytest.mark.synapse_credentials_needed
+    @pytest.mark.submission
     def test_submit_and_validate_filebased_manifest(
         self,
         client: FlaskClient,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -697,7 +697,7 @@ class TestManifestValidation:
         # Check errors
         assert (
             GenerateError.generate_filename_error(
-                val_rule="filenameExists syn61682648",
+                val_rule="filenameExists",
                 attribute_name="Filename",
                 row_num="3",
                 invalid_entry="schematic - main/MockFilenameComponent/txt4.txt",
@@ -709,7 +709,7 @@ class TestManifestValidation:
 
         assert (
             GenerateError.generate_filename_error(
-                val_rule="filenameExists syn61682648",
+                val_rule="filenameExists",
                 attribute_name="Filename",
                 row_num="4",
                 invalid_entry="schematic - main/MockFilenameComponent/txt5.txt",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -691,6 +691,7 @@ class TestManifestValidation:
             manifestPath=manifestPath,
             rootNode=rootNode,
             project_scope=["syn23643250"],
+            dataset_scope="syn61682648",
         )
 
         # Check errors

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -722,6 +722,21 @@ class TestManifestValidation:
         assert len(errors) == 2
         assert len(warnings) == 0
 
+    def test_filename_manifest_exception(self, helpers, dmge):
+        metadataModel = get_metadataModel(helpers, model_name="example.model.jsonld")
+
+        manifestPath = helpers.get_data_path(
+            "mock_manifests/InvalidFilenameManifest.csv"
+        )
+        rootNode = "MockFilename"
+
+        with pytest.raises(ValueError):
+            errors, warnings = metadataModel.validateModelManifest(
+                manifestPath=manifestPath,
+                rootNode=rootNode,
+                project_scope=["syn23643250"],
+            )
+
     def test_missing_column(self, helpers, dmge: DataModelGraph):
         """Test that a manifest missing a column returns the proper error."""
         model_name = "example.model.csv"


### PR DESCRIPTION
Specify the dataset with files that should be validated against as a parameter in the cli and api instead of in the data model