### PR TITLE
[FDS-2415] Fixes `pdoc` Workflow

### DIFF
--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - develop
-      - bwmac/FDS-2415/fix-pdoc-workflow
   workflow_dispatch:  # Allow manually triggering the workflow
 
 # security: restrict permissions for CI jobs.

--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - develop
+      - bwmac/FDS-2415/fix-pdoc-workflow
   workflow_dispatch:  # Allow manually triggering the workflow
 
 # security: restrict permissions for CI jobs.
@@ -79,6 +80,7 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/schematic
+          name: schematic-docs-${{ matrix.python-version }}
 
   # Deploy the artifact to GitHub pages.
   # This is a separate job so that only actions/deploy-pages has the necessary permissions.


### PR DESCRIPTION
After upgrading the version of `actions/upload-pages-artifact` in #1502, the `pdoc` workflow failed. This is due to the configuration of our workflow where we build documentation in both Python 3.9 and 3.10 without specifying the name, which is no longer allowed in `actions/upload-pages-artifact@v3`. This PR addresses this issue by selecting the Python version in the `name` section of this workflow block.

In the future we may want to decide if building the documentation for both versions is necessary, but for now this update should get the workflow running again. 