### PR TITLE
[SCHEMATIC-264] Added validation rules doc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -148,3 +148,4 @@ For the entire Python API reference documentation, you can visit the docs here: 
    tutorials
    troubleshooting
    cli_reference
+   validation_rules

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -146,6 +146,6 @@ For the entire Python API reference documentation, you can visit the docs here: 
    asset_store
    configuration
    tutorials
+   validation_rules
    troubleshooting
    cli_reference
-   validation_rules

--- a/docs/source/validation_rules.md
+++ b/docs/source/validation_rules.md
@@ -1,0 +1,659 @@
+# Validation Rules
+
+## Overview
+
+When Schematic validates a manifest, it uses a data model. The data model contains a list of validation rules for each component(data-type). This document describes all allowed validation rules currently implemented by Schematic.
+
+Rules that change the validation behavior which must be taken from the following pre-specified list, formatted in the indicated ways, and added to the data model to apply. An [example data model](https://github.com/Sage-Bionetworks/schematic/blob/develop/tests/data/example.model.csv) using each rule is available for reference.
+
+Rules can optionally be configured to raise  errors  and prevent manifest submission in the case of invalid entries, or warnings and allow submission when invalid entries are found within the attribute the rule is set for. Validators will be notified of the invalid values in both cases. Default message levels for each rule can be found below under each rule.
+
+Attributes that are not required will raise warnings when invalid entries are identified. For attributes that are not required, if a user does not submit a response, a warning or error will no longer be logged. If you desire raising an error for non-entries, set Required to True in the data model.
+
+Metadata validation is an explicit step in the submission pipeline and must be run either before or during manifest submission.
+
+## Validation Types
+
+Validation rules are just one type of validation run by Schematic to ensure that submitted manifests conform to the expectations set by the data model.
+
+This page details how to use Validation Rules, but please refer to [this documentation](https://sagebionetworks.jira.com/wiki/spaces/SCHEM/pages/3302785036) to learn about the other types of validation.
+
+## Rule Implementation
+
+| Rule | In-House | Great Expectations (GX) | JSON Schema Validation |
+| ---- | -------- | ----------------------- | ---------------------- |
+| list | yes | | |
+| regex module | yes | | |
+| float | yes | yes |  |
+| int | yes | yes | |
+| num | yes | yes | |
+| string | yes | yes | |
+| url | yes | | |
+| matchAtLeastOne | yes | | |
+| matchExactlyOne | yes | | |
+| matchNone | yes | | |
+| recommended | | yes | |
+| protectAges | | yes | |
+| unique | | yes | |
+| inRange | | yes | |
+| date | | yes | |
+| required | | | yes |
+
+## Rule Types and Details
+
+### List Validation Type
+
+#### list
+
+- Use to parse the imported value to a list of values and (optionally) to verify that the user provided value was a comma separated list, depending on how strictly entries must conform to the list structure. Values can come from Valid Values.
+
+- Format:
+
+  - `list <conformity level> <raised message level>`
+
+    - `list strict`
+
+      - Validates that entries are comma separated lists, and parses into list
+
+      - Requires all attribute entries to be comma-delimited, even ‘lists’ with only one element
+
+    - `list like`
+
+      - Assume entries are either lists or `list like` but do not verify that entries are comma separated lists, and attempt to parse into a list
+
+      - Single values, or ‘lists’ of length one, can be entered without a comma delimiter
+
+- Can use `list` rule in conjunction with `regex` rule to validate that the items in a list follow a specific pattern.
+
+  - All the values in the list need to follow the same pattern. This is ideal for when users need to provide a list of IDs.
+
+- Default behavior: raises `error`
+
+### Regex Validation Type
+
+#### regex
+
+- Use the `regex` validation rule when you want to require that a user input values in a specific format, i.e. an ID that follows a particular format.
+
+- Format:
+
+  - `regex <module> <regular_expression> <raised message level>`
+
+  - Module: is the Python `re` module that you want to use. A common one would be search. Refer to Python `re` source material to find the most appropriate module to use.
+
+  - Single spaces separate the three strings.
+
+- Example:
+
+  - `regex search [0-9]{4}\/[0-9]*`
+
+  - The regular expression defined above allows comparison to an expected format of a histological morphology code.
+
+- Default behavior: raises `error`
+
+- Notes/tips/warnings
+
+  - [regex101.com](https://regex101.com/) is a tool that can be used to build and validate the behavior of your regular expression
+
+  - If the module specified is match for a given attribute’s validation rule, regex match validation will be preformed in Google Sheets (but not Excel) real-time during metadata entry.
+
+  - The `strict_validation parameter` (in the config.yml file for CLI or in manifest generation REST API calls) sets whether to stop the user from entering incorrect information in a Google Sheets cell (`strict_validation = true`) or simply throws a warning (`strict_validation = false`). Default: `true`.
+
+  - `regex` validation in Google Sheets is different than standard regex validation (for example, it does not support validation of digits). See [this documentation](https://github.com/google/re2/wiki/Syntax) for details on Google regex syntax. It is up to the user/modeler to validate that `regex match` is working in their manifests, as intended. This is especially important if the `strict_validation` parameter is set to `True` as users will be blocked from entering incorrect data. If you are using Google Sheets and do not want to use real-time validation use `regex search` instead of `regex match`.
+
+### Type Validation Type
+
+- There are two parameters
+
+  - The first parameter is type and must be one of [ `float`, `int`, `num`, `str`]
+
+  - The second optional parameter is the msg level and must be one of [ `error`, `warning` ], defaults to `error`.
+
+- Examples: [ `str`, `str error`, `str warning`]
+
+#### float
+
+- Checks that the value is a float.
+
+#### int
+
+- Checks that the value is an integer.
+
+#### num
+
+- Checks that the value is either an integer or float.
+
+#### str
+
+- Checks that the value is a string (not a number).
+
+### URL Validation Type
+
+#### url
+
+- Using the `url` rule implies the user should add a URL to a free text box as a string. This function will check that the user has provided a usable URL. It will check for any standard URL error and throw an error if one is found. Further additions to this rule can allow for checking that a specific type of URL is added. For example, if the user needs to add a <http://protocols.io> URL, <http://protocols.io> can be added after url to perform this check. If the provided url does not contain this specific string, an error will be raised.
+
+- Format:
+
+  - `url <optional strings> <raised message level>`
+
+    - `url` must be specified first then an arbitrary number of strings can be added after (separated by spaces) to add additional levels of specificity.
+
+  - Alternatively, its valid to pass only ‘url’ to simply check if the input is a url.
+
+- Examples:
+
+  - `url http://protocols.io` Will check that any input is a valid URL, and will also check to see that the URL contains the string `http://protocols.io` If not, an error will be raised.
+
+  - `url dx.doi http://protocols.io` Will check that any input is a valid URL, and will also check to see that the URL contains the strings `dx.doi` and `http://protocols.io`. If not, an error will be raised.
+
+- Default behavior: raises `error`
+
+### Required Validation Type
+
+#### required
+
+ass validation.
+
+An attribute's requirement is typically set using the required column (csv) or field (JSONLD) in the data model. A `True` value means a users must supply a value, `False` means they are allowed to skip providing a value.
+
+Some users may want to use the same attribute across several manifests, but have different requirements based on the manifest/component. For example, say the data model contains an attribute called PatientID, and this attribute is used in manifests Biospecimen, Patient and Demographics. Say the modeler wants to require that PatientID be required in the Patient manifest but not Biospecimen or Demographics. In the standard Data Model format, there is only one requirement option per Attribute, so one would not be able to set requirements per component. But with the advent of component based rule settings, this can now be achieved.
+
+Requirements can be specified per component by setting the required field in the data model to `False`, and using component based rule setting along with the required "rule".
+
+Note: this new required validation rule is not a traditional validation rule, but rather impacts the JSON validation schema. This means requirements propagate automatically to manifests as well.
+
+Notes:
+
+- When using `required` in validation rules, the `Required` **column/field must be set to** `False` or this will cause the rule to not work as expected (i.e. components were the attribute is expected to not be required due to the validation rules, will still be required).
+
+  - Note: a warning will be raised for discrepancies in requirements settings are found when running validation.
+
+- `required` can be used in conjunction with other rules, without restriction.
+
+- The messaging level, like all JSON validation checks, is always set at `error`, and not modifiable.
+
+- `required` does not work with other rule modifiers, such as `warning`, `error` etc…
+
+  - Though it will not throw an error if rule modifiers are added, it will not work as intended, and a warning will appear
+
+    - For example, if the rule `^^#Biospecimen required warning`, is added to the data model a warning will be raised letting the user know that the rule modifier cannot be applied to required.
+
+- Adding `required` sets `Required` to `True` for the specified component. There is no way to set `Required` to `False` using the validation rules column, that would come from the `Required` field in the data model.
+
+- Controlling `required` through the validation rule will also impact Manifest formatting (in terms of required column highlighting).
+
+  - To check that `required` rules are working as expected, one could generate all impacted manifests and check the formatting is as expected.
+
+Examples:
+
+- `#BiospecimenManifest unique required warning^^unique error`
+
+  - For`BiospecimenManifest` manifests, the values supplied must be unique. If they aren’t a warning will be raised. If values are missing, an error will be raised.
+
+  - For all other manifests, the filling out values is optional. But, if the values supplied are not unique, an error will be raised.
+
+- `#Demographics required^^#BiospecimenManifest required^^`
+
+  - For `Demographics` and `BiospecimenManifest` manifests, values are required to be supplied, if they are not supplied an error will be raised.
+
+  - For all other manifests this attribute is not required.
+
+### Cross-manifest Validation Type
+
+Use cross-manifest validation rules when you want to check the values of an attribute in the manifest being validated against an attribute in the manifest(s) of a different component. For example, if a sample manifest has a patient id attribute and you want to check it against the id attribute of patient manifests.
+
+The format for cross-validation is: `<rule> <targetComponent>.<targetAttribute> <scope> <raised message level>`
+
+There are three rules that do cross-manifest validation: [`matchAtLeastOne`, `matchExactlyOne`, `matchNone`]
+
+There are two scopes to choose from: [ `value`, `set`]
+
+#### Value Scope
+
+When the value scope is used all values from the target attribute in all target manifests are combined. The values from the manifest being validated are compared to this combined list. In other words, there is no distinction between what values came from what target manifest.
+
+##### matchAtleastOne Value Scope
+
+The manifest is validated if each value in the target attribute exists at least once in the combined values of the target attribute of the target manifests.
+
+##### matchExactlyOne Value Scope
+
+The manifest is validated if each value in the target attribute exists once, and only once, in the combined values of the target attribute of the target manifests.
+
+##### matchNone Value Scope
+
+The manifest is validated if each value in the target attribute does not exist in the combined values of the target attribute of the target manifests.
+
+##### Examples Value Scope
+
+###### #1 Value Scope
+
+Tested manifest: ["A"]
+
+Target manifests: ["A", "B"]
+
+- matchExactlyOne: passes
+
+- matchAtleastOne: passes
+
+- matchNone: fails
+
+  - because "A" is in the target manifest
+
+###### #2 Value Scope
+
+Tested manifest: ["A", "C"]
+
+Target manifests: ["A", "B"]
+
+- matchExactlyOne: fails
+
+  - because "C" is not in the target manifest
+
+- matchAtleastOne: fails
+
+  - because "C" is not in the target manifest
+
+- matchNone: fails
+
+  - because "A" is in the target manifest
+
+###### #3 Value Scope
+
+Tested manifest: ["C"]
+
+Target manifests: ["A", "B"]
+
+- matchExactlyOne: fails
+
+  - because "C" is not in the target manifest
+
+- matchAtleastOne: fails
+
+  - because "C" is not in the target manifest
+
+- matchNone: passes
+
+###### #4 Value Scope
+
+Tested manifest: ["A", "A"]
+
+Target manifests: ["A", "B"]
+
+- matchExactlyOne: passes
+
+- matchAtleastOne: passes
+
+- matchNone: fails
+
+  - because "A" is in the target manifest
+
+###### #5 Value Scope
+
+Tested manifest: ["A"]
+
+Target manifests: ["A", "A"]
+
+- matchExactlyOne: fails
+
+  - because "A" is in the target manifest twice
+
+- matchAtleastOne: passes
+
+- matchNone: fails
+
+  - because "A" is in the target manifest
+
+###### #6 Value Scope
+
+Tested manifest: ["A"]
+
+Target manifests: ["A"], ["A"]
+
+matchExactlyOne: fails
+
+because "A" is in both target manifests
+
+matchAtleastOne: passes
+
+matchNone: fails
+
+because "A" is in the target manifest
+
+###### #7 Value Scope
+
+Tested manifest: ["A"]
+
+Target manifests: ["A", "B"],  ["A", "B"]
+
+- matchExactlyOne: fails
+
+  - because "A" is in both target manifests
+
+- matchAtleastOne: passes
+
+- matchNone: fails
+
+  - because "A" is in the target manifest
+
+#### Set scope
+
+When the set scope is used the values from the tested manifest are compared **one at a time** against each target manifest, and the number of matches are counted. The test to determine if the tested manifest matches the target manifest is to see if the tested manifest values are a subset of the target manifest values. Imagine a target manifest who's values are ["A", "B" "C"]:
+
+- [ ], ["A"], ["A", "A"], ["A", "B", "C"] are all subsets of the example target manifest.
+
+- [1], ["D"], ["D", "D"], ["D", "E"] are not subsets of the example target manifest.
+
+##### matchAtleastOne Set scope
+
+The manifest is validated if there is atleast one set match between the tested manifest and the target manifests
+
+##### matchExactlyOne Set scope
+
+The manifest is validated if there is one and only one set match between the tested manifest and the target manifests
+
+##### matchNone Set scope
+
+The manifest is validated if there are no set match between the tested manifest and the target manifests
+
+##### Examples Set scope
+
+###### #1 Set scope
+
+Tested manifest: ["A"]
+
+Target manifests: ["A", "B"]
+
+matchExactlyOne: passes
+
+matchAtleastOne: passes
+
+matchNone: fails
+
+because "A" is in the target manifest
+
+###### #2 Set scope
+
+Tested manifest: ["A"]
+
+Target manifests: ["A", "B"], ["C", "D"]
+
+- matchExactlyOne: passes
+
+- matchAtleastOne: passes
+
+- matchNone: fails
+
+  - because "A" is in atleast one of the target manifest
+
+###### #3 Set scope
+
+Tested manifest: ["A"]
+
+Target manifests: ["A", "B"], ["A", "B"]
+
+- matchExactlyOne: fails
+
+  - because "A" is in more than one target manifest
+
+- matchAtleastOne: passes
+
+- matchNone: fails
+
+  - because "A" is in atleast one of the target manifests
+
+###### #4 Set scope
+
+Tested manifest: ["C"]
+
+Target manifests: ["A", "B"]
+
+- matchExactlyOne: fails
+
+  - because "C" is not in the target manifest
+
+- matchAtleastOne: fails
+
+  - because "C" is not in the target manifest
+
+- matchNone: passes
+
+### Content Validation Type
+
+Rules can be used to validate the contents of entries for an attribute.
+
+#### recommended
+
+- Use to raise a warning when a manifest column is not required but empty. If an attribute is always necessary then ‘required' should be set to `TRUE` instead of using the `recommended` validation rule.
+
+- Format:
+
+  - `recommended <raised message level>`
+
+- Examples:
+
+  - `recommended`
+
+- Default behavior: raises `warning`
+
+#### protectAges
+
+- Use to ensure that patient ages under 18 and over 89 years of age are censored when uploading for sharing. If necessary, a censored version of the manifest will be created and uploaded along with the uncensored version. Uncensored versions will be uploaded as restricted and Terms of Use will need to be set.
+
+- Format:
+
+  - `protectAges <raised message level>`
+
+- Examples:
+
+  - `protectAges warning`
+
+- Default behavior: raises `warning`
+
+#### unique
+
+- Use to ensure that attribute values are not duplicated within a column.
+
+- Format:
+
+  - `unique <raised message level>`
+
+- Examples:
+
+  - `unique error`
+
+- Default behavior: raises `error`
+
+#### inRange
+
+- Use to ensure that numerical data is within a specified range
+
+- Format:
+
+  - `inRange <lower range bound> <upper range bound> <raised message level>`
+
+- Examples:
+
+  - `inRange 50 100 error`
+
+- Default behavior: raises `error`
+
+#### date
+
+- Use to ensure the value parses as a date
+
+- Uses `dateutils` to parse the value
+
+  - Can parse many formats
+
+  - YYYY-MM-DD format is recommended
+
+  - Every value must be read as a string so no formats such as YYYYDDMM which would be read in as an int
+
+- Default behavior: raises `error`
+
+### Filename Validation
+
+This requires paths to be enabled for the synapse master file view in use. Can be enabled by navigating to an existing view and selecting `show view schema` > `edit schema` > `add default view columns` > `save`. Paths are enabled on new views by default.
+
+This should be used only with the Filename attribute in a data model and specified with [Component Based Rule Setting](https://sagebionetworks.jira.com/wiki/spaces/SCHEM/pages/edit-v2/2645262364#Component-Based-Rule-Setting)
+
+#### filenameExists
+
+- Used to validate that the filenames and paths as they exist in the metadata manifest match the paths that are in the Synapse master File View for the specified dataset
+
+  - Conditions in which an error is raised:
+
+    - `missing entityId`: The entityId field for a manifest row is null or an empty string
+
+    - `entityId does not exist`: The entityId provided for a manifest row does not exist within the specified dataset’s file view
+
+    - `path does not exist`: The Filename in the manifest row does not exist within the specified dataset’s file view
+
+    - `mismatched entityId`: The entityId and Filename do not match the expected values from the specified dataset’s file view
+
+- Format
+
+  - `filenameExists <dataset scope> <raised message level>`
+
+- Example
+
+  - This sets the rule for the MockFilename component ONLY with the specified dataset scope syn61682648
+
+  - `#MockFilename filenameExists syn61682648^^`
+
+- Default behavior: raises `error`
+
+Given this File View:
+
+```python
+id,path
+syn61682653,schematic - main/MockFilenameComponent/txt1.txt
+syn61682659,schematic - main/MockFilenameComponent/txt4.txt
+syn61682660,schematic - main/MockFilenameComponent/txt2.txt
+syn61682662,schematic - main/MockFilenameComponent/txt3.txt
+syn63141243,schematic - main/MockFilenameComponent/txt6.txt
+```
+
+We get the following results for this Manifest:
+
+```python
+Component,Filename,entityId
+MockFilename,schematic - main/MockFilenameComponent/txt1.txt,syn61682653 # Pass
+MockFilename,schematic - main/MockFilenameComponent/txt2.txt,syn61682660 # Pass
+MockFilename,schematic - main/MockFilenameComponent/txt3.txt,syn61682653 # mismatched entityId
+MockFilename,schematic - main/MockFilenameComponent/this_file_does_not_exist.txt,syn61682653 # path does not exist
+MockFilename,schematic - main/MockFilenameComponent/txt4.txt,syn6168265 # entityId does not exist
+MockFilename,schematic - main/MockFilenameComponent/txt6.txt,  # missing entityId
+```
+
+### Rule Combinations
+
+Schematic allows certain combinations of existing validation rules to be used on a single attribute, where appropriate. Combinations currently allowed are enumerated in the table below, under 'Rule Combinations in Production'.
+
+Note:  isNa and required can be combined with all rules and rule combos.
+
+Rule combinations: [`list::regex`, `int::inRange`, `float::inRange`, `num::inRange`, `protectAges::inRange`]
+
+- Format:
+
+  - `<rule 1> <applicable rule 1 arguments>::<rule 2> <applicable rule 2 arguments>`
+
+  - ‘::’ delimiter used to separate each rule
+
+- Example:
+
+  - `list :: regex search [HTAN][0-9]{1}_[0-9]{4}_[0-9]*`
+
+### Component-Based Rule Setting
+
+**Component-Based Rule Setting** is a powerful feature in data modeling that enables users to create rules tailored to specific subsets of components or manifests. This functionality was developed to address scenarios where a data modeler needs to enforce uniqueness for certain attribute values within one manifest while allowing non-uniqueness in another.
+
+Here's how it works:
+
+1. **Rule Definition at Attribute Level**: Rules are defined at the attribute level within the data model.
+
+2. **Manifest-Level Referencing**: These rules can then be applied (or not) to specific manifests within the data model. This means that rules can be selectively enforced based on the manifest they're associated with.
+
+This feature offers flexibility and applicability beyond its original use case. The new **Component-Based Rule Setting** feature provides users with the following options:
+
+- **Apply a Rule to All Manifests Except Specified Ones**: Users can now define a rule that applies to all manifests within the data model except for those explicitly specified. In cases where exceptions are specified, users have the flexibility to define unique rules for these exceptions or opt not to apply any rule at all.
+
+- **Specify a Rule for a Single Manifest**: Alternatively, users can specify a rule that applies to a single manifest exclusively. This allows for fine-grained control over rule enforcement at the manifest level.
+
+- **Unique Rules for Each Manifest**: Users can also define unique rules for each manifest within the data model. This enables tailored rule enforcement based on the specific requirements and characteristics of each manifest.
+
+By leveraging the enhanced Component-Based Rule Setting feature, data modelers can efficiently enforce rules across their data models with greater precision and flexibility, ensuring data integrity while accommodating diverse use cases and requirements.
+
+Note: All restrictions to rule combos and implementation also apply to component based rules.
+
+Note: As always try the rule combos with mock data to ensure they are working as intended before using in production.
+
+- Format:
+
+  - `^^`Double carrots indicate that Component-Based rules are being set
+
+    - Use `^^` to separate component rule sets
+
+  - `#` In the first position (prior to the rule) to define the component/manifest to apply the rule to
+
+    - `#` character cannot be used without the `^^` to indicate component rule sets
+
+- Use case:
+
+  - Apply rule to all manifests *except* the specified set.
+
+    - `validation_rule^^#ComponentA`
+
+    - `validation_rule^^#ComponentA^^#ComponentB`
+
+  - Apply a unique rule to each manifest.
+
+    - `#ComponentA validation_rule_1^^#ComponentB validation_rule_2^^#ComponentC validation_rule_3`
+
+  - For the specified manifest, apply the given validation rule, but for all others, run a different rule
+
+    - `#ComponentA validation_rule_1^^validation_rule_2`
+
+    - `validation_rule_2^^#ComponentA validation_rule_1`
+
+  - Apply the validation rule to only one manifest
+
+    - `#ComponentA validation_rule_1^^`
+
+- Example Rules:
+
+  - Test by adding these rules to the `Patient ID` attribute in the `example.model.csv` model, then run validation with new rules against the example manifests.
+
+  - [Example Biospecimen Manifest](https://docs.google.com/spreadsheets/d/19_axG2Zj7URk4CT5qYjH0HfpMIOQ1dYEPvyaazSVNZE/edit#gid=0)
+
+  - [Example Patient Manifest](https://docs.google.com/spreadsheets/d/1IO0TkzwBX-lsu3rJDjWfgWYR6VlepingN9zuhkrgVUE/edit#gid=0)
+
+    - **Rule**: `#Patient int::inRange 100 900 error^^#Biospecimen int::inRange 100 900 warning`
+
+      - For the `Patient` manifest, apply the combo `rule int::inRange 100 900` at the `error` level.
+
+        - The value provided must be an integer in the range of 100-900; if it does not fall in the range, throw an error
+
+      - For the `Biospecimen` manifest, apply the combo rule `int::inRange 100 900` at the `warning` level
+
+        - The value provided must be an integer in the range of 100-900; if it does not fall in the range, throw a warning
+
+    - **Rule**: `#Patient int::inRange 100 900 error^^int::inRange 100 900 warning`
+
+      - For the `Patient` manifest, apply rule `int::inRange 100 900` at an `error` level
+
+      - For all other manifests, apply the `rule int::inRange 100 900` at a warning level
+
+    - **Rule**: `#Patient^^int::inRange 100 900 warning`
+
+      - For all manifests except `Patient` apply the rule `int::inRange 100 900` at the `warning` level
+
+    - **Rule**: `int::inRange 100 900 error^^#Biospecimen`
+
+      - Apply the rule `int::inRange 100 900 error`, to all manifests except `Biospecimen`
+
+    - **Rule**: `#Patient unique error^^`
+
+      - To the `PatientManifest` only, apply the `unique` validation rule at the `error` level

--- a/docs/source/validation_rules.rst
+++ b/docs/source/validation_rules.rst
@@ -189,15 +189,15 @@ Some users may want to use the same attribute across several manifests, but have
 
 Requirements can be specified per component by setting the required field in the data model to ``False``, and using component based rule setting along with the required "rule".
 
-.. code-block:: shell
+Note::
 
    This new required validation rule is not a traditional validation rule, but rather impacts the JSON validation schema. This means requirements propagate automatically to manifests as well.
 
-Notes:
 
-- When using the ``required`` validation rule, the ``Required`` column must ``False`` in the CSV, or the ``Required`` must be set to ``False`` in the JsonLD or this will cause the rule to not work as expected (i.e. components were the attribute is expected to not be required due to the validation rules, will still be required).
 
-.. code-block:: shell
+When using the ``required`` validation rule, the ``Required`` column must ``False`` in the CSV, or the ``Required`` must be set to ``False`` in the JsonLD or this will cause the rule to not work as expected (i.e. components were the attribute is expected to not be required due to the validation rules, will still be required).
+
+Note::
 
   While using the CLI, a warning will be raised for discrepancies in requirements settings are found when running validation.
 
@@ -608,7 +608,7 @@ Rule Combinations
 
 Schematic allows certain combinations of existing validation rules to be used on a single attribute, where appropriate.
 
-.. code-block:: shell
+Note::
 
   isNa and required can be combined with all rules and rule combos.
 
@@ -645,7 +645,7 @@ This feature offers flexibility and applicability beyond its original use case. 
 
 By leveraging the enhanced Component-Based Rule Setting feature, data modelers can efficiently enforce rules across their data models with greater precision and flexibility, ensuring data integrity while accommodating diverse use cases and requirements.
 
-.. code-block:: shell
+Notes::
 
   All restrictions to rule combos and implementation also apply to component based rules.
 

--- a/docs/source/validation_rules.rst
+++ b/docs/source/validation_rules.rst
@@ -3,12 +3,6 @@ Validation Rules
 ================
 
 
-.. toctree::
-   :maxdepth: 2
-   :glob:
-
-   *
-
 Overview
 ========
 
@@ -33,6 +27,8 @@ This page details how to use Validation Rules, but please refer to `this documen
 
 Rule Implementation
 ===================
+
+Some validation rules are handles by Schematic itself, while others are handled by using the Great Expectations library.
 
 ================ ======== ======================= ======================
 Rule             In-House Great Expectations (GX) JSON Schema Validation
@@ -113,20 +109,22 @@ regex
 
 - Default behavior: raises ``error``
 
-- Notes/tips/warnings
+.. note::
 
-  - `regex101.com <https://regex101.com/>`_ is a tool that can be used to build and validate the behavior of your regular expression
+  `regex101.com <https://regex101.com/>`_ is a tool that can be used to build and validate the behavior of your regular expression
 
-  - If the module specified is match for a given attribute's validation rule, regex match validation will be preformed in Google Sheets (but not Excel) real-time during metadata entry.
+  If the module specified is match for a given attribute's validation rule, regex match validation will be preformed in Google Sheets (but not Excel) real-time during metadata entry.
 
-  - The ``strict_validation parameter`` (in the config.yml file for CLI or in manifest generation REST API calls) sets whether to stop the user from entering incorrect information in a Google Sheets cell (``strict_validation = true``) or simply throws a warning (``strict_validation = false``). Default: ``true``.
+  The ``strict_validation parameter`` (in the [config.yml](https://github.com/Sage-Bionetworks/schematic/blob/develop/config_example.yml) file for CLI or in manifest generation REST API calls) sets whether to stop the user from entering incorrect information in a Google Sheets cell (``strict_validation = true``) or simply throws a warning (``strict_validation = false``). Default: ``true``.
 
-  - ``regex`` validation in Google Sheets is different than standard regex validation (for example, it does not support validation of digits). See `this documentation <https://github.com/google/re2/wiki/Syntax>`_ for details on Google regex syntax. It is up to the user/modeler to validate that ``regex match`` is working in their manifests, as intended. This is especially important if the ``strict_validation`` parameter is set to ``True`` as users will be blocked from entering incorrect data. If you are using Google Sheets and do not want to use real-time validation use ``regex search`` instead of ``regex match``.
+  ``regex`` validation in Google Sheets is different than standard regex validation (for example, it does not support validation of digits). See `this documentation <https://github.com/google/re2/wiki/Syntax>`_ for details on Google regex syntax. It is up to the user/modeler to validate that ``regex match`` is working in their manifests, as intended. This is especially important if the ``strict_validation`` parameter is set to ``True`` as users will be blocked from entering incorrect data. If you are using Google Sheets and do not want to use real-time validation use ``regex search`` instead of ``regex match``.
 
 Type Validation Type
 --------------------
 
-- There are two parameters
+- Format:
+
+  - ``<type> <warning level>``
 
   - The first parameter is type and must be one of [ ``float``, ``int``, ```num```, ``str``]
 
@@ -160,7 +158,7 @@ URL Validation Type
 url
 ~~~
 
-- Using the ``url`` rule implies the user should add a URL to a free text box as a string. This function will check that the user has provided a usable URL. It will check for any standard URL error and throw an error if one is found. Further additions to this rule can allow for checking that a specific type of URL is added. For example, if the user needs to add a ``http://protocols.io`` URL, ``http://protocols.io`` can be added after url to perform this check. If the provided url does not contain this specific string, an error will be raised.
+- Using the ``url`` rule implies the user should add a URL to a free text box as a string. This function will check that the user has provided a usable URL. It will check for any standard URL error and throw an error if one is found. Further additions to this rule can allow for checking that a specific type of URL is added. For example, if the user needs to ensure that the input contains a http://protocols.io  URL string, http://protocols.io can be added after url to perform this check.
 
 - Format:
 
@@ -195,9 +193,9 @@ Note: this new required validation rule is not a traditional validation rule, bu
 
 Notes:
 
-- When using ``required`` in validation rules, the ``Required`` **column/field must be set to** ``False`` or this will cause the rule to not work as expected (i.e. components were the attribute is expected to not be required due to the validation rules, will still be required).
+- When using the ``required`` validation rule, the ``Required`` column must ``False`` in the CSV, or the ``Required`` must be set to ``False`` in the JsonLD or this will cause the rule to not work as expected (i.e. components were the attribute is expected to not be required due to the validation rules, will still be required).
 
-  - Note: a warning will be raised for discrepancies in requirements settings are found when running validation.
+  - Note: While using the CLI, a warning will be raised for discrepancies in requirements settings are found when running validation.
 
 - ``required`` can be used in conjunction with other rules, without restriction.
 
@@ -213,7 +211,7 @@ Notes:
 
 - Controlling ``required`` through the validation rule will also impact Manifest formatting (in terms of required column highlighting).
 
-  - To check that ``required`` rules are working as expected, one could generate all impacted manifests and check the formatting is as expected.
+  - To verify that the ``required`` rule is working as expected, you can generate all impacted manifests—required, and columns should appear highlighted in light blue.
 
 Examples:
 

--- a/docs/source/validation_rules.rst
+++ b/docs/source/validation_rules.rst
@@ -59,25 +59,25 @@ list
 
 - Format:
 
-  - `list <conformity level> <raised message level>_`
+  - ``list <conformity level> <raised message level>``
 
-    - `list strict`
+    - ``list strict``
 
       - Validates that entries are comma separated lists, and parses into list
 
       - Requires all attribute entries to be comma-delimited, even lists with only one element
 
-    - `list like`
+    - ``list like``
 
-      - Assume entries are either lists or `list like` but do not verify that entries are comma separated lists, and attempt to parse into a list
+      - Assume entries are either lists or ``list like`` but do not verify that entries are comma separated lists, and attempt to parse into a list
 
       - Single values, or lists of length one, can be entered without a comma delimiter
 
-- Can use `list` rule in conjunction with `regex` rule to validate that the items in a list follow a specific pattern.
+- Can use ``list`` rule in conjunction with ``regex`` rule to validate that the items in a list follow a specific pattern.
 
   - All the values in the list need to follow the same pattern. This is ideal for when users need to provide a list of IDs.
 
-- Default behavior: raises `error`
+- Default behavior: raises ``error``
 
 Regex Validation Type
 ---------------------
@@ -85,23 +85,23 @@ Regex Validation Type
 regex
 ~~~~~
 
-- Use the `regex` validation rule when you want to require that a user input values in a specific format, i.e. an ID that follows a particular format.
+- Use the ``regex`` validation rule when you want to require that a user input values in a specific format, i.e. an ID that follows a particular format.
 
 - Format:
 
-  - `regex <module> <regular_expression> <raised message level>_`
+  - ``regex <module> <regular_expression> <raised message level>``
 
-  - Module: is the Python `re` module that you want to use. A common one would be search. Refer to Python `re` source material to find the most appropriate module to use.
+  - Module: is the Python ``re`` module that you want to use. A common one would be search. Refer to Python ``re`` source material to find the most appropriate module to use.
 
   - Single spaces separate the three strings.
 
 - Example:
 
-  - `regex search [0-9]{4}\/[0-9]*`
+  - ``regex search [0-9]{4}\/[0-9]*``
 
   - The regular expression defined above allows comparison to an expected format of a histological morphology code.
 
-- Default behavior: raises `error`
+- Default behavior: raises ``error``
 
 - Notes/tips/warnings
 
@@ -109,20 +109,20 @@ regex
 
   - If the module specified is match for a given attribute's validation rule, regex match validation will be preformed in Google Sheets (but not Excel) real-time during metadata entry.
 
-  - The `strict_validation parameter` (in the config.yml file for CLI or in manifest generation REST API calls) sets whether to stop the user from entering incorrect information in a Google Sheets cell (`strict_validation = true`) or simply throws a warning (`strict_validation = false`). Default: `true`.
+  - The ``strict_validation parameter`` (in the config.yml file for CLI or in manifest generation REST API calls) sets whether to stop the user from entering incorrect information in a Google Sheets cell (``strict_validation = true``) or simply throws a warning (``strict_validation = false``). Default: ``true``.
 
-  - `regex` validation in Google Sheets is different than standard regex validation (for example, it does not support validation of digits). See `this documentation <https://github.com/google/re2/wiki/Syntax>_` for details on Google regex syntax. It is up to the user/modeler to validate that `regex match` is working in their manifests, as intended. This is especially important if the `strict_validation` parameter is set to `True` as users will be blocked from entering incorrect data. If you are using Google Sheets and do not want to use real-time validation use `regex search` instead of `regex match`.
+  - ``regex`` validation in Google Sheets is different than standard regex validation (for example, it does not support validation of digits). See `this documentation <https://github.com/google/re2/wiki/Syntax>_` for details on Google regex syntax. It is up to the user/modeler to validate that ``regex match`` is working in their manifests, as intended. This is especially important if the ``strict_validation`` parameter is set to ``True`` as users will be blocked from entering incorrect data. If you are using Google Sheets and do not want to use real-time validation use ``regex search`` instead of ``regex match``.
 
 Type Validation Type
 --------------------
 
 - There are two parameters
 
-  - The first parameter is type and must be one of [ `float`, `int`, `num`, `str`]
+  - The first parameter is type and must be one of [ ``float``, ``int``, ```num```, ``str``]
 
-  - The second optional parameter is the msg level and must be one of [ `error`, `warning` ], defaults to `error`.
+  - The second optional parameter is the msg level and must be one of [ ``error``, ``warning`` ], defaults to ``error``.
 
-- Examples: [ `str`, `str error`, `str warning`]
+- Examples: [ ``str``, ``str error``, ``str warning``]
 
 float
 ~~~~~
@@ -150,23 +150,23 @@ URL Validation Type
 url
 ~~~
 
-- Using the `url` rule implies the user should add a URL to a free text box as a string. This function will check that the user has provided a usable URL. It will check for any standard URL error and throw an error if one is found. Further additions to this rule can allow for checking that a specific type of URL is added. For example, if the user needs to add a <http://protocols.io> URL, <http://protocols.io> can be added after url to perform this check. If the provided url does not contain this specific string, an error will be raised.
+- Using the ``url`` rule implies the user should add a URL to a free text box as a string. This function will check that the user has provided a usable URL. It will check for any standard URL error and throw an error if one is found. Further additions to this rule can allow for checking that a specific type of URL is added. For example, if the user needs to add a <http://protocols.io> URL, <http://protocols.io> can be added after url to perform this check. If the provided url does not contain this specific string, an error will be raised.
 
 - Format:
 
-  - `url <optional strings> <raised message level>_`
+  - ``url <optional strings> <raised message level>``
 
-    - `url` must be specified first then an arbitrary number of strings can be added after (separated by spaces) to add additional levels of specificity.
+    - ``url`` must be specified first then an arbitrary number of strings can be added after (separated by spaces) to add additional levels of specificity.
 
-  - Alternatively, its valid to pass only `url`` to simply check if the input is a url.
+  - Alternatively, its valid to pass only ``url`` to simply check if the input is a url.
 
 - Examples:
 
-  - `url http://protocols.io`_ Will check that any input is a valid URL, and will also check to see that the URL contains the string `http://protocols.io` If not, an error will be raised.
+  - ``url http://protocols.io`` Will check that any input is a valid URL, and will also check to see that the URL contains the string ``http://protocols.io`` If not, an error will be raised.
 
-  - `url dx.doi http://protocols.io`_ Will check that any input is a valid URL, and will also check to see that the URL contains the strings `dx.doi` and `http://protocols.io`. If not, an error will be raised.
+  - ``url dx.doi http://protocols.io`` Will check that any input is a valid URL, and will also check to see that the URL contains the strings ``dx.doi`` and ``http://protocols.io``. If not, an error will be raised.
 
-- Default behavior: raises `error`
+- Default behavior: raises ``error``
 
 Required Validation Type
 ------------------------
@@ -176,47 +176,47 @@ required
 
 ass validation.
 
-An attribute's requirement is typically set using the required column (csv) or field (JSONLD) in the data model. A `True` value means a users must supply a value, `False` means they are allowed to skip providing a value.
+An attribute's requirement is typically set using the required column (csv) or field (JSONLD) in the data model. A ``True`` value means a users must supply a value, ``False`` means they are allowed to skip providing a value.
 
 Some users may want to use the same attribute across several manifests, but have different requirements based on the manifest/component. For example, say the data model contains an attribute called PatientID, and this attribute is used in manifests Biospecimen, Patient and Demographics. Say the modeler wants to require that PatientID be required in the Patient manifest but not Biospecimen or Demographics. In the standard Data Model format, there is only one requirement option per Attribute, so one would not be able to set requirements per component. But with the advent of component based rule settings, this can now be achieved.
 
-Requirements can be specified per component by setting the required field in the data model to `False`, and using component based rule setting along with the required "rule".
+Requirements can be specified per component by setting the required field in the data model to ``False``, and using component based rule setting along with the required "rule".
 
 Note: this new required validation rule is not a traditional validation rule, but rather impacts the JSON validation schema. This means requirements propagate automatically to manifests as well.
 
 Notes:
 
-- When using `required` in validation rules, the `Required` **column/field must be set to** `False` or this will cause the rule to not work as expected (i.e. components were the attribute is expected to not be required due to the validation rules, will still be required).
+- When using ``required`` in validation rules, the ``Required`` **column/field must be set to** ``False`` or this will cause the rule to not work as expected (i.e. components were the attribute is expected to not be required due to the validation rules, will still be required).
 
   - Note: a warning will be raised for discrepancies in requirements settings are found when running validation.
 
-- `required` can be used in conjunction with other rules, without restriction.
+- ``required`` can be used in conjunction with other rules, without restriction.
 
-- The messaging level, like all JSON validation checks, is always set at `error`, and not modifiable.
+- The messaging level, like all JSON validation checks, is always set at ``error``, and not modifiable.
 
-- `required` does not work with other rule modifiers, such as `warning`, `error` etc…
+- ``required`` does not work with other rule modifiers, such as ``warning``, ``error`` etc…
 
   - Though it will not throw an error if rule modifiers are added, it will not work as intended, and a warning will appear
 
-    - For example, if the rule `^^#Biospecimen required warning`, is added to the data model a warning will be raised letting the user know that the rule modifier cannot be applied to required.
+    - For example, if the rule ``^^#Biospecimen required warning``, is added to the data model a warning will be raised letting the user know that the rule modifier cannot be applied to required.
 
-- Adding `required` sets `Required` to `True` for the specified component. There is no way to set `Required` to `False` using the validation rules column, that would come from the `Required` field in the data model.
+- Adding ``required`` sets ``Required`` to ``True`` for the specified component. There is no way to set ``Required`` to ``False`` using the validation rules column, that would come from the ``Required`` field in the data model.
 
-- Controlling `required` through the validation rule will also impact Manifest formatting (in terms of required column highlighting).
+- Controlling ``required`` through the validation rule will also impact Manifest formatting (in terms of required column highlighting).
 
-  - To check that `required` rules are working as expected, one could generate all impacted manifests and check the formatting is as expected.
+  - To check that ``required`` rules are working as expected, one could generate all impacted manifests and check the formatting is as expected.
 
 Examples:
 
-- `#BiospecimenManifest unique required warning^^unique error`
+- ``#BiospecimenManifest unique required warning^^unique error``
 
   - For`BiospecimenManifest` manifests, the values supplied must be unique. If they aren't a warning will be raised. If values are missing, an error will be raised.
 
   - For all other manifests, the filling out values is optional. But, if the values supplied are not unique, an error will be raised.
 
-- `#Demographics required^^#BiospecimenManifest required^^`
+- ``#Demographics required^^#BiospecimenManifest required^^``
 
-  - For `Demographics` and `BiospecimenManifest` manifests, values are required to be supplied, if they are not supplied an error will be raised.
+  - For ``Demographics`` and ``BiospecimenManifest`` manifests, values are required to be supplied, if they are not supplied an error will be raised.
 
   - For all other manifests this attribute is not required.
 
@@ -225,11 +225,11 @@ Cross-manifest Validation Type
 
 Use cross-manifest validation rules when you want to check the values of an attribute in the manifest being validated against an attribute in the manifest(s) of a different component. For example, if a sample manifest has a patient id attribute and you want to check it against the id attribute of patient manifests.
 
-The format for cross-validation is: `<rule> <targetComponent>.<targetAttribute> <scope> <raised message level>`
+The format for cross-validation is: ``<rule> <targetComponent>.<targetAttribute> <scope> <raised message level>``
 
-There are three rules that do cross-manifest validation: [`matchAtLeastOne`, `matchExactlyOne`, `matchNone`]
+There are three rules that do cross-manifest validation: [``matchAtLeastOne``, ``matchExactlyOne``, ``matchNone``]
 
-There are two scopes to choose from: [ `value`, `set`]
+There are two scopes to choose from: [ ``value``, ``set``]
 
 Value Scope
 ~~~~~~~~~~~
@@ -464,17 +464,17 @@ Rules can be used to validate the contents of entries for an attribute.
 recommended
 ~~~~~~~~~~~
 
-- Use to raise a warning when a manifest column is not required but empty. If an attribute is always necessary then `required`` should be set to `TRUE` instead of using the `recommended` validation rule.
+- Use to raise a warning when a manifest column is not required but empty. If an attribute is always necessary then ``required`` should be set to ``TRUE`` instead of using the ``recommended`` validation rule.
 
 - Format:
 
-  - `recommended <raised message level>`
+  - ``recommended <raised message level>``
 
 - Examples:
 
-  - `recommended`
+  - ``recommended``
 
-- Default behavior: raises `warning`
+- Default behavior: raises ``warning``
 
 protectAges
 ~~~~~~~~~~~
@@ -483,13 +483,13 @@ protectAges
 
 - Format:
 
-  - `protectAges <raised message level>`
+  - ``protectAges <raised message level>``
 
 - Examples:
 
-  - `protectAges warning`
+  - ``protectAges warning``
 
-- Default behavior: raises `warning`
+- Default behavior: raises ``warning``
 
 unique
 ~~~~~~
@@ -498,13 +498,13 @@ unique
 
 - Format:
 
-  - `unique <raised message level>`
+  - ``unique <raised message level>``
 
 - Examples:
 
-  - `unique error`
+  - ``unique error``
 
-- Default behavior: raises `error`
+- Default behavior: raises ``error``
 
 inRange
 ~~~~~~~
@@ -513,20 +513,20 @@ inRange
 
 - Format:
 
-  - `inRange <lower range bound> <upper range bound> <raised message level>`
+  - ``inRange <lower range bound> <upper range bound> <raised message level>``
 
 - Examples:
 
-  - `inRange 50 100 error`
+  - ``inRange 50 100 error``
 
-- Default behavior: raises `error`
+- Default behavior: raises ``error``
 
 date
 ~~~~
 
 - Use to ensure the value parses as a date
 
-- Uses `dateutils` to parse the value
+- Uses ``dateutils`` to parse the value
 
   - Can parse many formats
 
@@ -534,12 +534,12 @@ date
 
   - Every value must be read as a string so no formats such as YYYYDDMM which would be read in as an int
 
-- Default behavior: raises `error`
+- Default behavior: raises ``error``
 
 Filename Validation
 -------------------
 
-This requires paths to be enabled for the synapse master file view in use. Can be enabled by navigating to an existing view and selecting `show view schema` > `edit schema` > `add default view columns` > `save`. Paths are enabled on new views by default.
+This requires paths to be enabled for the synapse master file view in use. Can be enabled by navigating to an existing view and selecting ``show view schema`` > ``edit schema`` > ``add default view columns`` > ``save``. Paths are enabled on new views by default.
 
 This should be used only with the Filename attribute in a data model and specified with `Component Based Rule Setting <https://sagebionetworks.jira.com/wiki/spaces/SCHEM/pages/edit-v2/2645262364#Component-Based-Rule-Setting>`_
 
@@ -550,48 +550,47 @@ filenameExists
 
   - Conditions in which an error is raised:
 
-    - `missing entityId`: The entityId field for a manifest row is null or an empty string
+    - ``missing entityId``: The entityId field for a manifest row is null or an empty string
 
-    - `entityId does not exist`: The entityId provided for a manifest row does not exist within the specified dataset's file view
+    - ``entityId does not exist``: The entityId provided for a manifest row does not exist within the specified dataset's file view
 
-    - `path does not exist`: The Filename in the manifest row does not exist within the specified dataset's file view
+    - ``path does not exist``: The Filename in the manifest row does not exist within the specified dataset's file view
 
-    - `mismatched entityId`: The entityId and Filename do not match the expected values from the specified dataset's file view
+    - ``mismatched entityId``: The entityId and Filename do not match the expected values from the specified dataset's file view
 
 - Format
 
-  - `filenameExists <dataset scope> <raised message level>`
+  - ``filenameExists <dataset scope> <raised message level>``
 
 - Example
 
   - This sets the rule for the MockFilename component ONLY with the specified dataset scope syn61682648
 
-  - `#MockFilename filenameExists syn61682648^^`
+  - ``#MockFilename filenameExists syn61682648^^``
 
-- Default behavior: raises `error`
+- Default behavior: raises ``error``
 
-Given this File View:
+Given this File View::
 
-```python
-id,path
-syn61682653,schematic - main/MockFilenameComponent/txt1.txt
-syn61682659,schematic - main/MockFilenameComponent/txt4.txt
-syn61682660,schematic - main/MockFilenameComponent/txt2.txt
-syn61682662,schematic - main/MockFilenameComponent/txt3.txt
-syn63141243,schematic - main/MockFilenameComponent/txt6.txt
-```
+  id,path
+  syn61682653,schematic - main/MockFilenameComponent/txt1.txt
+  syn61682659,schematic - main/MockFilenameComponent/txt4.txt
+  syn61682660,schematic - main/MockFilenameComponent/txt2.txt
+  syn61682662,schematic - main/MockFilenameComponent/txt3.txt
+  syn63141243,schematic - main/MockFilenameComponent/txt6.txt
 
-We get the following results for this Manifest:
 
-```python
-Component,Filename,entityId
-MockFilename,schematic - main/MockFilenameComponent/txt1.txt,syn61682653 # Pass
-MockFilename,schematic - main/MockFilenameComponent/txt2.txt,syn61682660 # Pass
-MockFilename,schematic - main/MockFilenameComponent/txt3.txt,syn61682653 # mismatched entityId
-MockFilename,schematic - main/MockFilenameComponent/this_file_does_not_exist.txt,syn61682653 # path does not exist
-MockFilename,schematic - main/MockFilenameComponent/txt4.txt,syn6168265 # entityId does not exist
-MockFilename,schematic - main/MockFilenameComponent/txt6.txt,  # missing entityId
-```
+We get the following results for this Manifest::
+
+
+  Component,Filename,entityId
+  MockFilename,schematic - main/MockFilenameComponent/txt1.txt,syn61682653 # Pass
+  MockFilename,schematic - main/MockFilenameComponent/txt2.txt,syn61682660 # Pass
+  MockFilename,schematic - main/MockFilenameComponent/txt3.txt,syn61682653 # mismatched entityId
+  MockFilename,schematic - main/MockFilenameComponent/this_file_does_not_exist.txt,syn61682653 # path does not exist
+  MockFilename,schematic - main/MockFilenameComponent/txt4.txt,syn6168265 # entityId does not exist
+  MockFilename,schematic - main/MockFilenameComponent/txt6.txt,  # missing entityId
+
 
 Rule Combinations
 -----------------
@@ -600,17 +599,17 @@ Schematic allows certain combinations of existing validation rules to be used on
 
 Note:  isNa and required can be combined with all rules and rule combos.
 
-Rule combinations: [`list::regex`, `int::inRange`, `float::inRange`, `num::inRange`, `protectAges::inRange`]
+Rule combinations: [``list::regex``, ``int::inRange``, ``float::inRange``, ``num::inRange``, ``protectAges::inRange``]
 
 - Format:
 
-  - `<rule 1> <applicable rule 1 arguments>::<rule 2> <applicable rule 2 arguments>`
+  - ``<rule 1> <applicable rule 1 arguments>::<rule 2> <applicable rule 2 arguments>``
 
-  - `::` delimiter used to separate each rule
+  - ``::`` delimiter used to separate each rule
 
 - Example:
 
-  - `list :: regex search [HTAN][0-9]{1}_[0-9]{4}_[0-9]*`
+  - ``list :: regex search [HTAN][0-9]{1}_[0-9]{4}_[0-9]*``
 
 Component-Based Rule Setting
 ----------------------------
@@ -651,56 +650,56 @@ Note: As always try the rule combos with mock data to ensure they are working as
 
   - Apply rule to all manifests *except* the specified set.
 
-    - `validation_rule^^#ComponentA`
+    - ``validation_rule^^#ComponentA``
 
-    - `validation_rule^^#ComponentA^^#ComponentB`
+    - ``validation_rule^^#ComponentA^^#ComponentB``
 
   - Apply a unique rule to each manifest.
 
-    - `#ComponentA validation_rule_1^^#ComponentB validation_rule_2^^#ComponentC validation_rule_3`
+    - ``#ComponentA validation_rule_1^^#ComponentB validation_rule_2^^#ComponentC validation_rule_3``
 
   - For the specified manifest, apply the given validation rule, but for all others, run a different rule
 
-    - `#ComponentA validation_rule_1^^validation_rule_2`
+    - ``#ComponentA validation_rule_1^^validation_rule_2``
 
-    - `validation_rule_2^^#ComponentA validation_rule_1`
+    - ``validation_rule_2^^#ComponentA validation_rule_1``
 
   - Apply the validation rule to only one manifest
 
-    - `#ComponentA validation_rule_1^^`
+    - ``#ComponentA validation_rule_1^^``
 
 - Example Rules:
 
-  - Test by adding these rules to the `Patient ID` attribute in the `example.model.csv` model, then run validation with new rules against the example manifests.
+  - Test by adding these rules to the ``Patient ID`` attribute in the ``example.model.csv`` model, then run validation with new rules against the example manifests.
 
   - `Example Biospecimen Manifest <https://docs.google.com/spreadsheets/d/19_axG2Zj7URk4CT5qYjH0HfpMIOQ1dYEPvyaazSVNZE/edit#gid=0>`_
 
   - `Example Patient Manifest <https://docs.google.com/spreadsheets/d/1IO0TkzwBX-lsu3rJDjWfgWYR6VlepingN9zuhkrgVUE/edit#gid=0>`_
 
-    - **Rule**: `#Patient int::inRange 100 900 error^^#Biospecimen int::inRange 100 900 warning`
+    - **Rule**: ``#Patient int::inRange 100 900 error^^#Biospecimen int::inRange 100 900 warning``
 
-      - For the `Patient` manifest, apply the combo `rule int::inRange 100 900` at the `error` level.
+      - For the ``Patient`` manifest, apply the combo ``rule int::inRange 100 900`` at the ``error`` level.
 
         - The value provided must be an integer in the range of 100-900; if it does not fall in the range, throw an error
 
-      - For the `Biospecimen` manifest, apply the combo rule `int::inRange 100 900` at the `warning` level
+      - For the ``Biospecimen`` manifest, apply the combo rule ``int::inRange 100 900`` at the ``warning`` level
 
         - The value provided must be an integer in the range of 100-900; if it does not fall in the range, throw a warning
 
-    - **Rule**: `#Patient int::inRange 100 900 error^^int::inRange 100 900 warning`
+    - **Rule**: ``#Patient int::inRange 100 900 error^^int::inRange 100 900 warning``
 
-      - For the `Patient` manifest, apply rule `int::inRange 100 900` at an `error` level
+      - For the ``Patient`` manifest, apply rule ``int::inRange 100 900`` at an ``error`` level
 
-      - For all other manifests, apply the `rule int::inRange 100 900` at a warning level
+      - For all other manifests, apply the ``rule int::inRange 100 900`` at a warning level
 
-    - **Rule**: `#Patient^^int::inRange 100 900 warning`
+    - **Rule**: ``#Patient^^int::inRange 100 900 warning``
 
-      - For all manifests except `Patient` apply the rule `int::inRange 100 900` at the `warning` level
+      - For all manifests except ``Patient`` apply the rule ``int::inRange 100 900`` at the ``warning`` level
 
-    - **Rule**: `int::inRange 100 900 error^^#Biospecimen`
+    - **Rule**: ``int::inRange 100 900 error^^#Biospecimen``
 
-      - Apply the rule `int::inRange 100 900 error`, to all manifests except `Biospecimen`
+      - Apply the rule ``int::inRange 100 900 error``, to all manifests except ``Biospecimen``
 
-    - **Rule**: `#Patient unique error^^`
+    - **Rule**: ``#Patient unique error^^``
 
-      - To the `PatientManifest` only, apply the `unique` validation rule at the `error` level
+      - To the ``PatientManifest`` only, apply the ``unique`` validation rule at the ``error`` level

--- a/docs/source/validation_rules.rst
+++ b/docs/source/validation_rules.rst
@@ -109,7 +109,7 @@ regex
 
 - Default behavior: raises ``error``
 
-.. note::
+.. code-block:: shell
 
   `regex101.com <https://regex101.com/>`_ is a tool that can be used to build and validate the behavior of your regular expression
 
@@ -189,13 +189,17 @@ Some users may want to use the same attribute across several manifests, but have
 
 Requirements can be specified per component by setting the required field in the data model to ``False``, and using component based rule setting along with the required "rule".
 
-Note: this new required validation rule is not a traditional validation rule, but rather impacts the JSON validation schema. This means requirements propagate automatically to manifests as well.
+.. code-block:: shell
+
+   This new required validation rule is not a traditional validation rule, but rather impacts the JSON validation schema. This means requirements propagate automatically to manifests as well.
 
 Notes:
 
 - When using the ``required`` validation rule, the ``Required`` column must ``False`` in the CSV, or the ``Required`` must be set to ``False`` in the JsonLD or this will cause the rule to not work as expected (i.e. components were the attribute is expected to not be required due to the validation rules, will still be required).
 
-  - Note: While using the CLI, a warning will be raised for discrepancies in requirements settings are found when running validation.
+.. code-block:: shell
+
+  While using the CLI, a warning will be raised for discrepancies in requirements settings are found when running validation.
 
 - ``required`` can be used in conjunction with other rules, without restriction.
 
@@ -604,7 +608,9 @@ Rule Combinations
 
 Schematic allows certain combinations of existing validation rules to be used on a single attribute, where appropriate.
 
-Note:  isNa and required can be combined with all rules and rule combos.
+.. code-block:: shell
+
+  isNa and required can be combined with all rules and rule combos.
 
 Rule combinations: [``list::regex``, ``int::inRange``, ``float::inRange``, ``num::inRange``, ``protectAges::inRange``]
 
@@ -639,9 +645,11 @@ This feature offers flexibility and applicability beyond its original use case. 
 
 By leveraging the enhanced Component-Based Rule Setting feature, data modelers can efficiently enforce rules across their data models with greater precision and flexibility, ensuring data integrity while accommodating diverse use cases and requirements.
 
-Note: All restrictions to rule combos and implementation also apply to component based rules.
+.. code-block:: shell
 
-Note: As always try the rule combos with mock data to ensure they are working as intended before using in production.
+  All restrictions to rule combos and implementation also apply to component based rules.
+
+  As always try the rule combos with mock data to ensure they are working as intended before using in production.
 
 - Format:
 

--- a/docs/source/validation_rules.rst
+++ b/docs/source/validation_rules.rst
@@ -9,6 +9,8 @@ When Schematic validates a manifest, it uses a data model. The data model contai
 
 Rules that change the validation behavior which must be taken from the following pre-specified list, formatted in the indicated ways, and added to the data model to apply. An `example data model <https://github.com/Sage-Bionetworks/schematic/blob/develop/tests/data/example.model.csv>`_ using each rule is available for reference.
 
+The column the rule refers to must be in the manifest for validation to happen.
+
 Rules can optionally be configured to raise  errors  and prevent manifest submission in the case of invalid entries, or warnings and allow submission when invalid entries are found within the attribute the rule is set for. Validators will be notified of the invalid values in both cases. Default message levels for each rule can be found below under each rule.
 
 Attributes that are not required will raise warnings when invalid entries are identified. For attributes that are not required, if a user does not submit a response, a warning or error will no longer be logged. If you desire raising an error for non-entries, set Required to True in the data model.
@@ -28,22 +30,23 @@ Rule Implementation
 ================ ======== ======================= ======================
 Rule             In-House Great Expectations (GX) JSON Schema Validation
 ================ ======== ======================= ======================
-list             yes
-regex module     yes
-float            yes      yes
-int              yes      yes
-num              yes      yes
-string           yes      yes
-url              yes
-matchAtLeastOne  yes
-matchExactlyOne  yes
-matchNone        yes
-recommended               yes
-protectAges               yes
-unique                    yes
-inRange                   yes
-date                      yes
-required                                          yes
+list             +
+regex module     +
+float            +        +
+int              +        +
+num              +        +
+string           +        +
+url              +
+matchAtLeastOne  +
+matchExactlyOne  +
+matchNone        +
+recommended               +
+protectAges               +
+unique                    +
+inRange                   +
+date                      +
+required                                              +
+valid values                                          +
 ================ ======== ======================= ======================
 
 Rule Types and Details
@@ -65,11 +68,11 @@ list
 
       - Validates that entries are comma separated lists, and parses into list
 
-      - Requires all attribute entries to be comma-delimited, even lists with only one element
+      - Requires all attribute entries to be comma-delimited, even lists with only one element (lists with a trailing comma)
 
     - ``list like``
 
-      - Assume entries are either lists or ``list like`` but do not verify that entries are comma separated lists, and attempt to parse into a list
+      - Assume entries are either lists or like a list but do not verify that entries are comma separated lists, and attempt to parse into a list
 
       - Single values, or lists of length one, can be entered without a comma delimiter
 
@@ -478,7 +481,7 @@ recommended
 protectAges
 ~~~~~~~~~~~
 
-- Use to ensure that patient ages under 18 and over 89 years of age are censored when uploading for sharing. If necessary, a censored version of the manifest will be created and uploaded along with the uncensored version. Uncensored versions will be uploaded as restricted and Terms of Use will need to be set.
+- Use to ensure that patient ages under 18 and over 89 years of age are censored when uploading for sharing. If necessary, a censored version of the manifest will be created and uploaded along with the uncensored version. Uncensored versions will be uploaded as restricted and Terms of Use will need to be set. Please follow up with governance after upload to set the terms of use
 
 - Format:
 
@@ -594,7 +597,7 @@ We get the following results for this Manifest::
 Rule Combinations
 -----------------
 
-Schematic allows certain combinations of existing validation rules to be used on a single attribute, where appropriate. Combinations currently allowed are enumerated in the table below, under 'Rule Combinations in Production'.
+Schematic allows certain combinations of existing validation rules to be used on a single attribute, where appropriate.
 
 Note:  isNa and required can be combined with all rules and rule combos.
 

--- a/docs/source/validation_rules.rst
+++ b/docs/source/validation_rules.rst
@@ -5,6 +5,9 @@ Validation Rules
 
 .. toctree::
    :maxdepth: 2
+   :glob:
+
+   *
 
 Overview
 ========

--- a/docs/source/validation_rules.rst
+++ b/docs/source/validation_rules.rst
@@ -2,6 +2,10 @@
 Validation Rules
 ================
 
+
+.. toctree::
+   :maxdepth: 2
+
 Overview
 ========
 

--- a/docs/source/validation_rules.rst
+++ b/docs/source/validation_rules.rst
@@ -105,13 +105,13 @@ regex
 
 - Notes/tips/warnings
 
-  - `regex101.com <https://regex101.com/>_` is a tool that can be used to build and validate the behavior of your regular expression
+  - `regex101.com <https://regex101.com/>`_ is a tool that can be used to build and validate the behavior of your regular expression
 
   - If the module specified is match for a given attribute's validation rule, regex match validation will be preformed in Google Sheets (but not Excel) real-time during metadata entry.
 
   - The ``strict_validation parameter`` (in the config.yml file for CLI or in manifest generation REST API calls) sets whether to stop the user from entering incorrect information in a Google Sheets cell (``strict_validation = true``) or simply throws a warning (``strict_validation = false``). Default: ``true``.
 
-  - ``regex`` validation in Google Sheets is different than standard regex validation (for example, it does not support validation of digits). See `this documentation <https://github.com/google/re2/wiki/Syntax>_` for details on Google regex syntax. It is up to the user/modeler to validate that ``regex match`` is working in their manifests, as intended. This is especially important if the ``strict_validation`` parameter is set to ``True`` as users will be blocked from entering incorrect data. If you are using Google Sheets and do not want to use real-time validation use ``regex search`` instead of ``regex match``.
+  - ``regex`` validation in Google Sheets is different than standard regex validation (for example, it does not support validation of digits). See `this documentation <https://github.com/google/re2/wiki/Syntax>`_ for details on Google regex syntax. It is up to the user/modeler to validate that ``regex match`` is working in their manifests, as intended. This is especially important if the ``strict_validation`` parameter is set to ``True`` as users will be blocked from entering incorrect data. If you are using Google Sheets and do not want to use real-time validation use ``regex search`` instead of ``regex match``.
 
 Type Validation Type
 --------------------
@@ -150,7 +150,7 @@ URL Validation Type
 url
 ~~~
 
-- Using the ``url`` rule implies the user should add a URL to a free text box as a string. This function will check that the user has provided a usable URL. It will check for any standard URL error and throw an error if one is found. Further additions to this rule can allow for checking that a specific type of URL is added. For example, if the user needs to add a <http://protocols.io> URL, <http://protocols.io> can be added after url to perform this check. If the provided url does not contain this specific string, an error will be raised.
+- Using the ``url`` rule implies the user should add a URL to a free text box as a string. This function will check that the user has provided a usable URL. It will check for any standard URL error and throw an error if one is found. Further additions to this rule can allow for checking that a specific type of URL is added. For example, if the user needs to add a ``http://protocols.io`` URL, ``http://protocols.io`` can be added after url to perform this check. If the provided url does not contain this specific string, an error will be raised.
 
 - Format:
 
@@ -174,7 +174,6 @@ Required Validation Type
 required
 ~~~~~~~~
 
-ass validation.
 
 An attribute's requirement is typically set using the required column (csv) or field (JSONLD) in the data model. A ``True`` value means a users must supply a value, ``False`` means they are allowed to skip providing a value.
 
@@ -638,13 +637,13 @@ Note: As always try the rule combos with mock data to ensure they are working as
 
 - Format:
 
-  - `^^`Double carrots indicate that Component-Based rules are being set
+  - ``^^`` Double carrots indicate that Component-Based rules are being set
 
-    - Use `^^` to separate component rule sets
+    - Use ```^^``` to separate component rule sets
 
-  - `#` In the first position (prior to the rule) to define the component/manifest to apply the rule to
+  - ``#`` In the first position (prior to the rule) to define the component/manifest to apply the rule to
 
-    - `#` character cannot be used without the `^^` to indicate component rule sets
+    - ``#`` character cannot be used without the ``^^`` to indicate component rule sets
 
 - Use case:
 

--- a/docs/source/validation_rules.rst
+++ b/docs/source/validation_rules.rst
@@ -109,7 +109,7 @@ regex
 
 - Default behavior: raises ``error``
 
-.. code-block:: shell
+Notes::
 
   `regex101.com <https://regex101.com/>`_ is a tool that can be used to build and validate the behavior of your regular expression
 

--- a/docs/source/validation_rules.rst
+++ b/docs/source/validation_rules.rst
@@ -1,10 +1,13 @@
-# Validation Rules
+================
+Validation Rules
+================
 
-## Overview
+Overview
+========
 
 When Schematic validates a manifest, it uses a data model. The data model contains a list of validation rules for each component(data-type). This document describes all allowed validation rules currently implemented by Schematic.
 
-Rules that change the validation behavior which must be taken from the following pre-specified list, formatted in the indicated ways, and added to the data model to apply. An [example data model](https://github.com/Sage-Bionetworks/schematic/blob/develop/tests/data/example.model.csv) using each rule is available for reference.
+Rules that change the validation behavior which must be taken from the following pre-specified list, formatted in the indicated ways, and added to the data model to apply. An `example data model <https://github.com/Sage-Bionetworks/schematic/blob/develop/tests/data/example.model.csv>`_ using each rule is available for reference.
 
 Rules can optionally be configured to raise  errors  and prevent manifest submission in the case of invalid entries, or warnings and allow submission when invalid entries are found within the attribute the rule is set for. Validators will be notified of the invalid values in both cases. Default message levels for each rule can be found below under each rule.
 
@@ -12,56 +15,63 @@ Attributes that are not required will raise warnings when invalid entries are id
 
 Metadata validation is an explicit step in the submission pipeline and must be run either before or during manifest submission.
 
-## Validation Types
+Validation Types
+================
 
 Validation rules are just one type of validation run by Schematic to ensure that submitted manifests conform to the expectations set by the data model.
 
-This page details how to use Validation Rules, but please refer to [this documentation](https://sagebionetworks.jira.com/wiki/spaces/SCHEM/pages/3302785036) to learn about the other types of validation.
+This page details how to use Validation Rules, but please refer to `this documentation <https://sagebionetworks.jira.com/wiki/spaces/SCHEM/pages/3302785036>`_ to learn about the other types of validation.
 
-## Rule Implementation
+Rule Implementation
+===================
 
-| Rule | In-House | Great Expectations (GX) | JSON Schema Validation |
-| ---- | -------- | ----------------------- | ---------------------- |
-| list | yes | | |
-| regex module | yes | | |
-| float | yes | yes |  |
-| int | yes | yes | |
-| num | yes | yes | |
-| string | yes | yes | |
-| url | yes | | |
-| matchAtLeastOne | yes | | |
-| matchExactlyOne | yes | | |
-| matchNone | yes | | |
-| recommended | | yes | |
-| protectAges | | yes | |
-| unique | | yes | |
-| inRange | | yes | |
-| date | | yes | |
-| required | | | yes |
+================ ======== ======================= ======================
+Rule             In-House Great Expectations (GX) JSON Schema Validation
+================ ======== ======================= ======================
+list             yes
+regex module     yes
+float            yes      yes
+int              yes      yes
+num              yes      yes
+string           yes      yes
+url              yes
+matchAtLeastOne  yes
+matchExactlyOne  yes
+matchNone        yes
+recommended               yes
+protectAges               yes
+unique                    yes
+inRange                   yes
+date                      yes
+required                                          yes
+================ ======== ======================= ======================
 
-## Rule Types and Details
+Rule Types and Details
+======================
 
-### List Validation Type
+List Validation Type
+--------------------
 
-#### list
+list
+~~~~
 
 - Use to parse the imported value to a list of values and (optionally) to verify that the user provided value was a comma separated list, depending on how strictly entries must conform to the list structure. Values can come from Valid Values.
 
 - Format:
 
-  - `list <conformity level> <raised message level>`
+  - `list <conformity level> <raised message level>_`
 
     - `list strict`
 
       - Validates that entries are comma separated lists, and parses into list
 
-      - Requires all attribute entries to be comma-delimited, even ‘lists’ with only one element
+      - Requires all attribute entries to be comma-delimited, even lists with only one element
 
     - `list like`
 
       - Assume entries are either lists or `list like` but do not verify that entries are comma separated lists, and attempt to parse into a list
 
-      - Single values, or ‘lists’ of length one, can be entered without a comma delimiter
+      - Single values, or lists of length one, can be entered without a comma delimiter
 
 - Can use `list` rule in conjunction with `regex` rule to validate that the items in a list follow a specific pattern.
 
@@ -69,15 +79,17 @@ This page details how to use Validation Rules, but please refer to [this documen
 
 - Default behavior: raises `error`
 
-### Regex Validation Type
+Regex Validation Type
+---------------------
 
-#### regex
+regex
+~~~~~
 
 - Use the `regex` validation rule when you want to require that a user input values in a specific format, i.e. an ID that follows a particular format.
 
 - Format:
 
-  - `regex <module> <regular_expression> <raised message level>`
+  - `regex <module> <regular_expression> <raised message level>_`
 
   - Module: is the Python `re` module that you want to use. A common one would be search. Refer to Python `re` source material to find the most appropriate module to use.
 
@@ -93,15 +105,16 @@ This page details how to use Validation Rules, but please refer to [this documen
 
 - Notes/tips/warnings
 
-  - [regex101.com](https://regex101.com/) is a tool that can be used to build and validate the behavior of your regular expression
+  - `regex101.com <https://regex101.com/>_` is a tool that can be used to build and validate the behavior of your regular expression
 
-  - If the module specified is match for a given attribute’s validation rule, regex match validation will be preformed in Google Sheets (but not Excel) real-time during metadata entry.
+  - If the module specified is match for a given attribute's validation rule, regex match validation will be preformed in Google Sheets (but not Excel) real-time during metadata entry.
 
   - The `strict_validation parameter` (in the config.yml file for CLI or in manifest generation REST API calls) sets whether to stop the user from entering incorrect information in a Google Sheets cell (`strict_validation = true`) or simply throws a warning (`strict_validation = false`). Default: `true`.
 
-  - `regex` validation in Google Sheets is different than standard regex validation (for example, it does not support validation of digits). See [this documentation](https://github.com/google/re2/wiki/Syntax) for details on Google regex syntax. It is up to the user/modeler to validate that `regex match` is working in their manifests, as intended. This is especially important if the `strict_validation` parameter is set to `True` as users will be blocked from entering incorrect data. If you are using Google Sheets and do not want to use real-time validation use `regex search` instead of `regex match`.
+  - `regex` validation in Google Sheets is different than standard regex validation (for example, it does not support validation of digits). See `this documentation <https://github.com/google/re2/wiki/Syntax>_` for details on Google regex syntax. It is up to the user/modeler to validate that `regex match` is working in their manifests, as intended. This is especially important if the `strict_validation` parameter is set to `True` as users will be blocked from entering incorrect data. If you are using Google Sheets and do not want to use real-time validation use `regex search` instead of `regex match`.
 
-### Type Validation Type
+Type Validation Type
+--------------------
 
 - There are two parameters
 
@@ -111,47 +124,55 @@ This page details how to use Validation Rules, but please refer to [this documen
 
 - Examples: [ `str`, `str error`, `str warning`]
 
-#### float
+float
+~~~~~
 
 - Checks that the value is a float.
 
-#### int
+int
+~~~
 
 - Checks that the value is an integer.
 
-#### num
+num
+~~~
 
 - Checks that the value is either an integer or float.
 
-#### str
+str
+~~~
 
 - Checks that the value is a string (not a number).
 
-### URL Validation Type
+URL Validation Type
+-------------------
 
-#### url
+url
+~~~
 
 - Using the `url` rule implies the user should add a URL to a free text box as a string. This function will check that the user has provided a usable URL. It will check for any standard URL error and throw an error if one is found. Further additions to this rule can allow for checking that a specific type of URL is added. For example, if the user needs to add a <http://protocols.io> URL, <http://protocols.io> can be added after url to perform this check. If the provided url does not contain this specific string, an error will be raised.
 
 - Format:
 
-  - `url <optional strings> <raised message level>`
+  - `url <optional strings> <raised message level>_`
 
     - `url` must be specified first then an arbitrary number of strings can be added after (separated by spaces) to add additional levels of specificity.
 
-  - Alternatively, its valid to pass only ‘url’ to simply check if the input is a url.
+  - Alternatively, its valid to pass only `url`` to simply check if the input is a url.
 
 - Examples:
 
-  - `url http://protocols.io` Will check that any input is a valid URL, and will also check to see that the URL contains the string `http://protocols.io` If not, an error will be raised.
+  - `url http://protocols.io`_ Will check that any input is a valid URL, and will also check to see that the URL contains the string `http://protocols.io` If not, an error will be raised.
 
-  - `url dx.doi http://protocols.io` Will check that any input is a valid URL, and will also check to see that the URL contains the strings `dx.doi` and `http://protocols.io`. If not, an error will be raised.
+  - `url dx.doi http://protocols.io`_ Will check that any input is a valid URL, and will also check to see that the URL contains the strings `dx.doi` and `http://protocols.io`. If not, an error will be raised.
 
 - Default behavior: raises `error`
 
-### Required Validation Type
+Required Validation Type
+------------------------
 
-#### required
+required
+~~~~~~~~
 
 ass validation.
 
@@ -189,7 +210,7 @@ Examples:
 
 - `#BiospecimenManifest unique required warning^^unique error`
 
-  - For`BiospecimenManifest` manifests, the values supplied must be unique. If they aren’t a warning will be raised. If values are missing, an error will be raised.
+  - For`BiospecimenManifest` manifests, the values supplied must be unique. If they aren't a warning will be raised. If values are missing, an error will be raised.
 
   - For all other manifests, the filling out values is optional. But, if the values supplied are not unique, an error will be raised.
 
@@ -199,7 +220,8 @@ Examples:
 
   - For all other manifests this attribute is not required.
 
-### Cross-manifest Validation Type
+Cross-manifest Validation Type
+------------------------------
 
 Use cross-manifest validation rules when you want to check the values of an attribute in the manifest being validated against an attribute in the manifest(s) of a different component. For example, if a sample manifest has a patient id attribute and you want to check it against the id attribute of patient manifests.
 
@@ -209,25 +231,28 @@ There are three rules that do cross-manifest validation: [`matchAtLeastOne`, `ma
 
 There are two scopes to choose from: [ `value`, `set`]
 
-#### Value Scope
+Value Scope
+~~~~~~~~~~~
 
 When the value scope is used all values from the target attribute in all target manifests are combined. The values from the manifest being validated are compared to this combined list. In other words, there is no distinction between what values came from what target manifest.
 
-##### matchAtleastOne Value Scope
+matchAtleastOne Value Scope
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The manifest is validated if each value in the target attribute exists at least once in the combined values of the target attribute of the target manifests.
 
-##### matchExactlyOne Value Scope
+matchExactlyOne Value Scope
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The manifest is validated if each value in the target attribute exists once, and only once, in the combined values of the target attribute of the target manifests.
 
-##### matchNone Value Scope
+matchNone Value Scope
+^^^^^^^^^^^^^^^^^^^^^
 
 The manifest is validated if each value in the target attribute does not exist in the combined values of the target attribute of the target manifests.
 
-##### Examples Value Scope
-
-###### #1 Value Scope
+Example 1
+^^^^^^^^^
 
 Tested manifest: ["A"]
 
@@ -241,7 +266,8 @@ Target manifests: ["A", "B"]
 
   - because "A" is in the target manifest
 
-###### #2 Value Scope
+Example 2
+^^^^^^^^^
 
 Tested manifest: ["A", "C"]
 
@@ -259,7 +285,8 @@ Target manifests: ["A", "B"]
 
   - because "A" is in the target manifest
 
-###### #3 Value Scope
+Example 3
+^^^^^^^^^
 
 Tested manifest: ["C"]
 
@@ -275,7 +302,8 @@ Target manifests: ["A", "B"]
 
 - matchNone: passes
 
-###### #4 Value Scope
+Example 4
+^^^^^^^^^
 
 Tested manifest: ["A", "A"]
 
@@ -289,7 +317,8 @@ Target manifests: ["A", "B"]
 
   - because "A" is in the target manifest
 
-###### #5 Value Scope
+Example 5
+^^^^^^^^^
 
 Tested manifest: ["A"]
 
@@ -305,7 +334,8 @@ Target manifests: ["A", "A"]
 
   - because "A" is in the target manifest
 
-###### #6 Value Scope
+Example 6
+^^^^^^^^^
 
 Tested manifest: ["A"]
 
@@ -321,7 +351,8 @@ matchNone: fails
 
 because "A" is in the target manifest
 
-###### #7 Value Scope
+Example 7
+^^^^^^^^^
 
 Tested manifest: ["A"]
 
@@ -337,7 +368,8 @@ Target manifests: ["A", "B"],  ["A", "B"]
 
   - because "A" is in the target manifest
 
-#### Set scope
+Set scope
+~~~~~~~~~
 
 When the set scope is used the values from the tested manifest are compared **one at a time** against each target manifest, and the number of matches are counted. The test to determine if the tested manifest matches the target manifest is to see if the tested manifest values are a subset of the target manifest values. Imagine a target manifest who's values are ["A", "B" "C"]:
 
@@ -345,21 +377,23 @@ When the set scope is used the values from the tested manifest are compared **on
 
 - [1], ["D"], ["D", "D"], ["D", "E"] are not subsets of the example target manifest.
 
-##### matchAtleastOne Set scope
+matchAtleastOne Set scope
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The manifest is validated if there is atleast one set match between the tested manifest and the target manifests
 
-##### matchExactlyOne Set scope
+matchExactlyOne Set scope
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The manifest is validated if there is one and only one set match between the tested manifest and the target manifests
 
-##### matchNone Set scope
+matchNone Set scope
+^^^^^^^^^^^^^^^^^^^
 
 The manifest is validated if there are no set match between the tested manifest and the target manifests
 
-##### Examples Set scope
-
-###### #1 Set scope
+Example 1
+^^^^^^^^^
 
 Tested manifest: ["A"]
 
@@ -373,7 +407,8 @@ matchNone: fails
 
 because "A" is in the target manifest
 
-###### #2 Set scope
+Example 2
+^^^^^^^^^
 
 Tested manifest: ["A"]
 
@@ -387,7 +422,8 @@ Target manifests: ["A", "B"], ["C", "D"]
 
   - because "A" is in atleast one of the target manifest
 
-###### #3 Set scope
+Example 3
+^^^^^^^^^
 
 Tested manifest: ["A"]
 
@@ -403,7 +439,8 @@ Target manifests: ["A", "B"], ["A", "B"]
 
   - because "A" is in atleast one of the target manifests
 
-###### #4 Set scope
+Example 4
+^^^^^^^^^
 
 Tested manifest: ["C"]
 
@@ -419,13 +456,15 @@ Target manifests: ["A", "B"]
 
 - matchNone: passes
 
-### Content Validation Type
+Content Validation Type
+-----------------------
 
 Rules can be used to validate the contents of entries for an attribute.
 
-#### recommended
+recommended
+~~~~~~~~~~~
 
-- Use to raise a warning when a manifest column is not required but empty. If an attribute is always necessary then ‘required' should be set to `TRUE` instead of using the `recommended` validation rule.
+- Use to raise a warning when a manifest column is not required but empty. If an attribute is always necessary then `required`` should be set to `TRUE` instead of using the `recommended` validation rule.
 
 - Format:
 
@@ -437,7 +476,8 @@ Rules can be used to validate the contents of entries for an attribute.
 
 - Default behavior: raises `warning`
 
-#### protectAges
+protectAges
+~~~~~~~~~~~
 
 - Use to ensure that patient ages under 18 and over 89 years of age are censored when uploading for sharing. If necessary, a censored version of the manifest will be created and uploaded along with the uncensored version. Uncensored versions will be uploaded as restricted and Terms of Use will need to be set.
 
@@ -451,7 +491,8 @@ Rules can be used to validate the contents of entries for an attribute.
 
 - Default behavior: raises `warning`
 
-#### unique
+unique
+~~~~~~
 
 - Use to ensure that attribute values are not duplicated within a column.
 
@@ -465,7 +506,8 @@ Rules can be used to validate the contents of entries for an attribute.
 
 - Default behavior: raises `error`
 
-#### inRange
+inRange
+~~~~~~~
 
 - Use to ensure that numerical data is within a specified range
 
@@ -479,7 +521,8 @@ Rules can be used to validate the contents of entries for an attribute.
 
 - Default behavior: raises `error`
 
-#### date
+date
+~~~~
 
 - Use to ensure the value parses as a date
 
@@ -493,13 +536,15 @@ Rules can be used to validate the contents of entries for an attribute.
 
 - Default behavior: raises `error`
 
-### Filename Validation
+Filename Validation
+-------------------
 
 This requires paths to be enabled for the synapse master file view in use. Can be enabled by navigating to an existing view and selecting `show view schema` > `edit schema` > `add default view columns` > `save`. Paths are enabled on new views by default.
 
-This should be used only with the Filename attribute in a data model and specified with [Component Based Rule Setting](https://sagebionetworks.jira.com/wiki/spaces/SCHEM/pages/edit-v2/2645262364#Component-Based-Rule-Setting)
+This should be used only with the Filename attribute in a data model and specified with `Component Based Rule Setting <https://sagebionetworks.jira.com/wiki/spaces/SCHEM/pages/edit-v2/2645262364#Component-Based-Rule-Setting>`_
 
-#### filenameExists
+filenameExists
+~~~~~~~~~~~~~~
 
 - Used to validate that the filenames and paths as they exist in the metadata manifest match the paths that are in the Synapse master File View for the specified dataset
 
@@ -507,11 +552,11 @@ This should be used only with the Filename attribute in a data model and specifi
 
     - `missing entityId`: The entityId field for a manifest row is null or an empty string
 
-    - `entityId does not exist`: The entityId provided for a manifest row does not exist within the specified dataset’s file view
+    - `entityId does not exist`: The entityId provided for a manifest row does not exist within the specified dataset's file view
 
-    - `path does not exist`: The Filename in the manifest row does not exist within the specified dataset’s file view
+    - `path does not exist`: The Filename in the manifest row does not exist within the specified dataset's file view
 
-    - `mismatched entityId`: The entityId and Filename do not match the expected values from the specified dataset’s file view
+    - `mismatched entityId`: The entityId and Filename do not match the expected values from the specified dataset's file view
 
 - Format
 
@@ -548,7 +593,8 @@ MockFilename,schematic - main/MockFilenameComponent/txt4.txt,syn6168265 # entity
 MockFilename,schematic - main/MockFilenameComponent/txt6.txt,  # missing entityId
 ```
 
-### Rule Combinations
+Rule Combinations
+-----------------
 
 Schematic allows certain combinations of existing validation rules to be used on a single attribute, where appropriate. Combinations currently allowed are enumerated in the table below, under 'Rule Combinations in Production'.
 
@@ -560,13 +606,14 @@ Rule combinations: [`list::regex`, `int::inRange`, `float::inRange`, `num::inRan
 
   - `<rule 1> <applicable rule 1 arguments>::<rule 2> <applicable rule 2 arguments>`
 
-  - ‘::’ delimiter used to separate each rule
+  - `::` delimiter used to separate each rule
 
 - Example:
 
   - `list :: regex search [HTAN][0-9]{1}_[0-9]{4}_[0-9]*`
 
-### Component-Based Rule Setting
+Component-Based Rule Setting
+----------------------------
 
 **Component-Based Rule Setting** is a powerful feature in data modeling that enables users to create rules tailored to specific subsets of components or manifests. This functionality was developed to address scenarios where a data modeler needs to enforce uniqueness for certain attribute values within one manifest while allowing non-uniqueness in another.
 
@@ -626,9 +673,9 @@ Note: As always try the rule combos with mock data to ensure they are working as
 
   - Test by adding these rules to the `Patient ID` attribute in the `example.model.csv` model, then run validation with new rules against the example manifests.
 
-  - [Example Biospecimen Manifest](https://docs.google.com/spreadsheets/d/19_axG2Zj7URk4CT5qYjH0HfpMIOQ1dYEPvyaazSVNZE/edit#gid=0)
+  - `Example Biospecimen Manifest <https://docs.google.com/spreadsheets/d/19_axG2Zj7URk4CT5qYjH0HfpMIOQ1dYEPvyaazSVNZE/edit#gid=0>`_
 
-  - [Example Patient Manifest](https://docs.google.com/spreadsheets/d/1IO0TkzwBX-lsu3rJDjWfgWYR6VlepingN9zuhkrgVUE/edit#gid=0)
+  - `Example Patient Manifest <https://docs.google.com/spreadsheets/d/1IO0TkzwBX-lsu3rJDjWfgWYR6VlepingN9zuhkrgVUE/edit#gid=0>`_
 
     - **Rule**: `#Patient int::inRange 100 900 error^^#Biospecimen int::inRange 100 900 warning`
 


### PR DESCRIPTION
[SCHEMATIC-264]

# **Problem:**
There wasn't a doc file listing and describing the Schematic validation rules

# **Solution:**
Copied the doc from Schema hub, and fixed some of the verbage/spelling

# **Testing:**
None


[SCHEMATIC-264]: https://sagebionetworks.jira.com/browse/SCHEMATIC-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

https://schematicpy.readthedocs.io/en/schematic-264/