### PR TITLE
[FDS-2440] Check for and remove corrupt virtual environments in cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,24 @@ jobs:
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
-
+      #----------------------------------------------
+      # validate cached venv if it exists and remove if corrupt
+      #----------------------------------------------
+      - name: Check and remove broken virtual environment (if necessary)
+        if: steps.cached-poetry-dependencies.outputs.cache-hit == 'true'
+        run: |
+          VENV_PATH=$(poetry env info --path)
+          if [ -d "$VENV_PATH" ]; then
+          source $VENV_PATH/bin/activate && poetry run black --version || (echo "Removing broken venv"; rm -rf $VENV_PATH; echo "venv-deleted=true" >> $GITHUB_ENV)
+          else
+            echo "Virtual environment not found"
+          fi
+      #----------------------------------------------
+      # install dependencies and root project
+      #----------------------------------------------
+      - name: Install dependencies and root project
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true' || env.venv-deleted == 'true'
+        run: poetry install --no-interaction --all-extras
       #----------------------------------------------
       # install dependencies and root project
       #----------------------------------------------

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,13 +95,6 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true' || env.venv-deleted == 'true'
         run: poetry install --no-interaction --all-extras
       #----------------------------------------------
-      # install dependencies and root project
-      #----------------------------------------------
-      - name: Install dependencies and root project
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --all-extras
-
-      #----------------------------------------------
       #             perform linting
       #----------------------------------------------
       # Disabled until we agree to turn it on


### PR DESCRIPTION
## problem

Some of the CI builds on schematic have been breaking due to a corrupt virtual environment being loaded up. Currently the reason for this corruption is unknown. In the meantime, we can implement a failsafe to check for a corrupt virtual environment and remove it, then create a new venv to replace the corrupt one and cache it.

More context on [Slack](https://sagebionetworks.slack.com/archives/C07HLTBS5D2/p1726703103242389)

## solution

- [x] Add a step in `test.yml` to check for and remove corrupt virtual environments in the cache + create a new venv
- [ ] Add a step in `test.yml` to cache the new venv

## testing & preview