### PR TITLE
update tool for sonarcloud scan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,7 @@ jobs:
         with:
           files: "coverage.xml"
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4.1.0
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
         if: ${{ always() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves [DPE-1270](https://sagebionetworks.jira.com/browse/DPE-1270)

# Problem
Test workflow uses a deprecated tool for sonarcloud scanning.

# Solution
The deprecated tool is used by a tool we use directly, that tool has been updated to the latest version

# Testing
The workflow now completes successfully

[DPE-1270]: https://sagebionetworks.jira.com/browse/DPE-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ