### PR TITLE
[SCHEMATIC-136] Include schematic_api to resolve dependency issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 ]
 
 packages = [
-    { include = "schematic" }
+    { include = "schematic" },
+    { include = "schematic_api" }
 ]
 
 [tool.poetry.scripts]


### PR DESCRIPTION
## Problem
CLI dependency issue
```
 schematic --help
Traceback (most recent call last):
  File "/Users/tyu/anaconda3/envs/schematic-testing/bin/schematic", line 5, in <module>
    from schematic.__main__ import main
  File "/Users/tyu/anaconda3/envs/schematic-testing/lib/python3.9/site-packages/schematic/__init__.py", line 23, in <module>
    from schematic_api.api.security_controller import info_from_bearer_auth
ModuleNotFoundError: No module named 'schematic_api'
```

## Solution
Add `schematic_api` back in.  The alternative is to move this `info_from_bearer_auth` from `schematic_api.api` into `schematic` but I'm unsure of the impact of that on the API

i tested this in my own pypi distribution by renaming the package to be `tyu-schematicpy`. But this should work

```
pip install tyu-schematicpy
schematic --help
```

Furthermore, to test this, I created a tag and updated the dev infra to point to the tag just to triple check that the API won't fail.
