### PR TITLE
[SCHEMATIC-240] stripped google sheet information from open telemetry span status and message 

### DIFF
--- a/schematic/manifest/generator.py
+++ b/schematic/manifest/generator.py
@@ -1370,7 +1370,6 @@ class ManifestGenerator(object):
         Returns:
             ps.Spreadsheet: A Google Sheet object.
         """
-        logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
         # print('set data frame by url is being called', flush=True)
         # authorize pygsheets to read from the given URL
         gc = ps.authorize(custom_credentials=self.creds)
@@ -1382,13 +1381,9 @@ class ManifestGenerator(object):
         try:
             wb.set_dataframe(manifest_df, (1, 1), fit=True)
         except HttpError as ex:
-            span = get_current_span()
             pattern = r"https://sheets\.googleapis\.com/v4/spreadsheets/[\w-]+"
             sanitized_message = re.sub(pattern, "REDACTED", str(ex))
             sanitized_message_b = sanitized_message.encode(encoding="utf-8")
-            span.set_status(
-                Status(status_code=StatusCode.ERROR, description=sanitized_message)
-            )
             raise HttpError(ex.resp, sanitized_message_b)
 
         # update validation rules (i.e. no validation rules) for out of schema columns, if any


### PR DESCRIPTION
## Problem
When an error involving Google Sheets is logged, the message may include the URL of the Google Sheet being processed and the google sheet link can be found in signoz

## Solution 
Remove the sensitive information in the code. 
Evidence that this is working: 
As you can see, the google sheet links get turned to "REACTED": 
<img width="941" alt="Screenshot 2025-02-06 at 3 21 25 PM" src="https://github.com/user-attachments/assets/16e320bf-4480-4374-91da-32b3477746d5" />

The following can be achieved: 
* Google Sheet links have been removed from all status messages and event exceptions.
* Original error messages are preserved and not completely overridden.

Note: I tried creating a custom processor and experimenting if I could filter out the sensitive information when the spans are still recording using the processor. But something like: `parent_span.set_status(status=Status(status_code=StatusCode.ERROR, description=sanitized_message))` couldn't override the span exception messages in signoz because it only changes the span descriptions, and [this](https://github.com/SigNoz/signoz-otel-collector/blob/main/exporter/clickhousetracesexporter/clickhouse_exporter.go#L386) seems to suggest that signoz uses exception messages to populate the UI. 