### PR TITLE
[Schematic 272] Standardize Id and entityId before manifest submission

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -2117,7 +2117,7 @@ class SynapseStorage(BaseStorage):
         for col in manifest.columns:
             if col.lower() == "id":
                 manifest = manifest.rename(columns={col: "Id"})
-            elif col.lower() == "entityid":
+            if col.lower() == "entityid":
                 manifest = manifest.rename(columns={col: "entityId"})
 
         # If 'Id' still doesn't exist, see if uuid column exists

--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -2106,12 +2106,24 @@ class SynapseStorage(BaseStorage):
 
     def _add_id_columns_to_manifest(
         self, manifest: pd.DataFrame, dmge: DataModelGraphExplorer
-    ):
-        """Helper function to add id and entityId columns to the manifest if they do not already exist, Fill id values per row.
+    ) -> pd.DataFrame:
+        """
+        Ensures that the manifest DataFrame has standardized 'Id' and 'entityId' columns.
+
+        If any case variation of the 'id' column is present (e.g., 'id', 'ID', 'iD'), it is renamed to 'Id'.
+        If any case variation of the 'entityid' column is present, it is renamed to 'entityId'.
+        If 'Id' is still missing, it will be created as an empty column or derived from a 'Uuid' column,
+        depending on whether 'Uuid' is defined in the schema.
+        Missing values in the 'Id' column are filled with generated UUIDs.
+        If 'entityId' is still missing, it will be created and filled with empty strings.
+        If it is already present, any missing values will be replaced with empty strings.
+
         Args:
-        Returns (pd.DataFrame):
-            Manifest df with new Id and EntityId columns (and UUID values) if they were not already present.
-            If any case variation of "id" column is present, rename it to "Id".
+            manifest (pd.DataFrame): The metadata manifest to be updated.
+            dmge (DataModelGraphExplorer): data moodel graph explorer object
+
+        Returns:
+            pd.DataFrame: The updated manifest with a standardized 'Id' column and an 'entityId' column.
         """
         # Normalize any variation of 'id' to 'Id', "entityid" to "entityId"
         for col in manifest.columns:
@@ -2147,7 +2159,7 @@ class SynapseStorage(BaseStorage):
 
         # Add entityId as a column if not already there or
         # Fill any blanks with an empty string.
-        if not col_in_dataframe("entityId", manifest):
+        if "entityId" not in manifest:
             manifest["entityId"] = ""
         else:
             manifest["entityId"] = manifest["entityId"].fillna("")

--- a/tests/unit/test_store_synapse.py
+++ b/tests/unit/test_store_synapse.py
@@ -94,6 +94,11 @@ class TestStoreSynapse:
                 pd.DataFrame({"Id": ["test_value"], "EntityId": ["test_value"]}),
                 pd.DataFrame({"Id": ["test_value"], "entityId": ["test_value"]}),
             ),
+            # Case 5: 'EntityId' and "ID" in wrong mixed case — should be renamed to "Id" and 'entityId'
+            (
+                pd.DataFrame({"iD": ["test_value"], "EntityID": ["test_value"]}),
+                pd.DataFrame({"Id": ["test_value"], "entityId": ["test_value"]}),
+            ),
         ],
     )
     @pytest.mark.parametrize(

--- a/tests/unit/test_store_synapse.py
+++ b/tests/unit/test_store_synapse.py
@@ -94,9 +94,9 @@ class TestStoreSynapse:
                 pd.DataFrame({"Id": ["test_value"], "EntityId": ["test_value"]}),
                 pd.DataFrame({"Id": ["test_value"], "entityId": ["test_value"]}),
             ),
-            # Case 5: 'EntityId' and "ID" in wrong mixed case — should be renamed to "Id" and 'entityId'
+            # Case 5: 'EntityId' and "ID" are both in wrong mixed case — should be renamed to "Id" and 'entityId'
             (
-                pd.DataFrame({"iD": ["test_value"], "EntityID": ["test_value"]}),
+                pd.DataFrame({"iD": ["test_value"], "entityID": ["test_value"]}),
                 pd.DataFrame({"Id": ["test_value"], "entityId": ["test_value"]}),
             ),
         ],

--- a/tests/unit/test_store_synapse.py
+++ b/tests/unit/test_store_synapse.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 from schematic.store.synapse import SynapseStorage
+from schematic.schemas.data_model_graph import DataModelGraphExplorer
 
 
 class TestStoreSynapse:
@@ -14,6 +15,8 @@ class TestStoreSynapse:
         ("syn2", "test_file_1.txt"),
         ("syn3", "test_file_2.txt"),
     ]
+
+    DATA_MODEL_DICT = {"example.model.csv": "CSV", "example.model.jsonld": "JSONLD"}
 
     def test_get_file_entityIds_only_new_files_manifest_is_none(self) -> None:
         with pytest.raises(UnboundLocalError, match="No manifest was passed in"):
@@ -57,3 +60,50 @@ class TestStoreSynapse:
             "Filename": ["test_file_1.txt", "test_file_2.txt"],
             "entityId": ["syn2", "syn3"],
         }
+
+    @pytest.mark.parametrize(
+        "manifest_dataframe, expected",
+        [
+            # Case 1a: 'id' in lowercase — should be normalized to 'Id'
+            (
+                pd.DataFrame({"id": ["test_value"]}),
+                pd.DataFrame({"Id": ["test_value"], "entityId": [""]}),
+            ),
+            # Case 1b: 'ID' in uppercase — should be normalized to 'Id'
+            (
+                pd.DataFrame({"ID": ["test_value"]}),
+                pd.DataFrame({"Id": ["test_value"], "entityId": [""]}),
+            ),
+            # Case 1c: 'iD' mixed case — should be normalized to 'Id'
+            (
+                pd.DataFrame({"iD": ["test_value"]}),
+                pd.DataFrame({"Id": ["test_value"], "entityId": [""]}),
+            ),
+            # Case 2: 'Uuid' present — should be renamed to 'Id'
+            (
+                pd.DataFrame({"Uuid": ["test_value"]}),
+                pd.DataFrame({"Id": ["test_value"], "entityId": [""]}),
+            ),
+            # Case 3: 'entityID' in wrong mixed case — should be renamed to 'entityId'
+            (
+                pd.DataFrame({"Id": ["test_value"], "entityId": ["test_value"]}),
+                pd.DataFrame({"Id": ["test_value"], "entityId": ["test_value"]}),
+            ),
+            # Case 4: 'EntityId' in wrong mixed case — should be renamed to 'entityId'
+            (
+                pd.DataFrame({"Id": ["test_value"], "EntityId": ["test_value"]}),
+                pd.DataFrame({"Id": ["test_value"], "entityId": ["test_value"]}),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "data_model", list(DATA_MODEL_DICT.keys()), ids=list(DATA_MODEL_DICT.values())
+    )
+    def test_add_id_columns_to_manifest(
+        self, data_model, manifest_dataframe, expected, helpers
+    ) -> None:
+        dmge = helpers.get_data_model_graph_explorer(path=data_model)
+        pd.testing.assert_frame_equal(
+            self.synapse_store._add_id_columns_to_manifest(manifest_dataframe, dmge),
+            expected,
+        )


### PR DESCRIPTION
# **Problem:**
## Short description of the problem 
When submitting the manifest, if the "id" or "entityId" column is present with a non-standard casing (e.g., "ID", "iD", "entityid"), Schematic accepts the column as-is without normalizing the name. This later led to an issue when updating the table in future manifest submission. 

## More context
The error was: 
```
  File "/app/app/./schematic/store/synapse.py", line 3380, in updateTable
    self.tableToLoad = update_df(existing_table, self.tableToLoad, update_col)
  File "/app/app/./schematic/utils/df_utils.py", line 259, in update_df
    assert index_col in input_df, f"`input_df` lacks `{index_col}` column."
AssertionError: `input_df` lacks `Id` column.
```

The error occurred when the user tried to submit a manifest (with "id" column in lower case) to synapse using the NF data model: https://raw.githubusercontent.com/nf-osi/nf-metadata-dictionary/main/NF.jsonld

Upon further checking, for some reason, the submitted manifest retained the lowercase column name “id” instead of being updated to the capitalized “Id”.  (see version 7 [here](https://www.synapse.org/Synapse:syn65597609.7)) As a result, the table created from the submission also used “id”. In a later step, when updating the table, Schematic assumed the column name to be “Id” (see code reference [here](https://github.com/Sage-Bionetworks/schematic/blob/develop/schematic/store/synapse.py#L3362)), which prevented it from recognizing and updating the existing “id” column in the table.


# **Solution:**

## Attempts to reproduce the issue
* I attempted to replicate the issue using my own test project.
* Upon generating a manifest through Schematic, I confirmed that all expected columns. Column “id” (any case variation) did not appear. 
* I then submitted this generated manifest back to Synapse using option `table_and_file`.
* As expected, annotations were applied to files, and the "Id" column was correctly added to the annotations and to the submitted manifest file. 
* When I generated a manifest again after submission, as expected, I could see “eTag” and “Id” column. But if the manifest submitted before have column “id” (lower case), the manifest that gets generated again would have column “id”. 

## Uncertainty 
Given that everything worked as expected in my test environment, it's unclear why "id" (lowercase) appeared in the originally submitted manifest that triggered the error in the first place.  I am not sure if any of the following occurred: 

* Manual alteration?
   * Did the user manually change "Id" to "id" in the manifest before submission?
* Pre-existing manual annotations?
    * Were any annotations manually added to the dataset files before the first manifest was generated?
    * If "Id" was manually added as an annotation key before the manifest was created, and use_annotations was enabled during manifest generation, Schematic would attempt to map the existing annotation keys to the data model’s display names—resulting in the column "id" appearing in the generated manifest due to "id" being included in the NF data model. 

## Solution 
Since the source of the "id" column is unclear, I decided to normalize all variations of "id" to "Id" when adding "id" column during submission. Given that the "entityId" column could present similar casing issues, I applied the same normalization to it as well.

# **Testing:**
* added unit test to ensure column normalization is correct. 
