### PR TITLE
[SCHEMATIC-1] BugFix: manifest submission when data previously annotated without manifest upload

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -2825,7 +2825,7 @@ class SynapseStorage(BaseStorage):
             try:
                 logger.info("Trying batch mode for retrieving Synapse annotations")
                 table = self.getDatasetAnnotationsBatch(datasetId, dataset_file_ids)
-            except (SynapseAuthenticationError, SynapseHTTPError):
+            except (SynapseAuthenticationError, SynapseHTTPError, ValueError):
                 logger.info(
                     f"Unable to create a temporary file view bound to {datasetId}. "
                     "Defaulting to slower iterative retrieval of annotations."

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -2825,7 +2825,7 @@ class SynapseStorage(BaseStorage):
             try:
                 logger.info("Trying batch mode for retrieving Synapse annotations")
                 table = self.getDatasetAnnotationsBatch(datasetId, dataset_file_ids)
-            except (SynapseAuthenticationError, SynapseHTTPError):
+            except:
                 logger.info(
                     f"Unable to create a temporary file view bound to {datasetId}. "
                     "Defaulting to slower iterative retrieval of annotations."

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -3508,6 +3508,12 @@ class DatasetFileView:
         # Rename ROW_ETAG column to eTag and place at end of data frame
         if "ROW_ETAG" in self.table:
             row_etags = self.table.pop("ROW_ETAG")
+
+            # eTag column may already present if users annotated data without submitting manifest
+            # we're only concerned with the new values and not the existing ones
+            if "eTag" in self.table:
+                del self.table["eTag"]
+
             self.table.insert(len(self.table.columns), "eTag", row_etags)
 
         return self.table

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -2825,7 +2825,7 @@ class SynapseStorage(BaseStorage):
             try:
                 logger.info("Trying batch mode for retrieving Synapse annotations")
                 table = self.getDatasetAnnotationsBatch(datasetId, dataset_file_ids)
-            except:
+            except (SynapseAuthenticationError, SynapseHTTPError):
                 logger.info(
                     f"Unable to create a temporary file view bound to {datasetId}. "
                     "Defaulting to slower iterative retrieval of annotations."

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1006,23 +1006,26 @@ class TestDatasetFileView:
         expected_metadata = pd.DataFrame(
             {
                 "Component": {
-                    0: "BulkRNA-seqAssay",
+                    0: nan,
                     1: "BulkRNA-seqAssay",
                     2: "BulkRNA-seqAssay",
                     3: "BulkRNA-seqAssay",
+                    4: "BulkRNA-seqAssay",
                 },
-                "FileFormat": {0: "BAM", 1: "BAM", 2: "BAM", 3: "BAM"},
+                "FileFormat": {0: nan, 1: "BAM", 2: "BAM", 3: "BAM", 4: "BAM"},
                 "GenomeBuild": {
-                    0: "GRCh37",
+                    0: nan,
                     1: "GRCh37",
                     2: "GRCh37",
                     3: "GRCh37",
+                    4: "GRCh37",
                 },
                 "entityId": {
-                    0: "syn64020000",
-                    1: "syn64020001",
-                    2: "syn64020002",
-                    3: "syn64020003",
+                    0: "syn64019999",
+                    1: "syn64020000",
+                    2: "syn64020001",
+                    3: "syn64020002",
+                    4: "syn64020003",
                 },
             },
         ).set_index("entityId", drop=False)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, patch
 
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 from synapseclient import EntityViewSchema, Folder
 from synapseclient.core.exceptions import SynapseHTTPError
 from synapseclient.entity import File, Project
@@ -990,6 +990,34 @@ class TestDatasetFileView:
         year_value = table.loc[sample_a_row, "YearofBirth"][0]
         assert isinstance(year_value, str)
         assert year_value == "1980"
+
+    def test_tidy_no_manifest_uploaded(self, synapse_store):
+        """
+        Test to ensure that the table can be tidied without issue when a DatasetFileView object is instantiated
+        based on a dataset that has files annotated but no manifest uploaded.
+        Covers the case where a user validates a manifest with schematic, and annotates the files with a non-schematic tool (ie the R client),
+        and then tries to generate a manifest for the dataset with schematic.
+        """
+        # GIVEN a dataset that has files annotated but no manifest uplodaded
+        dataset_id = "syn64019998"
+        # WHEN a DatasetFileView object is instantiated based on the dataset
+        dataset_fileview = DatasetFileView(dataset_id, synapse_store.syn)
+        # AND the fileview is queried
+        table = dataset_fileview.query(tidy=False, force=True)
+        # THEN a table should be present
+        assert isinstance(table, pd.DataFrame)
+        # AND the table should not be empty
+        assert not table.empty
+        # AND the table should already include the eTag column
+        assert "eTag" in table.columns
+        original_etag_colum = table["eTag"]
+        # AND the table should be able to be tidied without an exception being raised
+        with does_not_raise():
+            table = dataset_fileview.tidy_table()
+        # AND the expected metadata should be present in the table
+
+        # AND the eTag column should be different from the original eTag column
+        assert (table["eTag"] != original_etag_colum).all()
 
 
 @pytest.mark.table_operations

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, patch
 import pandas as pd
 import pytest
 from numpy import nan
-from pandas.testing import assert_frame_equal, assert_series_equal
+from pandas.testing import assert_frame_equal
 from synapseclient import EntityViewSchema, Folder
 from synapseclient.core.exceptions import SynapseHTTPError
 from synapseclient.entity import File, Project

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1006,26 +1006,23 @@ class TestDatasetFileView:
         expected_metadata = pd.DataFrame(
             {
                 "Component": {
-                    0: nan,
+                    0: "BulkRNA-seqAssay",
                     1: "BulkRNA-seqAssay",
                     2: "BulkRNA-seqAssay",
                     3: "BulkRNA-seqAssay",
-                    4: "BulkRNA-seqAssay",
                 },
-                "FileFormat": {0: nan, 1: "BAM", 2: "BAM", 3: "BAM", 4: "BAM"},
+                "FileFormat": {0: "BAM", 1: "BAM", 2: "BAM", 3: "BAM"},
                 "GenomeBuild": {
-                    0: nan,
+                    0: "GRCh37",
                     1: "GRCh37",
                     2: "GRCh37",
                     3: "GRCh37",
-                    4: "GRCh37",
                 },
                 "entityId": {
-                    0: "syn64019999",
-                    1: "syn64020000",
-                    2: "syn64020001",
-                    3: "syn64020002",
-                    4: "syn64020003",
+                    0: "syn64020000",
+                    1: "syn64020001",
+                    2: "syn64020002",
+                    3: "syn64020003",
                 },
             },
         ).set_index("entityId", drop=False)


### PR DESCRIPTION
## Issue
Resolves [SCHEMATIC-1](https://sagebionetworks.jira.com/browse/SCHEMATIC-1) which occurs when users:
- Have a dataset/top level folder on synapse with 50 or more files
- generate a manifest with schematic/DCA and fill it out
  - possibly validate the manifest with schematic
- Use the manifest to annotate the data with a client other than schematic ie. R
- Try to generate a new manifest with schematic using the existing annotations from the data on synapse


## Changes

- when a temporary file view is created with `DatasetFileView` and the resulting view is "tidied", any existing `eTag`  columns will be removed before the new values are stored in that column.
- Test resources on synapse have been created to replicate the issue and an integration test has been added. It was not necessary to include 50+ files as we're testing `DatasetFileView` directly instead of through manifest generation

## Notes

- Technically using `--use_annotations` to generate a manifest for a dataset where there isn't already a manifest present is not supported, but this provides a way for users to get back on the recommended data flow path instead of having to start all over. 
- `DatasetFileView` is only used in this one case, gathering annotations for files in a dataset with more than 50 files. With the ability we have now to scope fileview queries in the `SynapseStorage` object and get the annotations for all files in a dataset we should consider whether we should deprecate the `DatasetFileView` class.
- We should also consider whether there's anything else preventing us from officially supporting using the `--use_annotations` feature when there is no manifest in the dataset since this change enables it in at least this case.

[SCHEMATIC-1]: https://sagebionetworks.jira.com/browse/SCHEMATIC-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ