### PR TITLE
[schematic-279] Avoid comparing trail white space when comparing jsonld in test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1066,4 +1066,4 @@ class TestCsvUtils:
         expected_jsonld = open(expected_jsonld_path).read()
         actual_jsonld = open(actual_jsonld_path).read()
 
-        assert expected_jsonld == actual_jsonld
+        assert json.loads(expected_jsonld) == json.loads(actual_jsonld)


### PR DESCRIPTION
# **Problem:**
Related to: https://sagebionetworks.jira.com/browse/SCHEMATIC-279
The following test was failing consistently when running locally: 
```
___________________________________________________________ TestCsvUtils.test_csv_to_schemaorg ___________________________________________________________

self = <tests.test_utils.TestCsvUtils object at 0x12e46d6c0>, helpers = <class 'tests.conftest.Helpers'>
tmp_path = PosixPath('/private/var/folders/vb/_xxgqfbd6j7_cm8vh69ps3tm0000gp/T/pytest-of-lpeng/pytest-19/test_csv_to_schemaorg0')

    def test_csv_to_schemaorg(self, helpers, tmp_path):
        """Test the CSV-to-JSON-LD conversion.
    
        This test also ensures that the CSV and JSON-LD
        files for the example data model stay in sync.
        TODO: This probably should be moved out of here and to test_schemas
        """
        csv_path = helpers.get_data_path("example.model.csv")
    
        # Instantiate DataModelParser
        data_model_parser = DataModelParser(path_to_data_model=csv_path)
    
        # Parse Model
        parsed_data_model = data_model_parser.parse_model()
    
        # Instantiate DataModelGraph
        data_model_grapher = DataModelGraph(parsed_data_model)
    
        # Generate graph
        graph_data_model = data_model_grapher.graph
    
        # Convert graph to JSONLD
        jsonld_data_model = convert_graph_to_jsonld(graph=graph_data_model)
    
        # saving updated schema.org schema
        actual_jsonld_path = "/Users/lpeng/Documents/schematic-git2/schematic/tests/data/example.from_csv.model.jsonld"
        export_schema(jsonld_data_model, actual_jsonld_path)
    
        # Compare both JSON-LD files
        expected_jsonld_path = helpers.get_data_path("example.model.jsonld")
        expected_jsonld = open(expected_jsonld_path).read()
        actual_jsonld = open(actual_jsonld_path).read()
    
>       assert expected_jsonld == actual_jsonld
E       assert '{\n    "@con...io/#0.1"\n}\n' == '{\n    "@con...s.io/#0.1"\n}'
E         
E         Skipping 52540 identical leading characters in diff, use -v to show
E           .io/#0.1"
E         - }
E         + }

tests/test_utils.py:1069: AssertionError
================================================================ short test summary info =================================================================

```
When I actually compared the example.model.jsonld and the one that we exported, I noticed that the difference was because the trailing white space in the end of file: 

```
(schematicpy-py3.10) lpeng@MacBookPro schematic % diff /Users/lpeng/Documents/schematic-git2/schematic/tests/data/example.from_csv.model_9adaab62-7da6-465a-9686-d9d993df6acf.jsonld /Users/lpeng/Documents/schematic-git2/schematic/tests/data/example.from_csv.model.jsonld
1772c1772
< }
---
> }
\ No newline at end of file
``` 
The JSON-LD file generated by the export_schema function does not include a trailing newline, whereas the example.model.jsonld file in the data folder does end with a newline.

This mismatch causes the test to consistently fail locally due to a difference in file content. However, this does not fully explain why the test sometimes passes on GitHub Actions, which suggests that there might be other platform-specific behavior that impact how the newline is being handled (?) 

# **Solution:**
One solution is to manually add a new line in export_schema function, so something like this: 
```
    with open(file_path, "w", encoding="utf-8") as json_file:
        json.dump(schema, json_file, sort_keys=True, indent=4, ensure_ascii=False)
        json_file.write("\n")
```
While this works, it feels a bit like a workaround. Since our intention is to compare the content of the JSON-LD files, it would be cleaner and more reliable to update the test to use json.loads() for comparison. This approach would avoid failures caused by trivial differences like trailing newlines or indentation.


# **Testing:**
The test is now passing locally. 
