### PR TITLE
Update link to readthedocs.io to stable instead of latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Schematic
-[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FSage-Bionetworks%2Fschematic%2Fbadge%3Fref%3Ddevelop&style=flat)](https://actions-badge.atrox.dev/Sage-Bionetworks/schematic/goto?ref=develop) [![Documentation Status](https://readthedocs.org/projects/sage-schematic/badge/?version=develop)](https://sage-schematic.readthedocs.io/en/develop/?badge=develop) [![PyPI version](https://badge.fury.io/py/schematicpy.svg)](https://badge.fury.io/py/schematicpy)
+[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FSage-Bionetworks%2Fschematic%2Fbadge%3Fref%3Ddevelop&style=flat)](https://actions-badge.atrox.dev/Sage-Bionetworks/schematic/goto?ref=develop) [![Documentation Status](https://readthedocs.org/projects/sage-schematic/badge/?version=develop)](https://sage-schematic.readthedocs.io/en/stable/?badge=develop) [![PyPI version](https://badge.fury.io/py/schematicpy.svg)](https://badge.fury.io/py/schematicpy)
 
 # Table of contents
 - [Schematic](#schematic)
@@ -337,7 +337,7 @@ schematic model -c /path/to/config.yml validate -dt <your data type> -mp <your c
 schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse dataset folder id> -vc <your data type> -mrt file_only
 ```
 
-Please visit more documentation [here](https://sage-schematic.readthedocs.io/en/develop/cli_reference.html) for more information. 
+Please visit more documentation [here](https://sage-schematic.readthedocs.io/en/stable/cli_reference.html) for more information. 
 
 
 


### PR DESCRIPTION
Currently, the typical links to the schematic CLI docs  are not displaying the CLI options properly:
- https://sage-schematic.readthedocs.io/en/develop/cli_reference.html
- https://sage-schematic.readthedocs.io/en/latest/cli_reference.html

This PR changes the link to https://sage-schematic.readthedocs.io/en/stable/cli_reference.html which appears to be working properly. However, it doesn't address the cause of issue, which may eventually propagate to the `stable` docs.