### PR TITLE
[Schematic-90] Use synapseclient user-agent string to track schematic library and CLI usage

### DIFF
--- a/schematic/__init__.py
+++ b/schematic/__init__.py
@@ -21,7 +21,7 @@ from opentelemetry.sdk.trace import TracerProvider, SpanProcessor
 from opentelemetry.trace import Span, SpanContext, get_current_span
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, Span
 from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
-from synapseclient import Synapse
+from synapseclient import Synapse, USER_AGENT
 from werkzeug import Request
 
 from schematic.configuration.configuration import CONFIG
@@ -34,6 +34,16 @@ logger = logging.getLogger(__name__)
 
 # Ensure environment variables are loaded
 load_dotenv()
+
+USER_AGENT_LIBRARY = {
+    "User-Agent": USER_AGENT["User-Agent"] + f" schematic/{__version__}"
+}
+
+USER_AGENT_COMMAND_LINE = {
+    "User-Agent": USER_AGENT["User-Agent"] + f" schematiccommandline/{__version__}"
+}
+
+USER_AGENT |= USER_AGENT_LIBRARY
 
 
 class AttributePropagatingSpanProcessor(SpanProcessor):

--- a/schematic/__main__.py
+++ b/schematic/__main__.py
@@ -4,6 +4,8 @@ import logging
 import click
 import click_log
 
+from synapseclient import USER_AGENT
+
 from schematic.manifest.commands import (
     manifest as manifest_cli,
 )  # get manifest commands
@@ -14,7 +16,9 @@ from schematic.schemas.commands import (
 from schematic.visualization.commands import (
     viz as viz_cli,
 )  # viz generation commands
-from schematic import __version__
+from schematic import __version__, USER_AGENT_COMMAND_LINE
+
+USER_AGENT |= USER_AGENT_COMMAND_LINE
 
 logger = logging.getLogger()
 click_log.basic_config(logger)

--- a/schematic/__main__.py
+++ b/schematic/__main__.py
@@ -4,8 +4,6 @@ import logging
 import click
 import click_log
 
-from synapseclient import USER_AGENT
-
 from schematic.manifest.commands import (
     manifest as manifest_cli,
 )  # get manifest commands
@@ -18,7 +16,6 @@ from schematic.visualization.commands import (
 )  # viz generation commands
 from schematic import __version__, USER_AGENT_COMMAND_LINE
 
-USER_AGENT |= USER_AGENT_COMMAND_LINE
 
 logger = logging.getLogger()
 click_log.basic_config(logger)
@@ -35,6 +32,10 @@ def main():
     """
     Command line interface to the `schematic` backend services.
     """
+    from synapseclient import USER_AGENT
+
+    USER_AGENT |= USER_AGENT_COMMAND_LINE
+
     logger.info("Starting schematic...")
     logger.debug("Existing sub-commands need to be used with schematic.")
 

--- a/tests/unit/test_metric_collection.py
+++ b/tests/unit/test_metric_collection.py
@@ -1,0 +1,36 @@
+from re import search
+from click.testing import CliRunner
+import pytest
+
+
+@pytest.fixture
+def command_line_user_agent_pattern():
+    yield "schematiccommandline" + "/(\\S+)"
+
+
+@pytest.fixture
+def library_user_agent_pattern():
+    yield "schematic" + "/(\\S+)"
+
+
+class TestUserAgentString:
+    def test_user_agent_string(
+        self,
+        library_user_agent_pattern,
+        command_line_user_agent_pattern,
+    ):
+        # GIVEN the default USER_AGENT string from the synapse client
+        from synapseclient import USER_AGENT
+
+        # WHEN schematic is imported to be used as a library
+        from schematic.__main__ import main
+
+        # THEN the User-Agent string should be updated to include the schematic library client string
+        assert search(library_user_agent_pattern, USER_AGENT["User-Agent"])
+
+        # AND when the command line is used to execute commands
+        runner = CliRunner()
+        result = runner.invoke(main)
+
+        # THEN the User-Agent string should be updated to include the schematic command line client string
+        assert search(command_line_user_agent_pattern, USER_AGENT["User-Agent"])


### PR DESCRIPTION
Resolves SCHEMATIC-190 and sets the synapseclient USER_AGENT string as discussed in the accompanying [design document](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/3867738119/SCHEMATIC-190+Schematic+User-Agent+Strings+Mini-Design+Doc).