### PR TITLE
[FDS-2373] Remove the need to do version checking on Synapse creation

### DIFF
--- a/schematic_api/api/security_controller.py
+++ b/schematic_api/api/security_controller.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 syn = Synapse(
     configPath=CONFIG.synapse_configuration_path,
     cache_client=False,
+    skip_checks=True,
 )
 jwks_client = PyJWKClient(
     uri=syn.authEndpoint + "/oauth2/jwks", headers=syn._generate_headers()


### PR DESCRIPTION
**Problem:**

1. As a part of the changes in #1493 I added the creation of a new Synapse instance in the JWT verification code. During init it calls and does a version check and a redirect check. This error showed up in an integration test:
```
.venv/lib/python3.9/site-packages/connexion/security/security_handler_factory.py:113: in get_bearerinfo_func
    return cls._get_function(security_definition, "x-bearerInfoFunc", 'BEARERINFO_FUNC')
.venv/lib/python3.9/site-packages/connexion/security/security_handler_factory.py:50: in _get_function
    return get_function_from_name(func)
.venv/lib/python3.9/site-packages/connexion/utils.py:116: in get_function_from_name
    module = importlib.import_module(module_name)
/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
schematic_api/api/security_controller.py:12: in <module>
    syn = Synapse(
.venv/lib/python3.9/site-packages/synapseclient/client.py:386: in __init__
    self.setEndpoints(
.venv/lib/python3.9/site-packages/synapseclient/client.py:699: in setEndpoints
    response = self._requests_session.get(
.venv/lib/python3.9/site-packages/requests/sessions.py:602: in get
    return self.request("GET", url, **kwargs)
.venv/lib/python3.9/site-packages/requests/sessions.py:589: in request
    resp = self.send(prep, **send_kwargs)
.venv/lib/python3.9/site-packages/requests/sessions.py:703: in send
    r = adapter.send(request, **kwargs)
.venv/lib/python3.9/site-packages/requests/adapters.py:682: in send
    raise ConnectionError(err, request=request)
E   requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
```

**Solution:**

1. Stop the version check on creation of the Synapse instance. In addition I'll also be making a change to Synapse to wrap this in our standard retry logic too.