### PR TITLE
[SCHEMATIC-157] Make some dependencies required to avoid `schematic CLI` commands from potentially erroring when doing a pip install

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -275,7 +275,7 @@ lxml = ["lxml"]
 name = "binapy"
 version = "0.8.0"
 description = "Binary Data manipulation, for humans."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "binapy-0.8.0-py3-none-any.whl", hash = "sha256:8af1e1e856900ef8b79ef32236e296127c9cf26414ec355982ff7ce5f173504d"},
@@ -606,7 +606,7 @@ click = "*"
 name = "clickclick"
 version = "20.10.2"
 description = "Click utility functions"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "clickclick-20.10.2-py2.py3-none-any.whl", hash = "sha256:c8f33e6d9ec83f68416dd2136a7950125bd256ec39ccc9a85c6e280a16be2bb5"},
@@ -649,7 +649,7 @@ test = ["pytest"]
 name = "connexion"
 version = "2.14.1"
 description = "Connexion - API first applications with OpenAPI/Swagger and Flask"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "connexion-2.14.1-py2.py3-none-any.whl", hash = "sha256:f343717241b4c4802a694c38fee66fb1693c897fe4ea5a957fa9b3b07caf6394"},
@@ -1059,7 +1059,7 @@ pyflakes = ">=3.1.0,<3.2.0"
 name = "flask"
 version = "2.1.3"
 description = "A simple framework for building complex web applications."
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "Flask-2.1.3-py3-none-any.whl", hash = "sha256:9013281a7402ad527f8fd56375164f3aa021ecfaff89bfe3825346c24f87e04c"},
@@ -1081,7 +1081,7 @@ dotenv = ["python-dotenv"]
 name = "flask-cors"
 version = "3.0.10"
 description = "A Flask extension adding a decorator for CORS support"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "Flask-Cors-3.0.10.tar.gz", hash = "sha256:b60839393f3b84a0f3746f6cdca56c1ad7426aa738b70d6c61375857823181de"},
@@ -1107,7 +1107,7 @@ files = [
 name = "furl"
 version = "2.1.3"
 description = "URL manipulation made simple."
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "furl-2.1.3-py2.py3-none-any.whl", hash = "sha256:9ab425062c4217f9802508e45feb4a83e54324273ac4b202f1850363309666c0"},
@@ -1965,7 +1965,7 @@ files = [
 name = "jwskate"
 version = "0.11.1"
 description = "A Pythonic implementation of the JOSE / JSON Web Crypto related RFCs (JWS, JWK, JWA, JWT, JWE)"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "jwskate-0.11.1-py3-none-any.whl", hash = "sha256:cdfa04fac10366afab08c20d2f75d1c6b57dc7d099b407b8fb4318349272f933"},
@@ -2716,7 +2716,7 @@ files = [
 name = "orderedmultidict"
 version = "1.0.1"
 description = "Ordered Multivalue Dictionary"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "orderedmultidict-1.0.1-py2.py3-none-any.whl", hash = "sha256:43c839a17ee3cdd62234c47deca1a8508a3f2ca1d0678a3bf791c87cf84adbf3"},
@@ -3859,7 +3859,7 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 name = "requests-oauth2client"
 version = "1.6.0"
 description = "An OAuth2.x client based on `requests`."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "requests_oauth2client-1.6.0-py3-none-any.whl", hash = "sha256:fa702619409cc93ab6433871d1ccec58140a70d86923fd742983fac47b334881"},
@@ -4384,7 +4384,7 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 name = "swagger-ui-bundle"
 version = "0.0.9"
 description = "swagger_ui_bundle - swagger-ui files in a pip package"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "swagger_ui_bundle-0.0.9-py3-none-any.whl", hash = "sha256:cea116ed81147c345001027325c1ddc9ca78c1ee7319935c3c75d3669279d575"},
@@ -4774,7 +4774,7 @@ test = ["websockets"]
 name = "werkzeug"
 version = "2.3.8"
 description = "The comprehensive WSGI web application library."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "werkzeug-2.3.8-py3-none-any.whl", hash = "sha256:bba1f19f8ec89d4d607a3bd62f1904bd2e609472d93cd85e9d4e178f472c3748"},
@@ -4897,10 +4897,10 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-api = ["Flask", "Flask-Cors", "Jinja2", "connexion", "opentelemetry-api", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-sdk", "pyopenssl", "requests-oauth2client"]
+api = ["Jinja2", "opentelemetry-api", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-sdk", "pyopenssl"]
 aws = ["uWSGI"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<3.11"
-content-hash = "51c3ee12af9b2e5be886b577dcccf8a4de7de411381225db30ea5bcfaa247cd5"
+content-hash = "3d585110760814bcfe58e9a6cc84226a1ed2dc16d17f5c1d0efc03f4e1500f9b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2547,7 +2547,7 @@ wrapt = ">=1.0.0,<2.0.0"
 name = "opentelemetry-instrumentation-flask"
 version = "0.49b1"
 description = "Flask instrumentation for OpenTelemetry"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "opentelemetry_instrumentation_flask-0.49b1-py3-none-any.whl", hash = "sha256:e3abb8aaccb86372bfddaa894fa9b4c6cc8c1ac2e023e0bb64c97f07d9df3d28"},
@@ -2643,7 +2643,7 @@ opentelemetry-util-http = "0.49b1"
 name = "opentelemetry-instrumentation-wsgi"
 version = "0.49b1"
 description = "WSGI Middleware for OpenTelemetry"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "opentelemetry_instrumentation_wsgi-0.49b1-py3-none-any.whl", hash = "sha256:6ab07115dc5c38f9c5b368e1ae4d9741cddeeef857ad01b211ee314a72ffdbea"},
@@ -4897,10 +4897,10 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-api = ["Flask", "Flask-Cors", "Jinja2", "connexion", "opentelemetry-api", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-instrumentation-flask", "opentelemetry-sdk", "pyopenssl", "requests-oauth2client"]
+api = ["Flask", "Flask-Cors", "Jinja2", "connexion", "opentelemetry-api", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-sdk", "pyopenssl", "requests-oauth2client"]
 aws = ["uWSGI"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<3.11"
-content-hash = "e6a9548ab006a486b1f64fecfd32177821b373ad8b6a4528e79a38449cfe8065"
+content-hash = "51c3ee12af9b2e5be886b577dcccf8a4de7de411381225db30ea5bcfaa247cd5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,11 +74,11 @@ PyJWT = "^2.9.0"
 opentelemetry-api = {version = ">=1.21.0", optional = true}
 opentelemetry-sdk = {version = ">=1.21.0", optional = true}
 opentelemetry-exporter-otlp-proto-http = {version="^1.0.0", optional = true}
-opentelemetry-instrumentation-flask = {version=">=0.48b0", optional = true}
+opentelemetry-instrumentation-flask = ">=0.48b0"
 requests-oauth2client = {version=">=1.6.0", optional = true}
 
 [tool.poetry.extras]
-api = ["connexion", "Flask", "Flask-Cors", "Jinja2", "pyopenssl", "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-instrumentation-flask", "requests-oauth2client"]
+api = ["connexion", "Flask", "Flask-Cors", "Jinja2", "pyopenssl", "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http", "requests-oauth2client"]
 aws = ["uWSGI"]
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,9 @@ pandarallel = "^1.6.4"
 pyopenssl = {version = "^23.0.0", optional = true}
 dataclasses-json = "^0.6.1"
 pydantic = "^1.10.4"
-connexion = {extras = ["swagger-ui"], version = "^2.8.0", optional = true}
-Flask = {version = "2.1.3", optional = true}
-Flask-Cors = {version = "^3.0.10", optional = true}
+connexion = {extras = ["swagger-ui"], version = "^2.8.0"}
+Flask = "2.1.3"
+Flask-Cors = "^3.0.10"
 uWSGI = {version = "^2.0.21", optional = true}
 Jinja2 = {version = ">2.11.3", optional = true}
 asyncio = "^3.4.3"
@@ -75,10 +75,10 @@ opentelemetry-api = {version = ">=1.21.0", optional = true}
 opentelemetry-sdk = {version = ">=1.21.0", optional = true}
 opentelemetry-exporter-otlp-proto-http = {version="^1.0.0", optional = true}
 opentelemetry-instrumentation-flask = ">=0.48b0"
-requests-oauth2client = {version=">=1.6.0", optional = true}
+requests-oauth2client = ">=1.6.0"
 
 [tool.poetry.extras]
-api = ["connexion", "Flask", "Flask-Cors", "Jinja2", "pyopenssl", "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http", "requests-oauth2client"]
+api = ["Jinja2", "pyopenssl", "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http"]
 aws = ["uWSGI"]
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Problem
Tagging as SCHEMATIC-157 as it is related to the `--all-extras` we had to tack on to make the CLI documentation to show up.

When doing 
```
docker build -t test .
docker run test schematic --version         
Traceback (most recent call last):
  File "/usr/local/bin/schematic", line 3, in <module>
    from schematic.__main__ import main
  File "/usr/src/app/schematic/__init__.py", line 10, in <module>
    from opentelemetry.instrumentation.flask import FlaskInstrumentor
ModuleNotFoundError: No module named 'opentelemetry.instrumentation.flask'
```

## Solution

Add in dependencies as non-optional (which does blow up the dependencies that people have to install when using the CLI...)

In particular,  made "connexion", "Flask", "Flask-Cors", "opentelemetry-instrumentation-flask", "requests-oauth2client" non-extras

```
docker build -t test .
docker run test schematic --help                 
Usage: schematic [OPTIONS] COMMAND [ARGS]...

  Command line interface to the `schematic` backend services.

Options:
  -v, --verbosity LVL  Either CRITICAL, ERROR, WARNING, INFO or DEBUG
  -h, --help           Show this message and exit.

Commands:
  manifest  Sub-commands with Manifest Generation utilities/methods.
  model     Sub-commands for Metadata Model related utilities/methods.
  schema    Sub-commands for Schema related utilities/methods.
  viz       Sub-commands for Visualization methods.
```