### PR TITLE
Fix: remove caching poetry dependencies in CI workfows

### DIFF
--- a/.github/workflows/api_test.yml
+++ b/.github/workflows/api_test.yml
@@ -43,21 +43,11 @@ jobs:
             | python3 - --version ${{ env.POETRY_VERSION }};
           poetry config virtualenvs.create true;
           poetry config virtualenvs.in-project true;
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
-
+          
       #----------------------------------------------
       # install dependencies and root project
       #----------------------------------------------
       - name: Install dependencies and root project
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --all-extras
 
       #----------------------------------------------

--- a/.github/workflows/pdoc.yml
+++ b/.github/workflows/pdoc.yml
@@ -53,20 +53,9 @@ jobs:
           poetry config virtualenvs.in-project true; 
 
       #----------------------------------------------
-      #       load cached venv if cache exists      
-      #----------------------------------------------
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ env.PYTHON_VERSION }}
-
-      #----------------------------------------------
       # install dependencies and root project
       #----------------------------------------------
       - name: Install dependencies and root project
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --all-extras
 
       # create documentation

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,20 +34,9 @@ jobs:
           poetry config virtualenvs.in-project true;
 
       #----------------------------------------------
-      #       load cached venv if cache exists      
-      #----------------------------------------------
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
-
-      #----------------------------------------------
       # install dependencies and root project
       #----------------------------------------------
       - name: Install dependencies and root project
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --all-extras
         
       #----------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
             | python3 - --version ${{ env.POETRY_VERSION }};
           poetry config virtualenvs.create true;
           poetry config virtualenvs.in-project true;
-          poetry env info --path; # print out virtual environment
+          poetry env info --path;
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           poetry config virtualenvs.create true;
           poetry config virtualenvs.in-project true;
           poetry env info;
-          poetry env info --path;
+          poetry config --list;
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         id: cached-poetry-dependencies
         uses: actions/cache@v4
         with:
-          path: .venv
+          path: ~/.cache/pypoetry/virtualenvs
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
 
       #----------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,25 +65,13 @@ jobs:
         run: |
           curl -sSL https://install.python-poetry.org \
             | python3 - --version ${{ env.POETRY_VERSION }};
-          poetry config virtualenvs.create true --local;
-          poetry config virtualenvs.in-project false --local;
-          poetry env info;
-          poetry config --list;
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
-
+          poetry config virtualenvs.create true;
+          poetry config virtualenvs.in-project false;
+          
       #----------------------------------------------
       # install dependencies and root project
       #----------------------------------------------
       - name: Install dependencies and root project
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --all-extras
 
       #----------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,7 +134,6 @@ jobs:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
         run: >
-          poetry shell;
           poetry run pytest --durations=0 --cov-append --cov-report=term --cov-report=html:htmlcov 
           --cov-report=xml:coverage.xml --cov=schematic/ --reruns 4 -n 8 tests/unit;
 
@@ -147,7 +146,6 @@ jobs:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
         run: >
-          poetry shell;
           poetry run pytest --durations=0 --cov-append --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov=schematic/
           -m "not (rule_benchmark)" --reruns 4 -n 8 --ignore=tests/unit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
             | python3 - --version ${{ env.POETRY_VERSION }};
           poetry config virtualenvs.create true;
           poetry config virtualenvs.in-project true;
+          poetry env info; # print out virtual environment
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
             | python3 - --version ${{ env.POETRY_VERSION }};
           poetry config virtualenvs.create true;
           poetry config virtualenvs.in-project true;
+          poetry env use 3.10;
           poetry env info;
           poetry config --list;
       #----------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,9 +65,8 @@ jobs:
         run: |
           curl -sSL https://install.python-poetry.org \
             | python3 - --version ${{ env.POETRY_VERSION }};
-          poetry config virtualenvs.create true;
-          poetry config virtualenvs.in-project true;
-          poetry env use 3.10;
+          poetry config virtualenvs.create true --local;
+          poetry config virtualenvs.in-project false --local;
           poetry env info;
           poetry config --list;
       #----------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,9 +134,9 @@ jobs:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
         run: >
-          source .venv/bin/activate;
-          pytest --durations=0 --cov-append --cov-report=term --cov-report=html:htmlcov 
-          --cov-report=xml:coverage.xml --cov=schematic/ --reruns 4 -n 8 tests/unit
+          poetry shell;
+          poetry run pytest --durations=0 --cov-append --cov-report=term --cov-report=html:htmlcov 
+          --cov-report=xml:coverage.xml --cov=schematic/ --reruns 4 -n 8 tests/unit;
 
       #----------------------------------------------
       #              run integration test suite
@@ -147,8 +147,8 @@ jobs:
           SYNAPSE_ACCESS_TOKEN: ${{ secrets.SYNAPSE_ACCESS_TOKEN }}
           SERVICE_ACCOUNT_CREDS: ${{ secrets.SERVICE_ACCOUNT_CREDS }}
         run: >
-          source .venv/bin/activate;
-          pytest --durations=0 --cov-append --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov=schematic/
+          poetry shell;
+          poetry run pytest --durations=0 --cov-append --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml --cov=schematic/
           -m "not (rule_benchmark)" --reruns 4 -n 8 --ignore=tests/unit
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
             | python3 - --version ${{ env.POETRY_VERSION }};
           poetry config virtualenvs.create true;
           poetry config virtualenvs.in-project true;
-          poetry env info; # print out virtual environment
+          poetry env info --path; # print out virtual environment
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
             | python3 - --version ${{ env.POETRY_VERSION }};
           poetry config virtualenvs.create true;
           poetry config virtualenvs.in-project true;
+          poetry env info;
           poetry env info --path;
       #----------------------------------------------
       #       load cached venv if cache exists


### PR DESCRIPTION
## Problem
Relates to: https://sagebionetworks.jira.com/browse/FDS-2439
For some reasons, virtual environment was not created successfully in this step: 
```
      - name: Install Poetry
        run: |
          curl -sSL https://install.python-poetry.org \
            | python3 - --version ${{ env.POETRY_VERSION }};
          poetry config virtualenvs.create true;
          poetry config virtualenvs.in-project true;
```
That caused poetry to show the following error: 
```
The virtual environment found in /home/runner/work/schematic/schematic/.venv seems to be broken.
Recreating virtualenv schematicpy in /home/runner/work/schematic/schematic/.venv
```

I can confirm that the virtual env didn't get created successfully because when I did `poetry env info`, `Path` variable is showing as empty, and `poetry env info --path` didn't work when I ran that on GH remotely. 

Since installing dependencies doesn't take that much time anyway, @BWMac, @jaymedina and I decided to remove the capacity of caching dependencies for now. 

More context can be found [here](https://sagebionetworks.slack.com/archives/C07HLTBS5D2/p1726703103242389)

## Solution 
Remove caching when installing dependencies. 

Note: in the future, if there's a need to utilize cached dependencies, the documentation here: https://python-poetry.org/docs/configuration/#virtualenvsin-project and also looking at these two commit: https://github.com/Sage-Bionetworks/schematic/pull/1507/commits/8339da7edc694f4fe75755e799ee1cbe61f119d2 and https://github.com/Sage-Bionetworks/schematic/pull/1507/commits/7fee9164fe7eaa9cc4fef2cced9677f93b26b17c will be helpful. 
