### PR TITLE
FDS-2403 Add Codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners of whole repo
+* @andrewelamb @GiaJordan @linglp


### PR DESCRIPTION
- Fixes [FDS-2403]
- Adds FAIR backend engineers as codeowners


[FDS-2403]: https://sagebionetworks.jira.com/browse/FDS-2403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ