### PR TITLE
[SCHEMATIC-214] change data model and component

### DIFF
--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -6,8 +6,8 @@ Sex,,"Female, Male, Other",,,TRUE,DataProperty,,,
 Year of Birth,,,,,FALSE,DataProperty,,,
 Diagnosis,,"Healthy, Cancer",,,TRUE,DataProperty,,,
 Cancer,,,"Cancer Type, Family History",,FALSE,ValidValue,,,
-Cancer Type,,"Breast, Colorectal, Lung, Prostate, Skin",,,TRUE,DataProperty,,,
-Family History,,"Breast, Colorectal, Lung, Prostate, Skin",,,TRUE,DataProperty,,,list strict
+Cancer Type,,"Breast, Colorectal, Lung, Prostate, Skin, None",,,TRUE,DataProperty,,,
+Family History,,"Breast, Colorectal, Lung, Prostate, Skin, None",,,TRUE,DataProperty,,,list strict
 Biospecimen,,,"Sample ID, Patient ID, Tissue Status, Component",,FALSE,DataType,Patient,,
 Sample ID,,,,,TRUE,DataProperty,,,
 Tissue Status,,"Healthy, Malignant",,,TRUE,DataProperty,,,
@@ -24,8 +24,8 @@ Check List,,,,,TRUE,DataProperty,,,list
 Check List Enum,,"ab, cd, ef, gh",,,TRUE,DataProperty,,,list
 Check List Like,,,,,TRUE,DataProperty,,,list like
 Check List Like Enum,,"ab, cd, ef, gh",,,TRUE,DataProperty,,,list like
-Check List Strict,,,,,TRUE,DataProperty,,,list strict 
-Check List Enum Strict,,"ab, cd, ef, gh",,,TRUE,DataProperty,,,list strict 
+Check List Strict,,,,,TRUE,DataProperty,,,list strict
+Check List Enum Strict,,"ab, cd, ef, gh",,,TRUE,DataProperty,,,list strict
 Check Regex List,,,,,TRUE,DataProperty,,,list::regex match [a-f]
 Check Regex List Strict,,,,,TRUE,DataProperty,,,list strict::regex match [a-f]
 Check Regex List Like,,,,,TRUE,DataProperty,,,list like::regex match [a-f]

--- a/tests/data/example.model.csv
+++ b/tests/data/example.model.csv
@@ -6,11 +6,11 @@ Sex,,"Female, Male, Other",,,TRUE,DataProperty,,,
 Year of Birth,,,,,FALSE,DataProperty,,,
 Diagnosis,,"Healthy, Cancer",,,TRUE,DataProperty,,,
 Cancer,,,"Cancer Type, Family History",,FALSE,ValidValue,,,
-Cancer Type,,"Breast, Colorectal, Lung, Prostate, Skin, None",,,TRUE,DataProperty,,,
-Family History,,"Breast, Colorectal, Lung, Prostate, Skin, None",,,TRUE,DataProperty,,,list strict
+Cancer Type,,"Breast, Colorectal, Lung, Prostate, Skin",,,TRUE,DataProperty,,,
+Family History,,"Breast, Colorectal, Lung, Prostate, Skin",,,TRUE,DataProperty,,,list strict
 Biospecimen,,,"Sample ID, Patient ID, Tissue Status, Component",,FALSE,DataType,Patient,,
 Sample ID,,,,,TRUE,DataProperty,,,
-Tissue Status,,"Healthy, Malignant",,,TRUE,DataProperty,,,
+Tissue Status,,"Healthy, Malignant, None",,,TRUE,DataProperty,,,
 Bulk RNA-seq Assay,,,"Filename, Sample ID, File Format, Component",,FALSE,DataType,Biospecimen,,
 Filename,,,,,TRUE,DataProperty,,,#MockFilename filenameExists^^
 File Format,,"FASTQ, BAM, CRAM, CSV/TSV",,,TRUE,DataProperty,,,

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -309,9 +309,6 @@
                 },
                 {
                     "@id": "bts:Skin"
-                },
-                {
-                    "@id": "bts:None"
                 }
             ],
             "sms:displayName": "Cancer Type",
@@ -346,9 +343,6 @@
                 },
                 {
                     "@id": "bts:Skin"
-                },
-                {
-                    "@id": "bts:None"
                 }
             ],
             "sms:displayName": "Family History",
@@ -475,26 +469,6 @@
             "sms:validationRules": []
         },
         {
-            "@id": "bts:None",
-            "@type": "rdfs:Class",
-            "rdfs:comment": "TBD",
-            "rdfs:label": "None",
-            "rdfs:subClassOf": [
-                {
-                    "@id": "bts:CancerType"
-                },
-                {
-                    "@id": "bts:FamilyHistory"
-                }
-            ],
-            "schema:isPartOf": {
-                "@id": "http://schema.biothings.io"
-            },
-            "sms:displayName": "None",
-            "sms:required": "sms:false",
-            "sms:validationRules": []
-        },
-        {
             "@id": "bts:Biospecimen",
             "@type": "rdfs:Class",
             "rdfs:comment": "TBD",
@@ -566,6 +540,9 @@
                 },
                 {
                     "@id": "bts:Malignant"
+                },
+                {
+                    "@id": "bts:None"
                 }
             ],
             "sms:displayName": "Tissue Status",
@@ -586,6 +563,23 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Malignant",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:None",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "None",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:TissueStatus"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "None",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },

--- a/tests/data/example.model.jsonld
+++ b/tests/data/example.model.jsonld
@@ -309,6 +309,9 @@
                 },
                 {
                     "@id": "bts:Skin"
+                },
+                {
+                    "@id": "bts:None"
                 }
             ],
             "sms:displayName": "Cancer Type",
@@ -343,6 +346,9 @@
                 },
                 {
                     "@id": "bts:Skin"
+                },
+                {
+                    "@id": "bts:None"
                 }
             ],
             "sms:displayName": "Family History",
@@ -465,6 +471,26 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Skin",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:None",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "TBD",
+            "rdfs:label": "None",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:CancerType"
+                },
+                {
+                    "@id": "bts:FamilyHistory"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "None",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },

--- a/tests/data/mock_manifests/Invalid_none_value_test_manifest.csv
+++ b/tests/data/mock_manifests/Invalid_none_value_test_manifest.csv
@@ -1,0 +1,6 @@
+Sample ID,Patient ID,Tissue Status,Component
+1,1,Healthy,Biospecimen
+2,2,Malignant,Biospecimen
+3,3,None,Biospecimen
+4,4,None,Biospecimen
+5,5,InvalidValue,Biospecimen

--- a/tests/data/mock_manifests/Valid_none_value_test_manifest.csv
+++ b/tests/data/mock_manifests/Valid_none_value_test_manifest.csv
@@ -1,0 +1,6 @@
+Sample ID,Patient ID,Tissue Status,Component
+1,1,Healthy,Biospecimen
+2,2,Malignant,Biospecimen
+3,3,None,Biospecimen
+4,4,None,Biospecimen
+5,5,None,Biospecimen

--- a/tests/integration/test_commands.py
+++ b/tests/integration/test_commands.py
@@ -339,7 +339,7 @@ class TestManifestCommand:
             assert False, f"Unexpected data validation found: {dv}"
         assert tissue_status_validation is not None
         assert tissue_status_validation.type == "list"
-        assert tissue_status_validation.formula1 == "Sheet2!$C$2:$C$3"
+        assert tissue_status_validation.formula1 == "Sheet2!$C$2:$C$4"
 
         # required fields are marked as “light blue”, while other non-required fields are marked as white.
         for col in ["Sample ID", "Patient ID", "Tissue Status", "Component"]:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -462,7 +462,7 @@ class TestDataModelGraph:
         )
 
         # Check Edge directions
-        assert 4 == (len(graph.out_edges("TissueStatus")))
+        assert 6 == (len(graph.out_edges("TissueStatus")))
         assert 2 == (len(graph.in_edges("TissueStatus")))
 
 


### PR DESCRIPTION
I think it'd be better to use the `example.model.csv` model and `Biospecimen` component for the tests of manifest `"None"` values given how `MockComponent` is used and the history of the `example_test_nones.model.csv` model that @thomasyu888 pointed out. 

Included in this PR is updates to the data model (CSV and JSONLD forms) and both valid and invalid manifests that can be used for the integration tests.