### PR TITLE
Add property descriptions to generated jsonschemas

### DIFF
--- a/schematic/schemas/json_schema_component_generator.py
+++ b/schematic/schemas/json_schema_component_generator.py
@@ -284,6 +284,14 @@ class JsonSchemaComponentGenerator:
 
         description_dict |= self.incomplete_component_json_schema
         self.component_json_schema = description_dict
+
+        for attribute, value in self.component_json_schema["properties"].items():
+            if isinstance(value, dict) and "description" not in value:
+                # TODO: Update to give either class label or display name
+                value["description"] = self.dmge.get_node_comment(
+                    node_display_name=attribute
+                )
+
         click.echo(f"Validation JSONschema generated for {self.component}.")
 
     def write_json_schema_to_file(

--- a/tests/data/expected_jsonschemas/expected.Biospecimen.schema.json
+++ b/tests/data/expected_jsonschemas/expected.Biospecimen.schema.json
@@ -4,24 +4,28 @@
   "description": "TBD",
   "properties": {
     "Component": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Patient ID": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Sample ID": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Tissue Status": {
+      "description": "TBD",
       "enum": [
         "Malignant",
         "None",

--- a/tests/data/expected_jsonschemas/expected.BulkRNA-seqAssay.schema.json
+++ b/tests/data/expected_jsonschemas/expected.BulkRNA-seqAssay.schema.json
@@ -120,12 +120,14 @@
   "description": "TBD",
   "properties": {
     "Component": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "File Format": {
+      "description": "TBD",
       "enum": [
         "CSV/TSV",
         "FASTQ",
@@ -134,12 +136,14 @@
       ]
     },
     "Filename": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Genome Build": {
+      "description": "TBD",
       "enum": [
         "GRCm38",
         "GRCh37",
@@ -148,8 +152,11 @@
         ""
       ]
     },
-    "Genome FASTA": {},
+    "Genome FASTA": {
+      "description": "TBD"
+    },
     "Sample ID": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"

--- a/tests/data/expected_jsonschemas/expected.MockComponent.schema.json
+++ b/tests/data/expected_jsonschemas/expected.MockComponent.schema.json
@@ -4,36 +4,42 @@
   "description": "Component to hold mock attributes for testing all validation rules",
   "properties": {
     "Check Ages": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Date": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Float": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Int": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check List": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check List Enum": {
+      "description": "TBD",
       "items": {
         "enum": [
           "ab",
@@ -46,6 +52,7 @@
       "type": "array"
     },
     "Check List Enum Strict": {
+      "description": "TBD",
       "items": {
         "enum": [
           "ab",
@@ -58,12 +65,14 @@
       "type": "array"
     },
     "Check List Like": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check List Like Enum": {
+      "description": "TBD",
       "items": {
         "enum": [
           "ab",
@@ -76,121 +85,143 @@
       "type": "array"
     },
     "Check List Strict": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Match Exactly": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Match Exactly values": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Match None": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Match None values": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Match at Least": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Match at Least values": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check NA": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Num": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Range": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
-    "Check Recommended": {},
+    "Check Recommended": {
+      "description": "TBD"
+    },
     "Check Regex Format": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Regex Integer": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Regex List": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Regex List Like": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Regex List Strict": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Regex Single": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check String": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check URL": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Check Unique": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Component": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"

--- a/tests/data/expected_jsonschemas/expected.MockFilename.schema.json
+++ b/tests/data/expected_jsonschemas/expected.MockFilename.schema.json
@@ -4,12 +4,14 @@
   "description": "TBD",
   "properties": {
     "Component": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Filename": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"

--- a/tests/data/expected_jsonschemas/expected.MockRDB.schema.json
+++ b/tests/data/expected_jsonschemas/expected.MockRDB.schema.json
@@ -4,18 +4,21 @@
   "description": "TBD",
   "properties": {
     "Component": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "MockRDB_id": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "SourceManifest": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"

--- a/tests/data/expected_jsonschemas/expected.Patient.schema.json
+++ b/tests/data/expected_jsonschemas/expected.Patient.schema.json
@@ -70,6 +70,7 @@
   "description": "TBD",
   "properties": {
     "Cancer Type": {
+      "description": "TBD",
       "enum": [
         "Prostate",
         "Colorectal",
@@ -80,18 +81,21 @@
       ]
     },
     "Component": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Diagnosis": {
+      "description": "TBD",
       "enum": [
         "Cancer",
         "Healthy"
       ]
     },
     "Family History": {
+      "description": "TBD",
       "items": {
         "enum": [
           "Prostate",
@@ -106,19 +110,23 @@
       "type": "array"
     },
     "Patient ID": {
+      "description": "TBD",
       "minLength": 1,
       "not": {
         "type": "null"
       }
     },
     "Sex": {
+      "description": "TBD",
       "enum": [
         "Male",
         "Female",
         "Other"
       ]
     },
-    "Year of Birth": {}
+    "Year of Birth": {
+      "description": "TBD"
+    }
   },
   "required": [
     "Sex",


### PR DESCRIPTION
# **Problem:**
Property/attribute descriptions were missing from generated jsonschema files

# **Solution:**
Functionality has been added to include those descriptions as well
the link to a data model for a test was also fixed to a permanent link

# **Testing:**
existing tests cover this case
