### PR TITLE
Delete HTAN data model in documentation 

### DIFF
--- a/docs/source/linkml.rst
+++ b/docs/source/linkml.rst
@@ -13,6 +13,4 @@ LinkML `documentation <https://linkml.io/linkml/>`_
 
 DPE performed a `comparison <https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/3856367618/SCHEMATIC-225+Exploration+of+LinkML+features+compared+to+Schematic+JSONLD>`_ between Schematics current functionality and what LinkML could provide via the CLI. This is currently restricted to Sage Bionetworks staff.
 
-The `HTAN2 model <https://github.com/ncihtan/htan-linkml/blob/get-gen-excel-working/HTAN2Model.yaml>`_ in LinkML
-
 The `NF Repo <https://github.com/nf-osi/nf-metadata-dictionary/>`_ that creates the LinkML model.


### PR DESCRIPTION
# **Problem:**
The HTAN data model is still in progress. We shouldn't share that with external users per feedbacks in sprint review. 

# **Solution:**
Remove the link in the documentation 