### PR TITLE
[FDS-2497] Wrap google API execute calls with a 5 attempt retry

### DIFF
--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -156,18 +156,6 @@ def export_manifest_csv(file_path: str, manifest: Union[pd.DataFrame, str]) -> N
         export_manifest_drive_service(manifest, file_path, mime_type="text/csv")
 
 
-def raise_final_error(retry_state: Any) -> Any:
-    """After the final attempt, raise the error.
-
-    Args:
-        retry_state (Any): retry state object
-
-    Returns:
-        Any: result of the outcome
-    """
-    return retry_state.outcome.result()
-
-
 @retry(
     stop=stop_after_attempt(5),
     wait=wait_chain(
@@ -176,7 +164,6 @@ def raise_final_error(retry_state: Any) -> Any:
         + [wait_fixed(5)]
     ),
     retry=retry_if_exception_type(HttpError),
-    retry_error_callback=raise_final_error,
 )
 def google_api_execute_wrapper(api_function_to_call: Callable[[], Any]) -> Any:
     """Retry wrapper for Google API calls, with a backoff strategy.

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -164,6 +164,7 @@ def export_manifest_csv(file_path: str, manifest: Union[pd.DataFrame, str]) -> N
         + [wait_fixed(5)]
     ),
     retry=retry_if_exception_type(HttpError),
+    reraise=True,
 )
 def google_api_execute_wrapper(api_function_to_call: Callable[[], Any]) -> Any:
     """Retry wrapper for Google API calls, with a backoff strategy.

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, TypedDict, Union, no_type_check
 import pandas as pd
 from google.oauth2 import service_account  # type: ignore
 from googleapiclient.discovery import Resource, build  # type: ignore
-from googleapiclient.errors import HttpError
+from googleapiclient.errors import HttpError  # type: ignore
 from tenacity import (
     retry,
     retry_if_exception_type,

--- a/schematic/utils/google_api_utils.py
+++ b/schematic/utils/google_api_utils.py
@@ -2,14 +2,23 @@
 
 # pylint: disable=logging-fstring-interpolation
 
-import os
-import logging
 import json
-from typing import Any, Union, no_type_check, TypedDict
+import logging
+import os
+from typing import Any, Callable, TypedDict, Union, no_type_check
 
 import pandas as pd
-from googleapiclient.discovery import build, Resource  # type: ignore
 from google.oauth2 import service_account  # type: ignore
+from googleapiclient.discovery import Resource, build  # type: ignore
+from googleapiclient.errors import HttpError
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_chain,
+    wait_fixed,
+)
+
 from schematic.configuration.configuration import CONFIG
 
 logger = logging.getLogger(__name__)
@@ -86,10 +95,10 @@ def execute_google_api_requests(service, requests_body, **kwargs) -> Any:
         and kwargs["service_type"] == "batch_update"
     ):
         # execute all requests
-        response = (
+        response = google_api_execute_wrapper(
             service.spreadsheets()
             .batchUpdate(spreadsheetId=kwargs["spreadsheet_id"], body=requests_body)
-            .execute()
+            .execute
         )
 
         return response
@@ -118,10 +127,10 @@ def export_manifest_drive_service(
 
     # use google drive
     # Pylint seems to have trouble with the google api classes, recognizing their methods
-    data = (
+    data = google_api_execute_wrapper(
         drive_service.files()  # pylint: disable=no-member
         .export(fileId=spreadsheet_id, mimeType=mime_type)
-        .execute()
+        .execute
     )
 
     # open file and write data
@@ -145,3 +154,37 @@ def export_manifest_csv(file_path: str, manifest: Union[pd.DataFrame, str]) -> N
         manifest.to_csv(file_path, index=False)
     else:
         export_manifest_drive_service(manifest, file_path, mime_type="text/csv")
+
+
+def raise_final_error(retry_state: Any) -> Any:
+    """After the final attempt, raise the error.
+
+    Args:
+        retry_state (Any): retry state object
+
+    Returns:
+        Any: result of the outcome
+    """
+    return retry_state.outcome.result()
+
+
+@retry(
+    stop=stop_after_attempt(5),
+    wait=wait_chain(
+        *[wait_fixed(1) for i in range(2)]
+        + [wait_fixed(2) for i in range(2)]
+        + [wait_fixed(5)]
+    ),
+    retry=retry_if_exception_type(HttpError),
+    retry_error_callback=raise_final_error,
+)
+def google_api_execute_wrapper(api_function_to_call: Callable[[], Any]) -> Any:
+    """Retry wrapper for Google API calls, with a backoff strategy.
+
+    Args:
+        api_function_to_call (Callable[[], Any]): The function to call
+
+    Returns:
+        Any: The result of the API call
+    """
+    return api_function_to_call()


### PR DESCRIPTION
**Problem:**

1. Errors like the following kept popping up:
```
 Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.15/x64/bin/schematic", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/click/decorators.py", line 45, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schematic/manifest/commands.py", line 251, in get_manifest
    result = create_single_manifest(
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schematic/manifest/commands.py", line 201, in create_single_manifest
    result = manifest_generator.get_manifest(
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schematic/manifest/generator.py", line 1789, in get_manifest
    manifest_url = self.get_empty_manifest(
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schematic/manifest/generator.py", line 1320, in get_empty_manifest
    manifest_url = self._create_empty_gs(
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schematic/manifest/generator.py", line 1245, in _create_empty_gs
    requests_body = self._create_requests_body(
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schematic/manifest/generator.py", line 1187, in _create_requests_body
    create_dropdown = self._request_dropdown(
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schematic/manifest/generator.py", line 991, in _request_dropdown
    validation_body = self._get_column_data_validation_values(
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schematic/manifest/generator.py", line 328, in _get_column_data_validation_values
    valid_values = self._store_valid_values_as_data_dictionary(
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/schematic/manifest/generator.py", line 309, in _store_valid_values_as_data_dictionary
    .execute()
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/googleapiclient/_helpers.py", line 130, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/googleapiclient/http.py", line 938, in execute
    raise HttpError(resp, content, uri=self.uri)
googleapiclient.errors.HttpError: <HttpError 502 when requesting https://sheets.googleapis.com/v4/spreadsheets/1hLLgWh8dEQHAn-IZQDGR3YbrL_SFMIIky2B3XJuplys/values/Sheet2%21F2%3AF8?valueInputOption=RAW&alt=json returned "Bad Gateway". Details: "<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 502 (Server Error)!!1</title>
  <style>
    ****margin:0;padding:0***html,code***font:15px/22px arial,sans-serif***html***background:#fff;color:#222;padding:15px***body***margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px**** > body***background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px***p***margin:11px 0 22px;overflow:hidden***ins***color:#777;text-decoration:none***a img***border:0***@media screen and (max-width:772px)***body***background:none;margin-top:0;max-width:none;padding-right:0***#logo***background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px***@media only screen and (min-resolution:192dpi)***#logo***background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0***@media only screen and (-webkit-min-device-pixel-ratio:2)***#logo***background:url(//www.google
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>502.</b> <ins>That’s an error.</ins>
  <p>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.  <ins>That’s all we know.</ins>
">
```

**Solution:**

1. Grabbing the retry logic used in other parts of the code to wrap the google API calls with retry.

**Testing:**

1. Relying on the existing tests that are hitting this logic. I also ran the code locally to verify the test.