### PR TITLE
[SCHEMATIC-249] Add markdown file linking to LinkML docs

### DIFF
--- a/docs/source/linkml.md
+++ b/docs/source/linkml.md
@@ -1,0 +1,15 @@
+# LinkML
+
+## Background
+
+DPE is currently looking into what the future of Schematic might look like. This includes the possibility of completely reworking how we handle data models. Currently, Schematic supports data models in CSV or JSON-LD format. Several DCCs are either using or planning on using LinkML to create their data models and then port them to JsonLD for use in schematic. One possibility in Schematic 2.0 (placeholder name) is to make LinkML the format for data models and to use native LinkML functionality where possible to reduce the work that Schematic does. DPE is currently looking into what the future of Schematic might look like. This includes the possibility of completely reworking how we handle data models. Currently, Schematic supports data models in CSV or JSON-LD format. Several DCCs are either using or planning on using LinkML to create their data models and then port them to JsonLD for use in schematic. One possibility in Schematic 2.0 (placeholder name) is to make LinkML the format for data models and to use native LinkML functionality where possible to reduce the work that Schematic does.
+
+## Links
+
+LinkML [documentation](https://linkml.io/linkml/)
+
+DPE performed a [comparison](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/3856367618/SCHEMATIC-225+Exploration+of+LinkML+features+compared+to+Schematic+JSONLD) between Schematics current functionality and what LinkML could provide via the CLI.
+
+The [HTAN2 model](https://github.com/ncihtan/htan-linkml/blob/get-gen-excel-working/HTAN2Model.yaml) in LinkML
+
+The [NF Repo](https://github.com/nf-osi/nf-metadata-dictionary/) that creates the LinkML model.


### PR DESCRIPTION
[SCHEMATIC-249]

# **Problem:**
The documentation didn't include a link to the LinkML comparison work.

# **Solution:**
A markdown document has been added

# **Testing:**
None
