### PR TITLE
Fixes failing `pdoc` deployment

### DIFF
--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/schematic
-          name: github-pages-${{ env.PYTHON_VERSION }}
+          name: github-pages
 
   # Deploy the artifact to GitHub pages.
   # This is a separate job so that only actions/deploy-pages has the necessary permissions.

--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       POETRY_VERSION:  1.3.0
-      PYTHON_VERSION: "3.10"
+      PYTHON_VERSION: 3.10
 
     steps:
       #----------------------------------------------

--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - develop
-      - bwmac/pdoc-deploy-fail
   workflow_dispatch:  # Allow manually triggering the workflow
 
 # security: restrict permissions for CI jobs.

--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - develop
+      - bwmac/pdoc-deploy-fail
   workflow_dispatch:  # Allow manually triggering the workflow
 
 # security: restrict permissions for CI jobs.
@@ -28,9 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       POETRY_VERSION:  1.3.0
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10"]
+      PYTHON_VERSION: "3.10"
 
     steps:
       #----------------------------------------------
@@ -39,10 +38,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
       
       #----------------------------------------------
       #          install & configure poetry         
@@ -62,7 +61,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ env.PYTHON_VERSION }}
 
       #----------------------------------------------
       # install dependencies and root project
@@ -79,7 +78,7 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/schematic
-          name: schematic-docs-${{ matrix.python-version }}
+          name: github-pages-${{ env.PYTHON_VERSION }}
 
   # Deploy the artifact to GitHub pages.
   # This is a separate job so that only actions/deploy-pages has the necessary permissions.


### PR DESCRIPTION
This is a follow-up to #1503 which should have fixed the `pdoc` deployment. The problem with the last change was that it created two artifacts with the names `schematic-docs-3.9` and `schematic-docs-3.10`, when the `deploy` step expects an artifact called `github-pages`. The previous fix required an update to the naming because the newer version of `upload-pages-artifact` does not allow duplicate names. So therefore we now cannot have the `build` part of the workflow run on both Python 3.9 and 3.10 and also have the `deploy` step work properly.

This PR adjusts the `build` step to use only Python 3.10 and then to produce a single artifact called `github-pages` which can then (hopefully) be deployed. 

**Note:** It is difficult to test this step in a feature branch because there is a branch protection policy in place preventing that from happening.