### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# **Problem:**
+
+- Describe the specific technical problem that this PR solves.
+- Include  details such as:
+    - How you reproduced the problem
+    - What code is affected
+    - Any relevant background information
+
+# **Solution:**
+
+- Describe the specific technical solution that this PR provides.
+- Include details such as:
+    - How you debugged the problem
+    - Why you chose this solution
+    - Does the solution make any impact beyond the immediate problem
+    - Any necessary technical debt incurred
+    - Any important design decisions/links to design documentation (if applicable)
+
+# **Testing:**
+
+- Describe any testing that was performed to validate the solution.
+- Include details such as:
+    - How you tested the solution
+    - Any relevant test results (Do not include any test results that may contain sensitive information)
+    - Any automated tests that were added to the codebase


### PR DESCRIPTION
Problem:
The Schematic repository did not have the new PR template we've decided is standard
Resolves [DPE-1253](https://sagebionetworks.jira.com/browse/DPE-1253)

Solution:
I've added the template to the repository to auto-populate the description of a PR when one is opened

Testing:
Changes will need to be validated after merge of this PR

[DPE-1253]: https://sagebionetworks.jira.com/browse/DPE-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ