### PR TITLE
fix: update artifact to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,7 @@ jobs:
 
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: htmlcov


### PR DESCRIPTION
Problem: 
My github action is not running: https://github.com/Sage-Bionetworks/schematic/actions/runs/10816488708/job/30007767713

See log: 
```
Prepare workflow directory
Prepare all required actions
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

Update artifact to v4 because of deprecation: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

See issue: https://sagebionetworks.jira.com/browse/FDS-2402
