### PR TITLE
[schematic-254] added documentation for manifest submission 

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,3 +1,5 @@
+.. _configure schematic:
+
 Configure Schematic
 ===================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. _index:
+
 Welcome to Schematic's documentation!
 =====================================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -148,3 +148,4 @@ For the entire Python API reference documentation, you can visit the docs here: 
    tutorials
    troubleshooting
    cli_reference
+   manifest_submission

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -148,6 +148,6 @@ For the entire Python API reference documentation, you can visit the docs here: 
    asset_store
    configuration
    tutorials
+   manifest_submission
    troubleshooting
    cli_reference
-   manifest_submission

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,3 +1,5 @@
+.. _installation:
+
 Installation
 ============
 

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -168,9 +168,30 @@ Option 2: Use the API
 
 
 
-Use project_scope parameter to expedite submission process
+Expedite submission process (Optional)
 -----------------------------------------------------------
 
 If your asset view contains multiple projects, it might take some time for the submission to finish.
 
 You could expedite the submission process by specifying the project_scope parameter. This parameter allows you to specify the project(s) that you want to submit the manifest to.
+
+To utilize this parameter, make sure that the projects listed there are part of the asset view.
+
+
+Option 1: Use the CLI
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt file_only -no-fa -tcn "class_label" -ps "project_id1, project_id2"
+
+- **-ps**: Specifies the project scope as a comma separated list of project IDs.
+
+
+Option 2: Use the API
+~~~~~~~~~~~~~~~~~~~~~~
+
+1. Locate the **model/submit** endpoint in the **Swagger UI**.
+2. Click **"Try it out"** to enable input fields.
+3. Follow instructions to Submit a Manifest file
+3. Locate "project_scope" parameter and click on **Add string items** to add project IDs.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -12,10 +12,10 @@ Ensure you have a Synapse account and have obtained your Synapse credential by f
 
 - **Install and Configure Schematic**:
   Ensure you have installed `schematic` and set up its dependencies.
-  Refer to the **"Installation Guide for Users"** for detailed instructions.
+  See the :ref:`installation` section for more details.
 
 - **Understand Important Concepts**:
-  Familiarize yourself with key concepts outlined on the :doc:`index.rst` page.
+  Understand Important Concepts: Familiarize yourself with key concepts outlined on the :ref:`index` of the documentation.
 
 - **Configuration File**:
   Learn more about each attribute in the configuration file by referring to the relevant documentation.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -231,7 +231,7 @@ Pre-requisite
 
 1. Ensure that all your manifests, including both the initial manifests and those containing rows to be upserted, include a primary key: <YourComponentName_id>. For example, if your component name is "Patient", the primary key should be "Patient_id".
 2. If you plan to use upsert in the future, select the upsert option during the initial table uploads.
-3. Currently it is required to use -dl/--use_display_label with table upserts.
+3. Currently it is required to use -tcn "display_label" with table upserts.
 
 
 Option 1: Use the CLI

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -105,8 +105,7 @@ Option 2: Use the API
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
-   - **schema_url**: The raw URL of your data model.
-     - If your data model is hosted on **GitHub**, use the following formats:
+   - **schema_url**: The raw URL of your data model. If your data model is hosted on **GitHub**, use the following formats:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
@@ -172,8 +171,7 @@ Option 2: Use the API
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
-   - **schema_url**: The raw URL of your data model.
-     - If your data model is hosted on **GitHub**, the URL should follow this format:
+   - **schema_url**: The raw URL of your data model. If your data model is hosted on **GitHub**, the URL should follow this format:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
@@ -223,8 +221,7 @@ Option 2: Use the API
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
-   - **schema_url**: The raw URL of your data model.
-     - If your data model is hosted on **GitHub**, use the following formats:
+   - **schema_url**: The raw URL of your data model. If your data model is hosted on **GitHub**, use the following formats:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
@@ -279,8 +276,7 @@ Option 2: Use the API
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
-   - **schema_url**: The raw URL of your data model.
-     - If your data model is hosted on **GitHub**, use the following formats:
+   - **schema_url**: The raw URL of your data model. If your data model is hosted on **GitHub**, use the following formats:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -35,6 +35,15 @@ This will open the **Swagger UI**, where you can explore all available API endpo
 Submit a Manifest File to Synapse
 ---------------------------------
 
+.. note::
+
+  You can configure the format of the manifest being submitted by using the `-mrt flag` in the CLI or the `manifest_record_type` in the API.
+
+  For table column names, here's a brief explanation of all the options:
+   - display_name: use raw display name defined in the data model as the column name, no modifications to the name will be made.
+   - display_label: use the display name formatting as the column name. Will strip blacklisted characters (including spaces) when present.
+   - class_label: default, use standard class label and strip any blacklisted characters (including spaces) when present. A schematic class label is UpperCamelCase.
+
 Option 1: Use the CLI
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -48,17 +57,24 @@ This command will upload your manifest to Synapse and automatically validate it.
 
 .. code-block:: bash
 
-    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt file_only
+    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt file_only -no-fa -tcn "class_label"
 
    - **-c /path/to/config.yml**: Specifies the configuration file containing the data model location and asset view (`master_fileview_id`).
    - **-mp**: Your manifest file path.
    - **-mrt**: The format of manifest submission. The options are: "table_and_file", "file_only", "file_and_entities", "table_file_and_entities". "file_only" option would submit the manifest as a file.
    - **-vc <your_data_type>**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`).
    - **-d <your_dataset_id>**: Retrieves the existing manifest associated with a specific dataset on Synpase.
+   - **-no-fa**: Skips the file annotations upload.
+   - **-tcn**: Table Column Names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label", but you can change it based on your requirements.
 
 
 Option 2: Use the API
 ~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing the default inputs.
+
 
 1. Locate the **model/submit** endpoint in the **Swagger UI**.
 2. Click **"Try it out"** to enable input fields.
@@ -82,11 +98,16 @@ Option 2: Use the API
 
    - table_manipulation is "replace" by default. You could keep it that way.
 
-   - set **`manifest_record_type`**` to "file_only"
+   - set **manifest_record_type** to "file_only" or you could change it based on your project requirements
+
+   - table_column_names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label".
 
 
-Submit a Manifest file and a Table to Synapse
----------------------------------------------
 
 Submit a Manifest file and Add Annotations
 -------------------------------------------
+
+
+
+Use dataset_scope or project_scope parameter to expedite submission process
+---------------------------------------------------------------------------

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -263,7 +263,7 @@ Option 2: Use the API
 
    - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
-   - remove default inputs in **dataset_scope** and **"project_scope"
+   - remove default inputs in **dataset_scope** and **"project_scope"**
 
    - set file_annotations_upload to `False` if you do not want annotations to be uploaded.
 

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -14,10 +14,10 @@ Ensure you have a Synapse account and set up Synapse configuration file correctl
   See the :ref:`installation` section for more details.
 
 - **Understand Important Concepts**:
-  Understand Important Concepts: Familiarize yourself with key concepts outlined on the :ref:`index` of the documentation.
+  Familiarize yourself with key concepts outlined on the :ref:`index` of the documentation.
 
 - **Configuration File**:
-  Learn more about each attribute in the configuration file by referring to the relevant documentation.
+  For more details on configuring Schematic, refer to the :ref:`configure schematic` section.
 
 - **Obtain a manifest**:
   Please obtain a manifest by following the documentation of generating a manifest.
@@ -41,6 +41,7 @@ Submit a Manifest File to Synapse
   For table column names, here's a brief explanation of all the options:
    - display_name: use raw display name defined in the data model as the column name, no modifications to the name will be made.
    - display_label: use the display name formatting as the column name. Will strip blacklisted characters (including spaces) when present.
+     The blacklisted characters are: ``"(", ")", ".", " ", "-" ``
    - class_label: default, use standard class label and strip any blacklisted characters (including spaces) when present. A schematic class label is UpperCamelCase.
 
 .. note::
@@ -52,6 +53,7 @@ Submit a Manifest File to Synapse
      syn12345678/
      ├── file1.csv
      ├── file2.csv
+     ├── manifest.csv
 
   Here is the top-level folder ID: syn12345678
 
@@ -60,9 +62,12 @@ Submit a Manifest File to Synapse
   .. code-block:: text
 
      syn12345678/
-     ├── subfolder/
+     ├── subfolder1/
      │   └── file1
-     ├── file2
+     ├── subfolder2/
+     │   └── file2
+     ├── file3
+     ├── manifest.csv
 
   Here is the top-level folder ID: syn12345678
 
@@ -93,19 +98,19 @@ Option 2: Use the API
 
 .. note::
 
-    During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing the default inputs.
+    During submission, validation is optional. If you have finished validation in previous step, you could skip validation by excluding the `data_type` and `dataset_scope` parameter values.
 
 
-1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`.
+1. Visit **model/submit** endpoint: `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
-   - **schema_url**: The URL of your data model.
+   - **schema_url**: The raw URL of your data model.
      - If your data model is hosted on **GitHub**, use the following formats:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
-   - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+   - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, exclude this parameter by removing the default inputs.
 
    - **dataset_id**: Provide the **top-level Synapse dataset ID**.
        - This can be either a **Synapse Project ID** or a **Folder ID**.
@@ -160,19 +165,19 @@ Option 2: Use the API
 
 .. note::
 
-    During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing the default inputs.
+    During submission, validation is optional. If you have finished validation in previous step, you could skip validation by excluding the `data_type` and `dataset_scope` parameter values.
 
 
-1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`.
+1. Visit **model/submit** endpoint: `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
-   - **schema_url**: The URL of your data model.
+   - **schema_url**: The raw URL of your data model.
      - If your data model is hosted on **GitHub**, the URL should follow this format:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
-   - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+   - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, exclude this parameter by removing the default inputs.
 
    - **dataset_id**: The **top-level Synapse dataset ID**.
      - This can be a **Synapse Project ID** or a **Folder ID**.
@@ -214,16 +219,16 @@ Option 1: Use the CLI
 Option 2: Use the API
 ~~~~~~~~~~~~~~~~~~~~~~
 
-1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`.
+1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
-   - **schema_url**: The URL of your data model.
+   - **schema_url**: The raw URL of your data model.
      - If your data model is hosted on **GitHub**, use the following formats:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
-   - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+   - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, exclude this parameter by removing the default inputs.
 
    - **dataset_id**: Provide the **top-level Synapse dataset ID**.
        - This can be either a **Synapse Project ID** or a **Folder ID**.
@@ -270,16 +275,16 @@ Option 1: Use the CLI
 Option 2: Use the API
 ~~~~~~~~~~~~~~~~~~~~~~
 
-1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`.
+1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
-   - **schema_url**: The URL of your data model.
+   - **schema_url**: The raw URL of your data model.
      - If your data model is hosted on **GitHub**, use the following formats:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
-   - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+   - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, exclude this parameter by removing the default inputs.
 
    - **dataset_id**: Provide the **top-level Synapse dataset ID**.
        - This can be either a **Synapse Project ID** or a **Folder ID**.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -47,9 +47,6 @@ Submit a Manifest File to Synapse
 Option 1: Use the CLI
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To submit a manifest file to Synapse, you will need to use the `schematic model submit` command.
-This command will upload your manifest to Synapse and automatically validate it.
-
 .. note::
 
     During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing `-vc <your data type>`
@@ -59,13 +56,13 @@ This command will upload your manifest to Synapse and automatically validate it.
 
     schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt file_only -no-fa -tcn "class_label"
 
-   - **-c /path/to/config.yml**: Specifies the configuration file containing the data model location and asset view (`master_fileview_id`).
-   - **-mp**: Your manifest file path.
-   - **-mrt**: The format of manifest submission. The options are: "table_and_file", "file_only", "file_and_entities", "table_file_and_entities". "file_only" option would submit the manifest as a file.
-   - **-vc <your_data_type>**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`).
-   - **-d <your_dataset_id>**: Retrieves the existing manifest associated with a specific dataset on Synpase.
-   - **-no-fa**: Skips the file annotations upload.
-   - **-tcn**: Table Column Names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label", but you can change it based on your requirements.
+- **-c /path/to/config.yml**: Specifies the configuration file containing the data model location and asset view (`master_fileview_id`).
+- **-mp**: Your manifest file path.
+- **-mrt**: The format of manifest submission. The options are: "table_and_file", "file_only", "file_and_entities", "table_file_and_entities". "file_only" option would submit the manifest as a file.
+- **-vc <your_data_type>**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`).
+- **-d <your_dataset_id>**: Retrieves the existing manifest associated with a specific dataset on Synpase.
+- **-no-fa**: Skips the file annotations upload.
+- **-tcn**: Table Column Names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label", but you can change it based on your requirements.
 
 
 Option 2: Use the API
@@ -92,7 +89,7 @@ Option 2: Use the API
 
    - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
-   - remove default inputs in dataset_scope and project_scope
+   - remove default inputs in **dataset_scope** and **project_scope**
 
    - set file_annotations_upload to false
 
@@ -107,7 +104,73 @@ Option 2: Use the API
 Submit a Manifest file and Add Annotations
 -------------------------------------------
 
+.. note::
+
+  Since annotations are enabled in the submission, if you are submitting a file-based manifest, you should see annotations attached to the entity IDs listed in the manifest.
 
 
-Use dataset_scope or project_scope parameter to expedite submission process
----------------------------------------------------------------------------
+
+Option 1: Use the CLI
+~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. note::
+
+    During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing `-vc <your data type>`
+
+
+.. code-block:: bash
+
+    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt file_only -no-fa -tcn "class_label"
+
+- **-c /path/to/config.yml**: Specifies the configuration file containing the data model location and asset view (`master_fileview_id`).
+- **-mp**: Your manifest file path.
+- **-mrt**: The format of manifest submission. The options are: "table_and_file", "file_only", "file_and_entities", "table_file_and_entities". "file_only" option would submit the manifest as a file.
+- **-vc <your_data_type>**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`).
+- **-d <your_dataset_id>**: Retrieves the existing manifest associated with a specific dataset on Synpase.
+- **-fa**: Enable file annotations upload.
+- **-tcn**: Table Column Names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label", but you can change it based on your requirements.
+
+
+Option 2: Use the API
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing the default inputs.
+
+
+1. Locate the **model/submit** endpoint in the **Swagger UI**.
+2. Click **"Try it out"** to enable input fields.
+3. Enter the required parameters and execute the request:
+
+   - **schema_url**: The URL of your data model.
+     - If your data model is hosted on **GitHub**, the URL should follow this format:
+       - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
+       - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
+
+   - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+
+   - **dataset_id**: The **top-level Synapse dataset ID**.
+     - This can be a **Synapse Project ID** or a **Folder ID**.
+
+   - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
+
+   - remove default inputs in **dataset_scope** and **project_scope**
+
+   - set file_annotations_upload to `True`
+
+   - table_manipulation is "replace" by default. You could keep it that way.
+
+   - set **manifest_record_type** to "file_only" or you could change it based on your project requirements
+
+   - table_column_names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label".
+
+
+
+Use project_scope parameter to expedite submission process
+-----------------------------------------------------------
+
+If your asset view contains multiple projects, it might take some time for the submission to finish.
+
+You could expedite the submission process by specifying the project_scope parameter. This parameter allows you to specify the project(s) that you want to submit the manifest to.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -50,31 +50,31 @@ This command will upload your manifest to Synapse and automatically validate it.
 
     schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt file_only
 
-   - **`-c /path/to/config.yml`**: Specifies the configuration file containing the data model location and asset view (`master_fileview_id`).
-   - **`-mp **: Your manifest file path.
-   - **`-mrt **: The format of manifest submission. The options are: "table_and_file", "file_only", "file_and_entities", "table_file_and_entities". "file_only" option would submit the manifest as a file.
-   - **`-vc <your_data_type>`**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`).
-   - **`-d <your_dataset_id>`**: Retrieves the existing manifest associated with a specific dataset on Synpase.
+   - **-c /path/to/config.yml**: Specifies the configuration file containing the data model location and asset view (`master_fileview_id`).
+   - **-mp**: Your manifest file path.
+   - **-mrt**: The format of manifest submission. The options are: "table_and_file", "file_only", "file_and_entities", "table_file_and_entities". "file_only" option would submit the manifest as a file.
+   - **-vc <your_data_type>**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`).
+   - **-d <your_dataset_id>**: Retrieves the existing manifest associated with a specific dataset on Synpase.
 
 
 Option 2: Use the API
 ~~~~~~~~~~~~~~~~~~~~~~
 
-1. Locate the **`model/submit`** endpoint in the **Swagger UI**.
+1. Locate the **model/submit** endpoint in the **Swagger UI**.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
-   - **`schema_url`**: The URL of your data model.
+   - **schema_url**: The URL of your data model.
      - If your data model is hosted on **GitHub**, the URL should follow this format:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
-   - **`data_type`**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+   - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
 
-   - **`dataset_id`**: The **top-level Synapse dataset ID**.
+   - **dataset_id**: The **top-level Synapse dataset ID**.
      - This can be a **Synapse Project ID** or a **Folder ID**.
 
-   - **`asset_view`**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
+   - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
    - remove default inputs in dataset_scope and project_scope
 

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -5,7 +5,7 @@ Prerequisites
 -------------
 
 **Obtain Synapse Credentials**:
-Ensure you have a Synapse account and have obtained your Synapse credential by following the instructions `here <https://python-docs.synapse.org/tutorials/authentication/#prerequisites>`_
+Ensure you have a Synapse account and set up Synapse configuration file correctly. See the :ref:`installation` section for more details.
 
 **Before Using the Schematic CLI**
 

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -210,8 +210,6 @@ Option 2: Use the API
 
    - **dataset_scope**: Remove default inputs.
 
-   - **project_scope**: Remove default inputs and add project IDs as string items.
-
    - **file_annotations_upload**: Set this to `false`.
 
    - **table_manipulation**: The default is "replace". You can keep it as is.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -5,8 +5,7 @@ Prerequisites
 -------------
 
 **Obtain Synapse Credentials**:
-Ensure you have a Synapse account and have obtained your Synapse credential by following the instructions here:
-    `<https://python-docs.synapse.org/tutorials/authentication/#prerequisites>`_
+Ensure you have a Synapse account and have obtained your Synapse credential by following the instructions `here <https://python-docs.synapse.org/tutorials/authentication/#prerequisites>`_
 
 **Before Using the Schematic CLI**
 
@@ -151,8 +150,8 @@ Option 2: Use the API
 
    - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
 
-  - **dataset_id**: The **top-level Synapse dataset ID**.
-    - This can be a **Synapse Project ID** or a **Folder ID**.
+   - **dataset_id**: The **top-level Synapse dataset ID**.
+     - This can be a **Synapse Project ID** or a **Folder ID**.
 
    - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
@@ -257,19 +256,25 @@ Option 2: Use the API
        - **JSON-LD**: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - **CSV**: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
-   - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+   - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`).
+     - To skip validation, remove the default inputs.
 
    - **dataset_id**: The **top-level Synapse dataset ID**.
      - This can be a **Synapse Project ID** or a **Folder ID**.
 
    - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
-   - **dataset_scope** and **project_scope**: Remove any default inputs provided in these fields.
+   - **dataset_scope** and **project_scope**:
+     - Remove any default inputs provided in these fields.
 
-   - **file_annotations_upload**: Set this to `False` if you do not want annotations to be uploaded.
+   - **file_annotations_upload**:
+     - Set this to `False` if you do not want annotations to be uploaded.
 
-   - **table_manipulation**: The default is **"replace"**. Update it to **"upsert"**.
+   - **table_manipulation**:
+     - The default is **"replace"**. Update it to **"upsert"**.
 
-   - **manifest_record_type**: Set this to **"table_and_file"**.
+   - **manifest_record_type**:
+     - Set this to **"table_and_file"**.
 
-   - **table_column_names**: Choose **"display_label"** for upsert.
+   - **table_column_names**:
+     - Choose **"display_label"** for upsert.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -41,7 +41,7 @@ Submit a Manifest File to Synapse
   For table column names, here's a brief explanation of all the options:
    - display_name: use raw display name defined in the data model as the column name, no modifications to the name will be made.
    - display_label: use the display name formatting as the column name. Will strip blacklisted characters (including spaces) when present.
-     The blacklisted characters are: ``"(", ")", ".", " ", "-" ``
+     The blacklisted characters are: "(", ")", ".", " ", "-"
    - class_label: default, use standard class label and strip any blacklisted characters (including spaces) when present. A schematic class label is UpperCamelCase.
 
 .. note::

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -78,26 +78,26 @@ Option 2: Use the API
 3. Enter the required parameters and execute the request:
 
    - **schema_url**: The URL of your data model.
-     - If your data model is hosted on **GitHub**, the URL should follow this format:
+     - If your data model is hosted on **GitHub**, use the following formats:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
-   - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+   - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
 
-   - **dataset_id**: The **top-level Synapse dataset ID**.
-     - This can be a **Synapse Project ID** or a **Folder ID**.
+   - **dataset_id**: Provide the **top-level Synapse dataset ID**.
+     - This can be either a **Synapse Project ID** or a **Folder ID**.
 
-   - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
+   - **asset_view**: Enter the **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
-   - remove default inputs in **dataset_scope** and **project_scope**
+   - **dataset_scope** and **project_scope**: Remove the default inputs.
 
-   - set file_annotations_upload to false
+   - **file_annotations_upload**: Set this to `false`.
 
-   - table_manipulation is "replace" by default. You could keep it that way.
+   - **table_manipulation**: The default is "replace". You can keep it as is.
 
-   - set **manifest_record_type** to "file_only" or you could change it based on your project requirements
+   - **manifest_record_type**: Set this to "file_only" or adjust it based on your project requirements.
 
-   - table_column_names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label".
+   - **table_column_names**: This is optional. Available options are "class_label", "display_label", and "display_name". The default is "class_label".
 
 
 
@@ -156,15 +156,15 @@ Option 2: Use the API
 
    - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
-   - remove default inputs in **dataset_scope** and **project_scope**
+   - **dataset_scope** and **project_scope**: Remove any default inputs provided in these fields.
 
-   - set file_annotations_upload to `True`
+   - **file_annotations_upload**: Set this to `True`.
 
-   - table_manipulation is "replace" by default. You could keep it that way.
+   - **table_manipulation**: The default is "replace". You can keep it as is or modify it if needed.
 
-   - set **manifest_record_type** to "file_only" or you could change it based on your project requirements
+   - **manifest_record_type**: Set this to "file_only" or adjust it based on your project requirements.
 
-   - table_column_names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label".
+   - **table_column_names**: This is optional. Available options are "class_label", "display_label", and "display_name". The default is "class_label".
 
 
 
@@ -200,24 +200,24 @@ Option 2: Use the API
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
-   - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+   - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
 
-   - **dataset_id**: The **top-level Synapse dataset ID**.
-     - This can be a **Synapse Project ID** or a **Folder ID**.
+   - **dataset_id**: Provide the **top-level Synapse dataset ID**.
+     - This can be either a **Synapse Project ID** or a **Folder ID**.
 
-   - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
+   - **asset_view**: Enter the **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
-   - remove default inputs in **dataset_scope**
+   - **dataset_scope**: Remove any default inputs provided in this field.
 
-   - locate "project_scope" parameter and remove the default inputs. Then click on **Add string items** to add project IDs.
+   - **project_scope**: Locate this parameter, remove the default inputs, and click on **Add string items** to add project IDs.
 
-   - set file_annotations_upload to `True`
+   - **file_annotations_upload**: Set this to `True`.
 
-   - table_manipulation is "replace" by default. You could keep it that way.
+   - **table_manipulation**: The default is "replace". You can keep it as is.
 
-   - set **manifest_record_type** to "file_only" or you could change it based on your project requirements
+   - **manifest_record_type**: Set this to "file_only" or adjust it based on your project requirements.
 
-   - table_column_names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label".
+   - **table_column_names**: This is optional. Available options are "class_label", "display_label", and "display_name". The default is "class_label".
 
 
 Enable upsert for manifest submission
@@ -253,8 +253,8 @@ Option 2: Use the API
 
    - **schema_url**: The URL of your data model.
      - If your data model is hosted on **GitHub**, the URL should follow this format:
-       - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
-       - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
+       - **JSON-LD**: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
+       - **CSV**: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
    - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
 
@@ -263,12 +263,12 @@ Option 2: Use the API
 
    - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
-   - remove default inputs in **dataset_scope** and **"project_scope"**
+   - **dataset_scope** and **project_scope**: Remove any default inputs provided in these fields.
 
-   - set file_annotations_upload to `False` if you do not want annotations to be uploaded.
+   - **file_annotations_upload**: Set this to `False` if you do not want annotations to be uploaded.
 
-   - table_manipulation is "replace" by default. Update it to **upsert**.
+   - **table_manipulation**: The default is **"replace"**. Update it to **"upsert"**.
 
-   - set **manifest_record_type** to "table_and_file".
+   - **manifest_record_type**: Set this to **"table_and_file"**.
 
-   - **table_column_names**: Choose display_label for upsert.
+   - **table_column_names**: Choose **"display_label"** for upsert.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -53,13 +53,13 @@ Option 1: Use the CLI
 
 .. code-block:: bash
 
-    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt file_only -no-fa -tcn "class_label"
+    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt table_and_file -no-fa -tcn "class_label"
 
 - **-c /path/to/config.yml**: Specifies the configuration file containing the data model location and asset view (`master_fileview_id`).
 - **-mp**: Your manifest file path.
 - **-mrt**: The format of manifest submission. The options are: "table_and_file", "file_only", "file_and_entities", "table_file_and_entities". "file_only" option would submit the manifest as a file.
-- **-vc <your_data_type>**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`).
-- **-d <your_dataset_id>**: Retrieves the existing manifest associated with a specific dataset on Synpase.
+- **-vc <your_data_type>**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove this flag.
+- **-d <your_dataset_id>**: the top level dataset id that you want to submit the manifest to.
 - **-no-fa**: Skips the file annotations upload.
 - **-tcn**: Table Column Names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label", but you can change it based on your requirements.
 
@@ -90,11 +90,11 @@ Option 2: Use the API
 
    - **dataset_scope** and **project_scope**: Remove the default inputs.
 
-   - **file_annotations_upload**: Set this to `false`.
+   - **file_annotations_upload**: Set this to `False`.
 
    - **table_manipulation**: The default is "replace". You can keep it as is.
 
-   - **manifest_record_type**: Set this to "file_only" or adjust it based on your project requirements.
+   - **manifest_record_type**: Set this to "table_and_file" or adjust it based on your project requirements.
 
    - **table_column_names**: This is optional. Available options are "class_label", "display_label", and "display_name". The default is "class_label".
 
@@ -120,13 +120,13 @@ Option 1: Use the CLI
 
 .. code-block:: bash
 
-    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt file_only -no-fa -tcn "class_label"
+    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt table_and_file -fa -tcn "class_label"
 
 - **-c /path/to/config.yml**: Specifies the configuration file containing the data model location and asset view (`master_fileview_id`).
 - **-mp**: Your manifest file path.
 - **-mrt**: The format of manifest submission. The options are: "table_and_file", "file_only", "file_and_entities", "table_file_and_entities". "file_only" option would submit the manifest as a file.
-- **-vc <your_data_type>**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`).
-- **-d <your_dataset_id>**: Retrieves the existing manifest associated with a specific dataset on Synpase.
+- **-vc <your_data_type>**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove this flag.
+- **-d <your_dataset_id>**: the top level dataset id that you want to submit the manifest to.
 - **-fa**: Enable file annotations upload.
 - **-tcn**: Table Column Names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label", but you can change it based on your requirements.
 
@@ -161,7 +161,7 @@ Option 2: Use the API
 
    - **table_manipulation**: The default is "replace". You can keep it as is or modify it if needed.
 
-   - **manifest_record_type**: Set this to "file_only" or adjust it based on your project requirements.
+   - **manifest_record_type**: Set this to "table_and_file" or adjust it based on your project requirements.
 
    - **table_column_names**: This is optional. Available options are "class_label", "display_label", and "display_name". The default is "class_label".
 
@@ -182,7 +182,7 @@ Option 1: Use the CLI
 
 .. code-block:: bash
 
-    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt file_only -no-fa -tcn "class_label" -ps "project_id1, project_id2"
+    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -no-fa -ps "project_id1, project_id2"
 
 - **-ps**: Specifies the project scope as a comma separated list of project IDs.
 
@@ -218,7 +218,8 @@ Option 2: Use the API
 
    - **manifest_record_type**: Set this to "file_only" or adjust it based on your project requirements.
 
-   - **table_column_names**: This is optional. Available options are "class_label", "display_label", and "display_name". The default is "class_label". You can keep it as is.
+   - **table_column_names**: This parameter is not applicable when uploading a manifest as a file. You can keep it as is and it will be ignored.
+
 
 Enable upsert for manifest submission
 -------------------------------------
@@ -239,7 +240,7 @@ Option 1: Use the CLI
 
 .. code-block:: bash
 
-    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt table_and_file -no-fa -tcn "display_label" -tm "upsert"
+    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -mrt table_and_file -no-fa -tcn "display_label" -tm "upsert"
 
 - **-tm**: The default option is "replace". Change it to "upsert" for enabling upsert.
 - **-tcn**: Use display label for upsert.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -96,7 +96,7 @@ Option 2: Use the API
     During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing the default inputs.
 
 
-1. Locate the **model/submit** endpoint in the **Swagger UI**.
+1. Locate the **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>` in the **Swagger UI**.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
@@ -163,7 +163,7 @@ Option 2: Use the API
     During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing the default inputs.
 
 
-1. Locate the **model/submit** endpoint in the **Swagger UI**.
+1. Locate the **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>` in the **Swagger UI**.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
@@ -214,7 +214,7 @@ Option 1: Use the CLI
 Option 2: Use the API
 ~~~~~~~~~~~~~~~~~~~~~~
 
-1. Locate the **model/submit** endpoint in the **Swagger UI**.
+1. Locate the **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>` in the **Swagger UI**.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
@@ -270,7 +270,7 @@ Option 1: Use the CLI
 Option 2: Use the API
 ~~~~~~~~~~~~~~~~~~~~~~
 
-1. Locate the **model/submit** endpoint in the **Swagger UI**.
+1. Locate the **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>` in the **Swagger UI**.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -43,6 +43,30 @@ Submit a Manifest File to Synapse
    - display_label: use the display name formatting as the column name. Will strip blacklisted characters (including spaces) when present.
    - class_label: default, use standard class label and strip any blacklisted characters (including spaces) when present. A schematic class label is UpperCamelCase.
 
+.. note::
+
+  Manifests should be submitted to the top-level dataset folder. Below are some examples demonstrating where the manifest file should go:
+
+  .. code-block:: text
+
+     syn12345678/
+     ├── file1.csv
+     ├── file2.csv
+
+  Here is the top-level folder ID: syn12345678
+
+  Here's an example using subfolders:
+
+  .. code-block:: text
+
+     syn12345678/
+     ├── subfolder/
+     │   └── file1
+     ├── file2
+
+  Here is the top-level folder ID: syn12345678
+
+
 Option 1: Use the CLI
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -1,0 +1,92 @@
+Submit a manifest to Synapse
+============================
+
+Prerequisites
+-------------
+
+**Obtain Synapse Credentials**:
+Ensure you have a Synapse account and have obtained your Synapse credential by following the instructions here:
+    `<https://python-docs.synapse.org/tutorials/authentication/#prerequisites>`_
+
+**Before Using the Schematic CLI**
+
+- **Install and Configure Schematic**:
+  Ensure you have installed `schematic` and set up its dependencies.
+  Refer to the **"Installation Guide for Users"** for detailed instructions.
+
+- **Understand Important Concepts**:
+  Familiarize yourself with key concepts outlined on the **home page** of the documentation.
+
+- **Configuration File**:
+  Learn more about each attribute in the configuration file by referring to the relevant documentation.
+
+- **Obtain a manifest**:
+  Please obtain a manifest by following the documentation of generating a manifest.
+
+
+**Using the Schematic API in Production**
+
+Visit the **Schematic API (Production Environment)**:
+`<https://schematic.api.sagebionetworks.org/v1/ui/#/>`_
+
+This will open the **Swagger UI**, where you can explore all available API endpoints.
+
+
+Submit a Manifest File to Synapse
+---------------------------------
+
+Option 1: Use the CLI
+~~~~~~~~~~~~~~~~~~~~~~
+
+To submit a manifest file to Synapse, you will need to use the `schematic model submit` command.
+This command will upload your manifest to Synapse and automatically validate it.
+
+.. note::
+
+    During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing `-vc <your data type>`
+
+
+.. code-block:: bash
+
+    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt file_only
+
+   - **`-c /path/to/config.yml`**: Specifies the configuration file containing the data model location and asset view (`master_fileview_id`).
+   - **`-mp **: Your manifest file path.
+   - **`-mrt **: The format of manifest submission. The options are: "table_and_file", "file_only", "file_and_entities", "table_file_and_entities". "file_only" option would submit the manifest as a file.
+   - **`-vc <your_data_type>`**: Defines the data type/schema model for the manifest (e.g., `"Patient"`, `"Biospecimen"`).
+   - **`-d <your_dataset_id>`**: Retrieves the existing manifest associated with a specific dataset on Synpase.
+
+
+Option 2: Use the API
+~~~~~~~~~~~~~~~~~~~~~~
+
+1. Locate the **`model/submit`** endpoint in the **Swagger UI**.
+2. Click **"Try it out"** to enable input fields.
+3. Enter the required parameters and execute the request:
+
+   - **`schema_url`**: The URL of your data model.
+     - If your data model is hosted on **GitHub**, the URL should follow this format:
+       - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
+       - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
+
+   - **`data_type`**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+
+   - **`dataset_id`**: The **top-level Synapse dataset ID**.
+     - This can be a **Synapse Project ID** or a **Folder ID**.
+
+   - **`asset_view`**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
+
+   - remove default inputs in dataset_scope and project_scope
+
+   - set file_annotations_upload to false
+
+   - table_manipulation is "replace" by default. You could keep it that way.
+
+   - set **`manifest_record_type`**` to "file_only"
+
+
+Submit a Manifest file and a Table to Synapse
+---------------------------------------------
+
+Submit a Manifest file and Add Annotations
+-------------------------------------------

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -252,29 +252,23 @@ Option 2: Use the API
 3. Enter the required parameters and execute the request:
 
    - **schema_url**: The URL of your data model.
-     - If your data model is hosted on **GitHub**, the URL should follow this format:
-       - **JSON-LD**: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
-       - **CSV**: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
+     - If your data model is hosted on **GitHub**, use the following formats:
+       - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
+       - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
-   - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`).
-     - To skip validation, remove the default inputs.
+   - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
 
-   - **dataset_id**: The **top-level Synapse dataset ID**.
-     - This can be a **Synapse Project ID** or a **Folder ID**.
+   - **dataset_id**: Provide the **top-level Synapse dataset ID**.
+       - This can be either a **Synapse Project ID** or a **Folder ID**.
 
-   - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
+   - **asset_view**: Enter the **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
-   - **dataset_scope** and **project_scope**:
-     - Remove any default inputs provided in these fields.
+   - **dataset_scope** and **project_scope**: Remove the default inputs.
 
-   - **file_annotations_upload**:
-     - Set this to `False` if you do not want annotations to be uploaded.
+   - **file_annotations_upload**: Set this to `False` if you do not want annotations to be uploaded.
 
-   - **table_manipulation**:
-     - The default is **"replace"**. Update it to **"upsert"**.
+   - **table_manipulation**: Update it to "upsert".
 
-   - **manifest_record_type**:
-     - Set this to **"table_and_file"**.
+   - **manifest_record_type**: Set this to **"table_and_file"**
 
-   - **table_column_names**:
-     - Choose **"display_label"** for upsert.
+   - **table_column_names**:  Choose **"display_label"** for upsert.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -196,29 +196,30 @@ Option 2: Use the API
 3. Enter the required parameters and execute the request:
 
    - **schema_url**: The URL of your data model.
-     - If your data model is hosted on **GitHub**, the URL should follow this format:
+     - If your data model is hosted on **GitHub**, use the following formats:
        - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
        - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
 
    - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
 
    - **dataset_id**: Provide the **top-level Synapse dataset ID**.
-     - This can be either a **Synapse Project ID** or a **Folder ID**.
+       - This can be either a **Synapse Project ID** or a **Folder ID**.
 
    - **asset_view**: Enter the **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
-   - **dataset_scope**: Remove any default inputs provided in this field.
+   - **project_scope**: Remove the default inputs. Add project IDs as string items.
 
-   - **project_scope**: Locate this parameter, remove the default inputs, and click on **Add string items** to add project IDs.
+   - **dataset_scope**: Remove default inputs.
 
-   - **file_annotations_upload**: Set this to `True`.
+   - **project_scope**: Remove default inputs and add project IDs as string items.
+
+   - **file_annotations_upload**: Set this to `false`.
 
    - **table_manipulation**: The default is "replace". You can keep it as is.
 
    - **manifest_record_type**: Set this to "file_only" or adjust it based on your project requirements.
 
-   - **table_column_names**: This is optional. Available options are "class_label", "display_label", and "display_name". The default is "class_label".
-
+   - **table_column_names**: This is optional. Available options are "class_label", "display_label", and "display_name". The default is "class_label". You can keep it as is.
 
 Enable upsert for manifest submission
 -------------------------------------

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -85,7 +85,7 @@ Option 2: Use the API
    - **data_type**: Specify the data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
 
    - **dataset_id**: Provide the **top-level Synapse dataset ID**.
-     - This can be either a **Synapse Project ID** or a **Folder ID**.
+       - This can be either a **Synapse Project ID** or a **Folder ID**.
 
    - **asset_view**: Enter the **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 
@@ -151,8 +151,8 @@ Option 2: Use the API
 
    - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
 
-   - **dataset_id**: The **top-level Synapse dataset ID**.
-     - This can be a **Synapse Project ID** or a **Folder ID**.
+  - **dataset_id**: The **top-level Synapse dataset ID**.
+    - This can be a **Synapse Project ID** or a **Folder ID**.
 
    - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
 

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -96,7 +96,7 @@ Option 2: Use the API
     During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing the default inputs.
 
 
-1. Locate the **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>` in the **Swagger UI**.
+1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
@@ -163,7 +163,7 @@ Option 2: Use the API
     During submission, validation is optional. If you have finished validation in previous step, you could skip validation by removing the default inputs.
 
 
-1. Locate the **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>` in the **Swagger UI**.
+1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
@@ -214,7 +214,7 @@ Option 1: Use the CLI
 Option 2: Use the API
 ~~~~~~~~~~~~~~~~~~~~~~
 
-1. Locate the **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>` in the **Swagger UI**.
+1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
@@ -270,7 +270,7 @@ Option 1: Use the CLI
 Option 2: Use the API
 ~~~~~~~~~~~~~~~~~~~~~~
 
-1. Locate the **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>` in the **Swagger UI**.
+1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`.
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -46,30 +46,30 @@ Submit a Manifest File to Synapse
 
 .. note::
 
-  Manifests should be submitted to the top-level dataset folder. Below are some examples demonstrating where the manifest file should go:
+   Manifests should be submitted to the top-level dataset folder. Below are some examples demonstrating where the manifest file should go:
 
-  .. code-block:: text
+   .. code-block:: text
 
-     syn12345678/
-     ├── file1.csv
-     ├── file2.csv
-     ├── manifest.csv
+      syn12345678/
+      ├── file1.csv
+      ├── file2.csv
+      ├── manifest.csv
 
-  Here is the top-level folder ID: syn12345678
+   Here is the top-level folder ID: syn12345678
 
-  Here's an example using subfolders:
+   Here's an example using subfolders:
 
-  .. code-block:: text
+   .. code-block:: text
 
-     syn12345678/
-     ├── subfolder1/
-     │   └── file1
-     ├── subfolder2/
-     │   └── file2
-     ├── file3
-     ├── manifest.csv
+      syn12345678/
+      ├── subfolder1/
+      │   └── file1
+      ├── subfolder2/
+      │   └── file2
+      ├── file3
+      ├── manifest.csv
 
-  Here is the top-level folder ID: syn12345678
+   Here is the top-level folder ID: syn12345678
 
 
 Option 1: Use the CLI
@@ -101,7 +101,7 @@ Option 2: Use the API
     During submission, validation is optional. If you have finished validation in previous step, you could skip validation by excluding the `data_type` and `dataset_scope` parameter values.
 
 
-1. Visit **model/submit** endpoint: `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_
+1. Visit the `**model/submit** endpoint <https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
@@ -168,7 +168,7 @@ Option 2: Use the API
     During submission, validation is optional. If you have finished validation in previous step, you could skip validation by excluding the `data_type` and `dataset_scope` parameter values.
 
 
-1. Visit **model/submit** endpoint: `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_
+1. Visit the `**model/submit** endpoint <https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
@@ -219,7 +219,7 @@ Option 1: Use the CLI
 Option 2: Use the API
 ~~~~~~~~~~~~~~~~~~~~~~
 
-1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_.
+1. Visit the `**model/submit** endpoint <https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 
@@ -275,7 +275,7 @@ Option 1: Use the CLI
 Option 2: Use the API
 ~~~~~~~~~~~~~~~~~~~~~~
 
-1. Visit **model/submit** endpoint `<https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_.
+1. Visit the `**model/submit** endpoint <https://schematic.api.sagebionetworks.org/v1/ui/#/Model%20Operations/schematic_api.api.routes.submit_manifest_route>`_
 2. Click **"Try it out"** to enable input fields.
 3. Enter the required parameters and execute the request:
 

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -169,7 +169,7 @@ Option 2: Use the API
 
 
 Expedite submission process (Optional)
------------------------------------------------------------
+---------------------------------------
 
 If your asset view contains multiple projects, it might take some time for the submission to finish.
 
@@ -193,5 +193,82 @@ Option 2: Use the API
 
 1. Locate the **model/submit** endpoint in the **Swagger UI**.
 2. Click **"Try it out"** to enable input fields.
-3. Follow instructions to Submit a Manifest file
-3. Locate "project_scope" parameter and click on **Add string items** to add project IDs.
+3. Enter the required parameters and execute the request:
+
+   - **schema_url**: The URL of your data model.
+     - If your data model is hosted on **GitHub**, the URL should follow this format:
+       - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
+       - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
+
+   - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+
+   - **dataset_id**: The **top-level Synapse dataset ID**.
+     - This can be a **Synapse Project ID** or a **Folder ID**.
+
+   - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
+
+   - remove default inputs in **dataset_scope**
+
+   - locate "project_scope" parameter and remove the default inputs. Then click on **Add string items** to add project IDs.
+
+   - set file_annotations_upload to `True`
+
+   - table_manipulation is "replace" by default. You could keep it that way.
+
+   - set **manifest_record_type** to "file_only" or you could change it based on your project requirements
+
+   - table_column_names: This is optional, and the available options are "class_label", "display_label", and "display_name". The default is "class_label".
+
+
+Enable upsert for manifest submission
+-------------------------------------
+
+By default, the CLI/API will replace the existing manifest and table with the new one. If you want to update the existing manifest and table, you could use the upsert option.
+
+
+Pre-requisite
+~~~~~~~~~~~~~~
+
+1. Ensure that all your manifests, including both the initial manifests and those containing rows to be upserted, include a primary key: <YourComponentName_id>. For example, if your component name is "Patient", the primary key should be "Patient_id".
+2. If you plan to use upsert in the future, select the upsert option during the initial table uploads.
+3. Currently it is required to use -dl/--use_display_label with table upserts.
+
+
+Option 1: Use the CLI
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    schematic model -c /path/to/config.yml submit -mp <your csv manifest path> -d <your synapse top level folder id> -vc <your data type> -mrt table_and_file -no-fa -tcn "display_label" -tm "upsert"
+
+- **-tm**: The default option is "replace". Change it to "upsert" for enabling upsert.
+- **-tcn**: Use display label for upsert.
+
+Option 2: Use the API
+~~~~~~~~~~~~~~~~~~~~~~
+
+1. Locate the **model/submit** endpoint in the **Swagger UI**.
+2. Click **"Try it out"** to enable input fields.
+3. Enter the required parameters and execute the request:
+
+   - **schema_url**: The URL of your data model.
+     - If your data model is hosted on **GitHub**, the URL should follow this format:
+       - JSON-LD: `https://raw.githubusercontent.com/<your-repo-path>/data-model.jsonld`
+       - CSV: `https://raw.githubusercontent.com/<your-repo-path>/data-model.csv`
+
+   - **data_type**: The data type or schema model for your manifest (e.g., `"Patient"`, `"Biospecimen"`). To skip validation, remove the default inputs.
+
+   - **dataset_id**: The **top-level Synapse dataset ID**.
+     - This can be a **Synapse Project ID** or a **Folder ID**.
+
+   - **asset_view**: The **Synapse ID of the fileview** containing the top-level dataset for which you want to generate a manifest.
+
+   - remove default inputs in **dataset_scope** and **"project_scope"
+
+   - set file_annotations_upload to `False` if you do not want annotations to be uploaded.
+
+   - table_manipulation is "replace" by default. Update it to **upsert**.
+
+   - set **manifest_record_type** to "table_and_file".
+
+   - **table_column_names**: Choose display_label for upsert.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -15,7 +15,7 @@ Ensure you have a Synapse account and have obtained your Synapse credential by f
   Refer to the **"Installation Guide for Users"** for detailed instructions.
 
 - **Understand Important Concepts**:
-  Familiarize yourself with key concepts outlined on the **home page** of the documentation.
+  Familiarize yourself with key concepts outlined on the :doc:`index.rst` page.
 
 - **Configuration File**:
   Learn more about each attribute in the configuration file by referring to the relevant documentation.

--- a/docs/source/manifest_submission.rst
+++ b/docs/source/manifest_submission.rst
@@ -31,6 +31,22 @@ Visit the **Schematic API (Production Environment)**:
 This will open the **Swagger UI**, where you can explore all available API endpoints.
 
 
+Run help command
+----------------
+
+You could run the following commands to learn about subcommands with manifest submission:
+
+.. code-block:: bash
+
+    schematic model -h
+
+You could also run the following commands to learn about all the options with manifest submission:
+
+.. code-block:: bash
+
+    schematic model --config path/to/config.yml submit -h
+
+
 Submit a Manifest File to Synapse
 ---------------------------------
 

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -3250,7 +3250,7 @@ class TableOperations:
         Method to upsert rows from a new manifest into an existing table on synapse
         For upsert functionality to work, primary keys must follow the naming convention of <componenet>_id
         `-tm upsert` should be used for initial table uploads if users intend to upsert into them at a later time; using 'upsert' at creation will generate the metadata necessary for upsert functionality.
-        Currently it is required to use -dl/--use_display_label with table upserts.
+        Currently it is required to use -tcn "display label" with table upserts.
 
 
         Args:


### PR DESCRIPTION
# Problem 
Not enough documentation for manifest submission. The interface wasn't user friendly enough 

# Solution 
* updated documentation include instructions on submitting a manifest using the CLI and the APIs
* covered most of the use cases

# Test
View the latest doc here: https://schematicpy.readthedocs.io/en/schematic-254/manifest_submission.html#