### PR TITLE
[DPE-1151] Update ReadMe instructions and environment variable when exporting to signoz cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,8 +514,9 @@ environment variable should be set:
 - `OTEL_EXPORTER_OTLP_HEADERS=signoz-ingestion-key=<key>`
 - `OTEL_EXPORTER_OTLP_ENDPOINT=https://ingest.us.signoz.cloud`
 
-If a key is required please reach out to DPE and a unique ingestion key will be provided.
+If you do not have access to SigNoz Cloud and require a key, please contact DPE to request a unique ingestion key.
 
+For internal developers with access to SigNoz Cloud, you can obtain an ingestion key by following the step [here](https://signoz.io/docs/ingestion/signoz-cloud/keys/).
 
 # Contributors
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,56 @@ After running this step, your setup is complete, and you can test it on a python
 After running the steps above, your setup is complete, and you can test it on a `python` instance or by running a command based on the examples in the [Command Line Usage](#command-line-usage) section.
 
 # Command Line Usage
+
+## Provide environment variables
+To configure environment variables for using the CLI, follow these steps:
+
+### Option 1: Export Environment Variables Temporarily
+This method sets environment variables for the current terminal session only.
+
+1. Open your terminal.
+2. Run the following command to export the environment variable:
+
+```
+export YOUR_VARIABLE_NAME="your_value"
+```
+### Option 2: Persist Environment Variables in ~/.bash_profile
+This method makes the variables available in every terminal session.
+
+1. Open or create the ~/.bash_profile file using a text editor
+2. Add the environment variables to the file:
+
+```
+export YOUR_VARIABLE_NAME1="your_value"
+export YOUR_VARIABLE_NAME2="another_value"
+```
+
+3. Reload the bash profile by running:
+
+```
+source ~/.bash_profile
+```
+
+### Option 3: Use a .env File
+1. Make a copy of the `.env.example` file and rename it to `.env`.
+
+2. Uncomment the environment variables you need or add new ones as required in `.env`.
+
+3. There are several ways to load the environment variables specified in the `.env` file into your current shell environment. One method is to run the following command in your terminal:
+
+```
+set -o allexport && source .env && set +o allexport
+```
+
+4. Choose an environment variable from the .env file and ensure it is properly loaded by running:
+
+```
+echo $YOUR_VARIABLE_NAME
+```
+
+
+
+## Common commands
 1. Generate a new manifest as a google sheet
 
 ```

--- a/env.example
+++ b/env.example
@@ -15,7 +15,7 @@ SERVICE_ACCOUNT_CREDS='Provide service account creds'
 # SERVICE_INSTANCE_ID=schematic-1234
 ## Other examples: dev, staging, prod
 # DEPLOYMENT_ENVIRONMENT=local
-# OTEL_EXPORTER_OTLP_ENDPOINT=https://....
+# OTEL_EXPORTER_OTLP_ENDPOINT=https://ingest.us.signoz.cloud
 ## Opentelemetry API Key for export
 # OTEL_EXPORTER_OTLP_HEADERS=signoz-ingestion-key=<key>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ opentelemetry-api = {version = ">=1.21.0", optional = true}
 opentelemetry-sdk = {version = ">=1.21.0", optional = true}
 opentelemetry-exporter-otlp-proto-http = {version="^1.0.0", optional = true}
 opentelemetry-instrumentation-flask = ">=0.48b0"
+python-dotenv = "^0.21.0"
 
 [tool.poetry.extras]
 api = ["Jinja2", "pyopenssl", "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http"]
@@ -88,7 +89,6 @@ pytest-mock = "^3.5.1"
 pytest-rerunfailures = "^12.0"
 pytest-asyncio = "^0.24.0"
 flake8 = "^6.0.0"
-python-dotenv = "^0.21.0"
 black = "^23.7.0" #If the version spec of black is changed here, the version specified in .pre-commit-config.yaml should be updated to match
 mypy = "^1.4.1"
 pylint = "^2.16.1"

--- a/schematic/__init__.py
+++ b/schematic/__init__.py
@@ -27,9 +27,13 @@ from schematic.configuration.configuration import CONFIG
 from schematic.loader import LOADER
 from schematic.version import __version__
 from schematic_api.api.security_controller import info_from_bearer_auth
+from dotenv import load_dotenv
 
 Synapse.allow_client_caching(False)
 logger = logging.getLogger(__name__)
+
+# Ensure environment variables are loaded
+load_dotenv()
 
 
 def create_telemetry_session() -> requests.Session:


### PR DESCRIPTION
## Changes
* Updated instructions when exporting traces to Signoz Cloud
* Ensured environment variables can be loaded in `__init__.py`

## Tests
* Ensured that after setting environment variables in `.env`, when running tests locally, results can be found on Signoz Cloud
* Ensured that after setting environment variables in `.env`, when running schematic api locally, results can be found on Signoz Cloud
* Ensured that results of test run on Github can be found in Signoz Cloud
* Ensured that after setting environment variables in `.env`, when running schematic CLI locally, results can be found on Signoz Cloud