### PR TITLE
[FDS-2383] Update to run integration tests on default runner with python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,14 +49,14 @@ jobs:
       #----------------------------------------------
       #       verify runner environment
       #----------------------------------------------
-      - name: Print runner environment information
-        run: |
-          echo "Running on runner: $RUNNER_NAME"
-          echo "Runner OS: $RUNNER_OS"
-          echo "Runner OS version: $RUNNER_OS_VERSION"
-          echo "Runner architecture: $RUNNER_ARCH"
-          echo "Total memory: $(free -h)"
-          echo "CPU info: $(lscpu)"
+      # - name: Print runner environment information
+      #   run: |
+      #     echo "Running on runner: $RUNNER_NAME"
+      #     echo "Runner OS: $RUNNER_OS"
+      #     echo "Runner OS version: $RUNNER_OS_VERSION"
+      #     echo "Runner architecture: $RUNNER_ARCH"
+      #     echo "Total memory: $(free -h)"
+      #     echo "CPU info: $(lscpu)"
 
       #----------------------------------------------
       #          install & configure poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
+    runs-on: ubuntu-latest
     env:
       POETRY_VERSION:  1.3.0
     strategy:
@@ -49,14 +49,14 @@ jobs:
       #----------------------------------------------
       #       verify runner environment
       #----------------------------------------------
-      # - name: Print runner environment information
-      #   run: |
-      #     echo "Running on runner: $RUNNER_NAME"
-      #     echo "Runner OS: $RUNNER_OS"
-      #     echo "Runner OS version: $RUNNER_OS_VERSION"
-      #     echo "Runner architecture: $RUNNER_ARCH"
-      #     echo "Total memory: $(free -h)"
-      #     echo "CPU info: $(lscpu)"
+      - name: Print runner environment information
+        run: |
+          echo "Running on runner: $RUNNER_NAME"
+          echo "Runner OS: $RUNNER_OS"
+          echo "Runner OS version: $RUNNER_OS_VERSION"
+          echo "Runner architecture: $RUNNER_ARCH"
+          echo "Total memory: $(free -h)"
+          echo "CPU info: $(lscpu)"
 
       #----------------------------------------------
       #          install & configure poetry
@@ -125,16 +125,29 @@ jobs:
           poetry run pylint schematic/visualization/* schematic/configuration/*.py schematic/exceptions.py schematic/help.py schematic/loader.py schematic/version.py schematic/utils/*.py schematic/schemas/*.py
 
       #----------------------------------------------
-      #              run test suite
+      #              run unit test suite
       #----------------------------------------------
-      - name: Run tests
+      - name: Run unit tests
         env:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
         run: >
           source .venv/bin/activate;
-          pytest --durations=0 --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov=schematic/
-          -m "not (rule_benchmark)" --reruns 4 -n 8
+          pytest --durations=0 --cov-append --cov-report=term --cov-report=html:htmlcov 
+          --cov-report=xml:coverage.xml --cov=schematic/ --reruns 4 -n 8 tests/unit
+
+      #----------------------------------------------
+      #              run integration test suite
+      #----------------------------------------------
+      - name: Run integration tests
+        if: ${{ contains(fromJSON('["3.10"]'), matrix.python-version) }}
+        env:
+          SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
+          SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
+        run: >
+          source .venv/bin/activate;
+          pytest --durations=0 --cov-append --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov=schematic/
+          -m "not (rule_benchmark)" --reruns 4 -n 8 --ignore=tests/unit
 
 
       - name: Upload pytest test results
@@ -143,7 +156,7 @@ jobs:
           name: pytest-results-${{ matrix.python-version }}
           path: htmlcov
         # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
+        if: ${{ always() && contains(fromJSON('["3.10"]'), matrix.python-version) }}
       - name: Upload XML coverage report
         id: upload_coverage_report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/FDS-2383

**Problem:**

1. Integration tests running on the 4 core, 150GB SSD GH runner are racking up costs.
2. Integration tests are running across all matrixed versions of python leading to additional cost.

**Solution:**

1. Updating the runner back to the public GH runner: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories - 4 core, 16GB ram, 14 GB SSD.
2. Update the integration tests to run on py 3.10
3. Updating the unit tests to run on both 3.9 and 3.10

**Testing:**

1. Will be looking at the GH action run