### PR TITLE
[SCHEMATIC-306] add get_colum_type method to DMGE class

### DIFF
--- a/schematic/models/metadata.py
+++ b/schematic/models/metadata.py
@@ -178,7 +178,7 @@ class MetadataModel(object):
         # get required components for the input/source component
         req_components = self.dmge.get_component_requirements(source_component)
 
-        # retreive components as graph
+        # retrieve components as graph
         if as_graph:
             req_components_graph = self.dmge.get_component_requirements_graph(
                 source_component

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -972,8 +972,8 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         Returns:
             The node label
         """
-        if not node_label:
-            if not node_display_name:
+        if node_label is None:
+            if node_display_name is None:
                 raise ValueError("must provide either node_label or node_display_name")
             node_label = self.get_node_label(node_display_name)
         return node_label

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -965,16 +965,30 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
             node_label: The label of the node to get the type from
             node_display_name: The display name of the node to get the type from
 
+        Returns:
+            The column type of the node if it has one, otherwise None
+        """
+        node_label = self._get_node_label(node_label, node_display_name)
+        rel_node_label = self.dmr.get_relationship_value("columnType", "node_label")
+        return self.graph.nodes[node_label][rel_node_label]
+
+    def _get_node_label(
+        self, node_label: Optional[str] = None, node_display_name: Optional[str] = None
+    ) -> str:
+        """Returns the node label depending on the type of input
+
+        Args:
+            node_label: The label of the node to get the type from
+            node_display_name: The display name of the node to get the type from
+
         Raises:
             ValueError: If neither node_label or node_display_name is provided
 
         Returns:
-            The column type of the node if it hs one, otherwise None
+            The node label
         """
         if not node_label:
             if not node_display_name:
                 raise ValueError("must provide either node_label or node_display_name")
             node_label = self.get_node_label(node_display_name)
-
-        rel_node_label = self.rel_dict["columnType"]["node_label"]
-        return self.graph.nodes[node_label][rel_node_label]
+        return node_label

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -975,7 +975,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
     def _get_node_label(
         self, node_label: Optional[str] = None, node_display_name: Optional[str] = None
     ) -> str:
-        """Returns the node label depending on the type of input
+        """Returns the node label if given otherwise gets the node label from the display name
 
         Args:
             node_label: The label of the node to get the type from

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -204,9 +204,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         Returns:
             valid_values, list: List of valid values associated with the provided node.
         """
-        if not node_label:
-            assert node_display_name is not None
-            node_label = self.get_node_label(node_display_name)
+        node_label = self._get_node_label(node_label, node_display_name)
 
         valid_values = []
         for node_1, node_2, rel in self.graph.edges:
@@ -589,9 +587,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         Returns:
             Comment associated with node, as a string.
         """
-        if not node_label:
-            assert node_display_name is not None
-            node_label = self.get_node_label(node_display_name)
+        node_label = self._get_node_label(node_label, node_display_name)
 
         if not node_label:
             return ""
@@ -728,10 +724,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
               If display_names=True, a list of valid values (display names) associated
                 with a given node
         """
-        if not node_label:
-            assert node_display_name is not None
-            node_label = self.get_node_label(node_display_name)
-
+        node_label = self._get_node_label(node_label, node_display_name)
         try:
             # get node range in the order defined in schema for given node
             required_range = self.find_node_range(node_label=node_label)
@@ -766,10 +759,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
             True: If the given node is a "required" node.
             False: If the given node is not a "required" (i.e., an "optional") node.
         """
-        if not node_label:
-            assert node_display_name is not None
-            node_label = self.get_node_label(node_display_name)
-
+        node_label = self._get_node_label(node_label, node_display_name)
         rel_node_label = self.rel_dict["required"]["node_label"]
         node_required = self.graph.nodes[node_label][rel_node_label]
         return node_required
@@ -785,14 +775,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         Returns:
             A set of validation rules associated with node, as a list or a dictionary.
         """
-        if not node_label:
-            if node_display_name is None:
-                raise ValueError(
-                    "Either node_label or node_display_name must be provided."
-                )
-
-            # try search node label using display name
-            node_label = self.get_node_label(node_display_name)
+        node_label = self._get_node_label(node_label, node_display_name)
 
         if not node_label:
             return []
@@ -838,10 +821,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         Returns:
             List of nodes that are adjacent to the given node, by SubclassOf relationship.
         """
-        if not node_label:
-            assert node_display_name is not None
-            node_label = self.get_node_label(node_display_name)
-
+        node_label = self._get_node_label(node_label, node_display_name)
         return self.get_adjacent_nodes_by_relationship(
             node_label=node_label, relationship=self.rel_dict["subClassOf"]["edge_key"]
         )

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -207,9 +207,8 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
 
         valid_values = []
         for node_1, node_2, rel in self.graph.edges:
-            if (
-                node_1 == node_label
-                and rel == self.dmr.get_relationship_value("rangeIncludes", "edge_key")
+            if node_1 == node_label and rel == self.dmr.get_relationship_value(
+                "rangeIncludes", "edge_key"
             ):
                 valid_values.append(node_2)
         valid_values = list(set(valid_values))
@@ -626,7 +625,9 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         else:
             required_dependencies = self.get_adjacent_nodes_by_relationship(
                 node_label=source_node,
-                relationship=self.dmr.get_relationship_value("requiresDependency", "edge_key"),
+                relationship=self.dmr.get_relationship_value(
+                    "requiresDependency", "edge_key"
+                ),
             )
 
         if display_names:
@@ -635,7 +636,9 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
 
             for req in required_dependencies:
                 dependencies_display_names.append(
-                    self.graph.nodes[req][self.dmr.get_relationship_value("displayName", "node_label")]
+                    self.graph.nodes[req][
+                        self.dmr.get_relationship_value("displayName", "node_label")
+                    ]
                 )
 
             return dependencies_display_names
@@ -666,7 +669,9 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
             List of display names.
         """
         node_list_display_names = [
-            self.graph.nodes[node][self.dmr.get_relationship_value("displayName", "node_label")]
+            self.graph.nodes[node][
+                self.dmr.get_relationship_value("displayName", "node_label")
+            ]
             for node in node_list
         ]
 
@@ -822,7 +827,8 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         """
         node_label = self._get_node_label(node_label, node_display_name)
         return self.get_adjacent_nodes_by_relationship(
-            node_label=node_label, relationship=self.dmr.get_relationship_value("subClassOf", "edge_key")
+            node_label=node_label,
+            relationship=self.dmr.get_relationship_value("subClassOf", "edge_key"),
         )
 
     def find_child_classes(self, schema_class: str) -> list:

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -972,8 +972,8 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         Returns:
             The node label
         """
-        if node_label is None:
-            if node_display_name is None:
-                raise ValueError("must provide either node_label or node_display_name")
-            node_label = self.get_node_label(node_display_name)
-        return node_label
+        if node_label is not None:
+            return node_label
+        if node_display_name is not None:
+            return self.get_node_label(node_display_name)
+        raise ValueError("Either 'node_label' or 'node_display_name' must be provided.")

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -244,10 +244,10 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         node_display_name: Optional[str] = None,
     ) -> bool:
         """Check if a node is required taking into account the manifest component it is defined in
-        (requirements can be set in validaiton rule as well as required column)
+        (requirements can be set in validation rule as well as required column)
         Args:
             manifest_component: str, manifest component display name that the node belongs to.
-            node_validation_rules: list[str], valdation rules for a given node and component.
+            node_validation_rules: list[str], validation rules for a given node and component.
             node_label: str, Label of the node you would want to get the comment for.
             node_display_name: str, node display name for the node being queried.
         Returns:
@@ -263,7 +263,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
                 node_display_name=node_display_name,
             )
 
-        # Check if the valdation rule specifies that the node is required for this particular
+        # Check if the validation rule specifies that the node is required for this particular
         # component.
         if rule_in_rule_list("required", node_validation_rules):
             node_required = True
@@ -290,7 +290,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
 
                 logger.error(error_str)
         else:
-            # If requirements are not being set in the validaiton rule, then just pull the
+            # If requirements are not being set in the validation rule, then just pull the
             # standard node requirements from the model
             node_required = self.get_node_required(
                 node_label=node_label, node_display_name=node_display_name
@@ -303,7 +303,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         node_label: Optional[str] = None,
         node_display_name: Optional[str] = None,
     ) -> list:
-        """Get valdation rules for a given node and component.
+        """Get validation rules for a given node and component.
         Args:
             manifest_component: str, manifest component display name that the node belongs to.
             node_label: str, Label of the node you would want to get the comment for.
@@ -396,7 +396,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
           type of edge / relationship type.
 
         Args:
-            source_node: The node whose descendants need to be retreived.
+            source_node: The node whose descendants need to be retrieved.
             relationship: Edge / link relationship type with possible values same as in above docs.
             connected:
               If True, we need to ensure that all descendant nodes are reachable from the source
@@ -406,7 +406,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
             ordered:
               If True, the list of descendants will be topologically ordered.
               If False, the list has no particular order (depends on the order in which the
-                descendats were traversed in the subgraph).
+                descendants were traversed in the subgraph).
 
         Returns:
             List of nodes that are descendants from a particular node (sorted / unsorted)
@@ -481,7 +481,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         node: str,
         relationship: str,
     ) -> list[tuple[str, str]]:
-        """Get a list of out-edges of a node where the edges match a specifc type of relationship.
+        """Get a list of out-edges of a node where the edges match a specific type of relationship.
 
         i.e., the edges connecting a node to its neighbors are of relationship type -- "parentOf"
           (set of edges to children / sub-class nodes).
@@ -531,7 +531,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
 
         # Handle out edges
         if self.rel_dict[key]["jsonld_direction"] == "out":
-            # use outedges
+            # use out edges
 
             original_edge_weights_dict = {
                 attached_node: self.graph[source_node][attached_node][edge_key][
@@ -544,7 +544,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
             }
         # Handle in edges
         else:
-            # use inedges
+            # use in edges
             original_edge_weights_dict = {
                 attached_node: self.graph[attached_node][source_node][edge_key][
                     "weight"
@@ -844,7 +844,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         Returns:
             properties, list: List of properties associate with a given schema class.
         Raises:
-            KeyError: Key error is raised if the provded schema_class is not in the graph
+            KeyError: Key error is raised if the provided schema_class is not in the graph
         """
 
         if not self.is_class_in_schema(schema_class):
@@ -909,7 +909,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         """Create a sub-schema graph
         Args:
             source, str: source node label to start graph
-            direction, str: direction to create the vizualization, choose from "up", "down", "both"
+            direction, str: direction to create the visualization, choose from "up", "down", "both"
             size, float: max height and width of the graph, if one value provided it is used for
               both.
         Returns:

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -9,7 +9,10 @@ from opentelemetry import trace
 
 from schematic.schemas.data_model_edges import DataModelEdges
 from schematic.schemas.data_model_nodes import DataModelNodes
-from schematic.schemas.data_model_relationships import DataModelRelationships
+from schematic.schemas.data_model_relationships import (
+    DataModelRelationships,
+    JSONSchemaType,
+)
 from schematic.utils.general import unlist
 from schematic.utils.schema_utils import (
     DisplayLabelType,
@@ -952,3 +955,26 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
                     edges.append((_path[i], _path[i + 1]))
             return visualize(edges, size=size)
         return None
+
+    def get_node_column_type(
+        self, node_label: Optional[str] = None, node_display_name: Optional[str] = None
+    ) -> Optional[JSONSchemaType]:
+        """Gets the column type of the node
+
+        Args:
+            node_label: The label of the node to get the type from
+            node_display_name: The display name of the node to get the type from
+
+        Raises:
+            ValueError: If neither node_label or node_display_name is provided
+
+        Returns:
+            The column type of the node if it hs one, otherwise None
+        """
+        if not node_label:
+            if not node_display_name:
+                raise ValueError("must provide either node_label or node_display_name")
+            node_label = self.get_node_label(node_display_name)
+
+        rel_node_label = self.rel_dict["columnType"]["node_label"]
+        return self.graph.nodes[node_label][rel_node_label]

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -162,7 +162,6 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         """
         self.graph = graph  # At this point the graph is expected to be fully formed.
         self.dmr = DataModelRelationships()
-        self.rel_dict = self.dmr.relationships_dictionary
 
     def find_properties(self) -> set[str]:
         """
@@ -175,7 +174,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         """
         properties_list: list[str] = []
         for node_1, _, rel in self.graph.edges:
-            if rel == self.rel_dict["domainIncludes"]["edge_key"]:
+            if rel == self.dmr.get_relationship_value("domainIncludes", "edge_key"):
                 properties_list.append(node_1)
         properties_set = set(properties_list)
         return properties_set
@@ -210,7 +209,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         for node_1, node_2, rel in self.graph.edges:
             if (
                 node_1 == node_label
-                and rel == self.rel_dict["rangeIncludes"]["edge_key"]
+                and rel == self.dmr.get_relationship_value("rangeIncludes", "edge_key")
             ):
                 valid_values.append(node_2)
         valid_values = list(set(valid_values))
@@ -274,7 +273,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
                 if not node_display_name:
                     assert node_label is not None
                     node_display_name = self.graph.nodes[node_label][
-                        self.rel_dict["displayName"]["node_label"]
+                        self.dmr.get_relationship_value("displayName", "node_label")
                     ]
                 error_str = " ".join(
                     [
@@ -349,7 +348,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
             reversed(
                 self.get_descendants_by_edge_type(
                     source_component,
-                    self.rel_dict["requiresComponent"]["edge_key"],
+                    self.dmr.get_relationship_value("requiresComponent", "edge_key"),
                     ordered=True,
                 )
             )
@@ -379,7 +378,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
 
         # get the subgraph induced on required component nodes
         req_components_graph = self.get_subgraph_by_edge_type(
-            self.rel_dict["requiresComponent"]["edge_key"],
+            self.dmr.get_relationship_value("requiresComponent", "edge_key"),
         ).subgraph(req_components)
 
         return req_components_graph
@@ -527,10 +526,10 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
                 f"Cannot find node: {source_node_label} in the graph, please check entry."
             )
 
-        edge_key = self.rel_dict[key]["edge_key"]
+        edge_key = self.dmr.get_relationship_value(key, "edge_key")
 
         # Handle out edges
-        if self.rel_dict[key]["jsonld_direction"] == "out":
+        if self.dmr.get_relationship_value(key, "jsonld_direction") == "out":
             # use out edges
 
             original_edge_weights_dict = {
@@ -593,7 +592,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
             return ""
 
         node_definition = self.graph.nodes[node_label][
-            self.rel_dict["comment"]["node_label"]
+            self.dmr.get_relationship_value("comment", "node_label")
         ]
         return node_definition
 
@@ -621,13 +620,13 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         if schema_ordered:
             # get dependencies in the same order in which they are defined in the schema
             required_dependencies = self.get_ordered_entry(
-                key=self.rel_dict["requiresDependency"]["edge_key"],
+                key=self.dmr.get_relationship_value("requiresDependency", "edge_key"),
                 source_node_label=source_node,
             )
         else:
             required_dependencies = self.get_adjacent_nodes_by_relationship(
                 node_label=source_node,
-                relationship=self.rel_dict["requiresDependency"]["edge_key"],
+                relationship=self.dmr.get_relationship_value("requiresDependency", "edge_key"),
             )
 
         if display_names:
@@ -636,7 +635,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
 
             for req in required_dependencies:
                 dependencies_display_names.append(
-                    self.graph.nodes[req][self.rel_dict["displayName"]["node_label"]]
+                    self.graph.nodes[req][self.dmr.get_relationship_value("displayName", "node_label")]
                 )
 
             return dependencies_display_names
@@ -667,7 +666,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
             List of display names.
         """
         node_list_display_names = [
-            self.graph.nodes[node][self.rel_dict["displayName"]["node_label"]]
+            self.graph.nodes[node][self.dmr.get_relationship_value("displayName", "node_label")]
             for node in node_list
         ]
 
@@ -760,7 +759,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
             False: If the given node is not a "required" (i.e., an "optional") node.
         """
         node_label = self._get_node_label(node_label, node_display_name)
-        rel_node_label = self.rel_dict["required"]["node_label"]
+        rel_node_label = self.dmr.get_relationship_value("required", "node_label")
         node_required = self.graph.nodes[node_label][rel_node_label]
         return node_required
 
@@ -823,7 +822,7 @@ class DataModelGraphExplorer:  # pylint: disable=too-many-public-methods
         """
         node_label = self._get_node_label(node_label, node_display_name)
         return self.get_adjacent_nodes_by_relationship(
-            node_label=node_label, relationship=self.rel_dict["subClassOf"]["edge_key"]
+            node_label=node_label, relationship=self.dmr.get_relationship_value("subClassOf", "edge_key")
         )
 
     def find_child_classes(self, schema_class: str) -> list:

--- a/schematic/schemas/data_model_graph.py
+++ b/schematic/schemas/data_model_graph.py
@@ -101,7 +101,7 @@ class DataModelGraph:  # pylint: disable=too-few-public-methods
             G: nx.MultiDiGraph, networkx graph representation of the data model
         """
         # Get all relationships with edges
-        edge_relationships = self.dmr.retreive_rel_headers_dict(edge=True)
+        edge_relationships = self.dmr.retrieve_rel_headers_dict(edge=True)
 
         # Find all nodes
         all_nodes = self.dmn.gather_all_nodes_in_model(

--- a/schematic/schemas/data_model_nodes.py
+++ b/schematic/schemas/data_model_nodes.py
@@ -26,10 +26,10 @@ class DataModelNodes:
         }
         self.data_model_relationships = DataModelRelationships()
         self.value_relationships = (
-            self.data_model_relationships.retreive_rel_headers_dict(edge=False)
+            self.data_model_relationships.retrieve_rel_headers_dict(edge=False)
         )
         self.edge_relationships_dictionary = (
-            self.data_model_relationships.retreive_rel_headers_dict(edge=True)
+            self.data_model_relationships.retrieve_rel_headers_dict(edge=True)
         )
         self.properties = self.get_data_model_properties(
             attr_rel_dict=attribute_relationships_dict

--- a/schematic/schemas/data_model_parser.py
+++ b/schematic/schemas/data_model_parser.py
@@ -235,7 +235,9 @@ class DataModelCSVParser:
                     )
             if model_includes_column_type:
                 column_type_dict = self.parse_column_type(attr)
-                attr_rel_dictionary[attribute_name].update(column_type_dict)
+                attr_rel_dictionary[attribute_name]["Relationships"].update(
+                    column_type_dict
+                )
         return attr_rel_dictionary
 
     def parse_column_type(self, attr: dict) -> dict:
@@ -264,7 +266,7 @@ class DataModelCSVParser:
             relationship="columnType",
         )
 
-        return {"columnType": column_type}
+        return {"ColumnType": column_type}
 
     @tracer.start_as_current_span("Schemas::DataModelCSVParser::parse_csv_model")
     def parse_csv_model(

--- a/schematic/schemas/data_model_parser.py
+++ b/schematic/schemas/data_model_parser.py
@@ -129,7 +129,7 @@ class DataModelCSVParser:
         # Load relationships dictionary.
         self.rel_dict = self.dmr.define_data_model_relationships()
         # Get edge relationships
-        self.edge_relationships_dictionary = self.dmr.retreive_rel_headers_dict(
+        self.edge_relationships_dictionary = self.dmr.retrieve_rel_headers_dict(
             edge=True
         )
         # Load required csv headers

--- a/schematic/schemas/data_model_relationships.py
+++ b/schematic/schemas/data_model_relationships.py
@@ -251,23 +251,46 @@ class DataModelRelationships:
 
         return rel_headers_dict
 
+    def get_relationship_value(
+        self, relationship: str, value: str, none_if_missing: bool = False
+    ) -> Any:
+        """Returns a value from the relationship dictionary
+
+        Args:
+            relationship: The name of the relationship, the key in the top level relationship dict
+            value: The name of the value to get, the key dict of the relationship itself
+            none_if_missing: What happens if the value isn't a key in the relationship
+              If True returns None
+              If False an exception is raised
+
+        Raises:
+            ValueError: If the relationship doesn't exists
+            ValueError: If the value isn't in the relationship and none_if_missing is False
+
+        Returns:
+            The value
+        """
+        if relationship not in self.relationships_dictionary:
+            raise ValueError(f"Relationship: '{relationship}' not in dictionary")
+        if value not in self.relationships_dictionary[relationship]:
+            if not none_if_missing:
+                raise ValueError(
+                    f"Value: '{value}' not in relationship dictionary: '{relationship}'"
+                )
+            return None
+        return self.relationships_dictionary[relationship][value]
+
     def get_allowed_values(self, relationship: str) -> Optional[list[Any]]:
         """Gets the allowed values for the relationship
 
-        Args:
+        Arguments:
             relationship: The name of the relationship
-
-        Raises:
-            ValueError: If the relationship doesn't exist
-            AssertionError: If the allowed values aren't a list
 
         Returns:
              A list of allowed values if they exist, otherwise None
         """
-        if relationship not in self.relationships_dictionary:
-            raise ValueError(f"Relationship: '{relationship}' not in dictionary")
-        allowed_values = self.relationships_dictionary[relationship].get(
-            "allowed_values"
+        allowed_values = self.get_relationship_value(
+            relationship, "allowed_values", none_if_missing=True
         )
         assert isinstance(allowed_values, list) or allowed_values is None
         return allowed_values

--- a/schematic/schemas/data_model_relationships.py
+++ b/schematic/schemas/data_model_relationships.py
@@ -264,7 +264,7 @@ class DataModelRelationships:
               If False an exception is raised
 
         Raises:
-            ValueError: If the relationship doesn't exists
+            ValueError: If the relationship doesn't exist
             ValueError: If the value isn't in the relationship and none_if_missing is False
 
         Returns:

--- a/schematic/schemas/data_model_relationships.py
+++ b/schematic/schemas/data_model_relationships.py
@@ -267,9 +267,10 @@ class DataModelRelationships:
         Args:
             relationship: The name of the relationship, the key in the top level relationship dict
             value: The name of the value to get, the key dict of the relationship itself
-            none_if_missing: What happens if the value isn't a key in the relationship
-              If True returns None
-              If False an exception is raised
+            none_if_missing: Determines the behavior when the specified value is not found
+              in the relationship dictionary:
+                If True returns None
+                If False an exception is raised
 
         Raises:
             ValueError: If the relationship doesn't exist
@@ -278,13 +279,19 @@ class DataModelRelationships:
         Returns:
             The value
         """
-        if relationship not in self.relationships_dictionary:
-            raise ValueError(f"Relationship: '{relationship}' not in dictionary")
-        if value not in self.relationships_dictionary[relationship]:
+        if relationship.strip() not in self.relationships_dictionary:
+            msg = (
+                f"Relationship: '{relationship}' not in dictionary: "
+                f"[{list(self.relationships_dictionary.keys())}]"
+            )
+            raise ValueError(msg)
+        if value.strip().lower() not in self.relationships_dictionary[relationship]:
             if not none_if_missing:
-                raise ValueError(
-                    f"Value: '{value}' not in relationship dictionary: '{relationship}'"
+                msg = (
+                    f"Value: '{value}' not in relationship dictionary: "
+                    f"[{list(self.relationships_dictionary[relationship].keys())}]"
                 )
+                raise ValueError(msg)
             return None
         return self.relationships_dictionary[relationship][value]
 

--- a/schematic/schemas/data_model_relationships.py
+++ b/schematic/schemas/data_model_relationships.py
@@ -21,13 +21,13 @@ class DataModelRelationships:
     def define_data_model_relationships(self) -> dict:
         """Define the relationships and their attributes so they can be accessed
           through other classes.
-        The key is how it the relationship will be referenced througout Schematic.
+        The key is how it the relationship will be referenced throughout Schematic.
         Note: Though we could use other keys to determine which keys define nodes and edges,
-            edge_rel is used as an explicit definition, for easier code readablity.
+            edge_rel is used as an explicit definition, for easier code readability.
         key:
             jsonld_key: Name for relationship in the JSONLD.
                         Include in all sub-dictionaries.
-            csv_header: Str, name for this relationshp in the CSV data model.
+            csv_header: Str, name for this relationship in the CSV data model.
                         Enter None if not part of the CSV data model.
             node_label: Name for relationship in the graph representation of the data model.
                         Do not include this key for edge relationships.

--- a/schematic/schemas/data_model_relationships.py
+++ b/schematic/schemas/data_model_relationships.py
@@ -1,6 +1,7 @@
 """Data Model Relationships"""
 
-from typing import Optional, Any, Literal, get_args
+from typing import Optional, Any
+from enum import Enum
 
 from schematic.utils.schema_utils import (
     convert_bool_to_str,
@@ -9,7 +10,14 @@ from schematic.utils.schema_utils import (
     parse_validation_rules,
 )
 
-JSONSchemaType = Literal["string", "number", "integer", "boolean"]
+
+class JSONSchemaType(Enum):
+    """This enum is allowed values type values for a JSON Schema in a data model"""
+
+    STRING = "string"
+    NUMBER = "number"
+    INTEGER = "integer"
+    BOOLEAN = "boolean"
 
 
 class DataModelRelationships:
@@ -201,7 +209,7 @@ class DataModelRelationships:
                 "required_header": False,
                 "edge_rel": False,
                 "node_attr_dict": {"default": None},
-                "allowed_values": list(get_args(JSONSchemaType)),
+                "allowed_values": [enum.value for enum in JSONSchemaType],
             },
         }
 

--- a/schematic/schemas/data_model_relationships.py
+++ b/schematic/schemas/data_model_relationships.py
@@ -229,9 +229,9 @@ class DataModelRelationships:
 
         return required_headers
 
-    def retreive_rel_headers_dict(self, edge: bool) -> dict[str, str]:
+    def retrieve_rel_headers_dict(self, edge: bool) -> dict[str, str]:
         """
-        Helper function to retrieve CSV headers for edge and non-edge relationships
+        Helper method to retrieve CSV headers for edge and non-edge relationships
           defined by edge_type.
 
         Args:

--- a/schematic/schemas/data_model_relationships.py
+++ b/schematic/schemas/data_model_relationships.py
@@ -1,6 +1,6 @@
 """Data Model Relationships"""
 
-from typing import Optional, Any
+from typing import Optional, Any, Literal, get_args
 
 from schematic.utils.schema_utils import (
     convert_bool_to_str,
@@ -8,6 +8,8 @@ from schematic.utils.schema_utils import (
     get_label_from_display_name,
     parse_validation_rules,
 )
+
+JSONSchemaType = Literal["string", "number", "integer", "boolean"]
 
 
 class DataModelRelationships:
@@ -199,7 +201,7 @@ class DataModelRelationships:
                 "required_header": False,
                 "edge_rel": False,
                 "node_attr_dict": {"default": None},
-                "allowed_values": ["string", "integer", "number", "boolean"],
+                "allowed_values": list(get_args(JSONSchemaType)),
             },
         }
 

--- a/schematic/schemas/data_model_relationships.py
+++ b/schematic/schemas/data_model_relationships.py
@@ -282,14 +282,14 @@ class DataModelRelationships:
         if relationship.strip() not in self.relationships_dictionary:
             msg = (
                 f"Relationship: '{relationship}' not in dictionary: "
-                f"[{list(self.relationships_dictionary.keys())}]"
+                f"{list(self.relationships_dictionary.keys())}"
             )
             raise ValueError(msg)
         if value.strip().lower() not in self.relationships_dictionary[relationship]:
             if not none_if_missing:
                 msg = (
                     f"Value: '{value}' not in relationship dictionary: "
-                    f"[{list(self.relationships_dictionary[relationship].keys())}]"
+                    f"{list(self.relationships_dictionary[relationship].keys())}"
                 )
                 raise ValueError(msg)
             return None

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1048,7 +1048,7 @@ class TestDataModelEdges:
 
     """
 
-    def test_skip_edge(self, helpers, DMR:, data_model_edges):
+    def test_skip_edge(self, helpers, DMR:DataModelRelationships, data_model_edges):
         # Instantiate graph object and set node
         G = nx.MultiDiGraph()
         node = "Diagnosis"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -386,10 +386,10 @@ class TestDataModelRelationships:
         ]
 
     @pytest.mark.parametrize("edge", [True, False], ids=["True", "False"])
-    def test_retreive_rel_headers_dict(self, DMR: DataModelRelationships, edge: bool):
+    def test_retrieve_rel_headers_dict(self, DMR: DataModelRelationships, edge: bool):
         """Tests method returns correct values"""
         if edge:
-            assert DMR.retreive_rel_headers_dict(edge=edge) == {
+            assert DMR.retrieve_rel_headers_dict(edge=edge) == {
                 "rangeIncludes": "Valid Values",
                 "requiresDependency": "DependsOn",
                 "requiresComponent": "DependsOn Component",
@@ -397,7 +397,7 @@ class TestDataModelRelationships:
                 "domainIncludes": "Properties",
             }
         else:
-            assert DMR.retreive_rel_headers_dict(edge=edge) == {
+            assert DMR.retrieve_rel_headers_dict(edge=edge) == {
                 "columnType": "ColumnType",
                 "displayName": "Attribute",
                 "label": None,
@@ -1048,7 +1048,7 @@ class TestDataModelEdges:
 
     """
 
-    def test_skip_edge(self, helpers, DMR, data_model_edges):
+    def test_skip_edge(self, helpers, DMR:, data_model_edges):
         # Instantiate graph object and set node
         G = nx.MultiDiGraph()
         node = "Diagnosis"
@@ -1065,7 +1065,7 @@ class TestDataModelEdges:
         DMN = DataModelNodes(parsed_data_model)
 
         # Get edge relationships and all nodes from the parsed model
-        edge_relationships = DMR.retreive_rel_headers_dict(edge=True)
+        edge_relationships = DMR.retrieve_rel_headers_dict(edge=True)
         all_nodes = DMN.gather_all_nodes_in_model(attr_rel_dict=parsed_data_model)
 
         # Sanity check to ensure that the node we intend to test exists in the data model
@@ -1108,7 +1108,7 @@ class TestDataModelEdges:
         ids=["subClassOf", "Valid Value", "all others"],
     )
     def test_generate_edge(
-        self, helpers, DMR, data_model_edges, node_to_add, edge_relationship
+        self, helpers, DMR:DataModelRelationships, data_model_edges, node_to_add, edge_relationship
     ):
         # Instantiate graph object
         G = nx.MultiDiGraph()
@@ -1125,7 +1125,7 @@ class TestDataModelEdges:
         DMN = DataModelNodes(parsed_data_model)
 
         # Get edge relationships and all nodes from the parsed model
-        edge_relationships = DMR.retreive_rel_headers_dict(edge=True)
+        edge_relationships = DMR.retrieve_rel_headers_dict(edge=True)
         all_nodes = DMN.gather_all_nodes_in_model(attr_rel_dict=parsed_data_model)
 
         # Sanity check to ensure that the node we intend to test exists in the data model
@@ -1173,7 +1173,7 @@ class TestDataModelEdges:
     def test_generate_weights(
         self,
         helpers,
-        DMR,
+        DMR:DataModelRelationships,
         data_model_edges,
         node_to_add,
         other_node,
@@ -1195,7 +1195,7 @@ class TestDataModelEdges:
         DMN = DataModelNodes(parsed_data_model)
 
         # Get edge relationships and all nodes from the parsed model
-        edge_relationships = DMR.retreive_rel_headers_dict(edge=True)
+        edge_relationships = DMR.retrieve_rel_headers_dict(edge=True)
         all_nodes = DMN.gather_all_nodes_in_model(attr_rel_dict=parsed_data_model)
 
         # Sanity check to ensure that the node we intend to test exists in the data model

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1048,7 +1048,7 @@ class TestDataModelEdges:
 
     """
 
-    def test_skip_edge(self, helpers, DMR:DataModelRelationships, data_model_edges):
+    def test_skip_edge(self, helpers, DMR: DataModelRelationships, data_model_edges):
         # Instantiate graph object and set node
         G = nx.MultiDiGraph()
         node = "Diagnosis"
@@ -1108,7 +1108,12 @@ class TestDataModelEdges:
         ids=["subClassOf", "Valid Value", "all others"],
     )
     def test_generate_edge(
-        self, helpers, DMR:DataModelRelationships, data_model_edges, node_to_add, edge_relationship
+        self,
+        helpers,
+        DMR: DataModelRelationships,
+        data_model_edges,
+        node_to_add,
+        edge_relationship,
     ):
         # Instantiate graph object
         G = nx.MultiDiGraph()
@@ -1173,7 +1178,7 @@ class TestDataModelEdges:
     def test_generate_weights(
         self,
         helpers,
-        DMR:DataModelRelationships,
+        DMR: DataModelRelationships,
         data_model_edges,
         node_to_add,
         other_node,

--- a/tests/unit/test_data_model_graph.py
+++ b/tests/unit/test_data_model_graph.py
@@ -10,7 +10,7 @@ from tests.conftest import Helpers
 DATA_MODEL_DICT = {"example.model.csv": "CSV", "example.model.jsonld": "JSONLD"}
 
 
-@pytest.fixture(name="column_type_dmge", scope="module")
+@pytest.fixture(name="column_type_dmge_jsonld", scope="module")
 def fixture_column_type_dmge() -> DataModelGraphExplorer:
     """Returns a DataModelGraphExplorer using the example data model with columnType attributes"""
     data_model_parser = DataModelParser(
@@ -113,11 +113,11 @@ class TestDataModelGraphExplorer:
         self,
         node_label: str,
         expected_type: Optional[JSONSchemaType],
-        column_type_dmge: DataModelGraphExplorer,
+        column_type_dmge_jsonld: DataModelGraphExplorer,
     ) -> None:
         """Tests for DataModelGraphExplorer.get_node_column_type using node label"""
         assert (
-            column_type_dmge.get_node_column_type(node_label=node_label)
+            column_type_dmge_jsonld.get_node_column_type(node_label=node_label)
             == expected_type
         )
 
@@ -134,10 +134,12 @@ class TestDataModelGraphExplorer:
         self,
         node_display_name: str,
         expected_type: Optional[JSONSchemaType],
-        column_type_dmge: DataModelGraphExplorer,
+        column_type_dmge_jsonld: DataModelGraphExplorer,
     ) -> None:
         """Tests for DataModelGraphExplorer.get_node_column_type using node display name"""
         assert (
-            column_type_dmge.get_node_column_type(node_display_name=node_display_name)
+            column_type_dmge_jsonld.get_node_column_type(
+                node_display_name=node_display_name
+            )
             == expected_type
         )

--- a/tests/unit/test_data_model_graph.py
+++ b/tests/unit/test_data_model_graph.py
@@ -2,9 +2,24 @@ from typing import Optional, Union
 
 import pytest
 
+from schematic.schemas.data_model_relationships import JSONSchemaType
+from schematic.schemas.data_model_graph import DataModelGraph, DataModelGraphExplorer
+from schematic.schemas.data_model_parser import DataModelParser
 from tests.conftest import Helpers
 
 DATA_MODEL_DICT = {"example.model.csv": "CSV", "example.model.jsonld": "JSONLD"}
+
+
+@pytest.fixture(name="column_type_dmge", scope="module")
+def fixture_column_type_dmge() -> DataModelGraphExplorer:
+    """Returns a DataModelGraphExplorer using the example data model with columnType attributes"""
+    data_model_parser = DataModelParser(
+        path_to_data_model="tests/data/example.model_column_type.jsonld"
+    )
+    parsed_data_model = data_model_parser.parse_model()
+    data_model_grapher = DataModelGraph(parsed_data_model)
+    graph_data_model = data_model_grapher.graph
+    return DataModelGraphExplorer(graph_data_model)
 
 
 class TestDataModelGraphExplorer:
@@ -84,3 +99,45 @@ class TestDataModelGraphExplorer:
             DMGE.get_node_validation_rules(
                 node_label=node_label, node_display_name=node_display_name
             )
+
+    @pytest.mark.parametrize(
+        "node_label, expected_type",
+        [
+            ("CheckString", "string"),
+            ("CheckNum", "number"),
+            ("CheckURL", None),
+        ],
+        ids=["CheckString", "CheckNum", "CheckURL"],
+    )
+    def test_get_node_column_type_with_node_labels(
+        self,
+        node_label: str,
+        expected_type: Optional[JSONSchemaType],
+        column_type_dmge: DataModelGraphExplorer,
+    ) -> None:
+        """Tests for DataModelGraphExplorer.get_node_column_type using node label"""
+        assert (
+            column_type_dmge.get_node_column_type(node_label=node_label)
+            == expected_type
+        )
+
+    @pytest.mark.parametrize(
+        "node_display_name, expected_type",
+        [
+            ("Check String", "string"),
+            ("Check Num", "number"),
+            ("Check URL", None),
+        ],
+        ids=["Check String", "Check Num", "Check URL"],
+    )
+    def test_get_node_column_type_with_display_name(
+        self,
+        node_display_name: str,
+        expected_type: Optional[JSONSchemaType],
+        column_type_dmge: DataModelGraphExplorer,
+    ) -> None:
+        """Tests for DataModelGraphExplorer.get_node_column_type using node display name"""
+        assert (
+            column_type_dmge.get_node_column_type(node_display_name=node_display_name)
+            == expected_type
+        )

--- a/tests/unit/test_data_model_graph.py
+++ b/tests/unit/test_data_model_graph.py
@@ -11,10 +11,22 @@ DATA_MODEL_DICT = {"example.model.csv": "CSV", "example.model.jsonld": "JSONLD"}
 
 
 @pytest.fixture(name="column_type_dmge_jsonld", scope="module")
-def fixture_column_type_dmge() -> DataModelGraphExplorer:
+def fixture_column_type_dmge_jsonld() -> DataModelGraphExplorer:
     """Returns a DataModelGraphExplorer using the example data model with columnType attributes"""
     data_model_parser = DataModelParser(
         path_to_data_model="tests/data/example.model_column_type.jsonld"
+    )
+    parsed_data_model = data_model_parser.parse_model()
+    data_model_grapher = DataModelGraph(parsed_data_model)
+    graph_data_model = data_model_grapher.graph
+    return DataModelGraphExplorer(graph_data_model)
+
+
+@pytest.fixture(name="column_type_dmge_csv", scope="module")
+def fixture_column_type_dmge_csv() -> DataModelGraphExplorer:
+    """Returns a DataModelGraphExplorer using the example data model with columnType attributes"""
+    data_model_parser = DataModelParser(
+        path_to_data_model="tests/data/example.model.column_type_component.csv"
     )
     parsed_data_model = data_model_parser.parse_model()
     data_model_grapher = DataModelGraph(parsed_data_model)
@@ -109,7 +121,7 @@ class TestDataModelGraphExplorer:
         ],
         ids=["CheckString", "CheckNum", "CheckURL"],
     )
-    def test_get_node_column_type_with_node_labels(
+    def test_get_node_column_type_with_node_labels_jsonld(
         self,
         node_label: str,
         expected_type: Optional[JSONSchemaType],
@@ -118,6 +130,27 @@ class TestDataModelGraphExplorer:
         """Tests for DataModelGraphExplorer.get_node_column_type using node label"""
         assert (
             column_type_dmge_jsonld.get_node_column_type(node_label=node_label)
+            == expected_type
+        )
+
+    @pytest.mark.parametrize(
+        "node_label, expected_type",
+        [
+            ("Stringtype", "string"),
+            ("Numtype", "number"),
+            ("CheckURL", None),
+        ],
+        ids=["Stringtype", "Numtype", "CheckURL"],
+    )
+    def test_get_node_column_type_with_node_labels_csv(
+        self,
+        node_label: str,
+        expected_type: Optional[JSONSchemaType],
+        column_type_dmge_csv: DataModelGraphExplorer,
+    ) -> None:
+        """Tests for DataModelGraphExplorer.get_node_column_type using node label"""
+        assert (
+            column_type_dmge_csv.get_node_column_type(node_label=node_label)
             == expected_type
         )
 

--- a/tests/unit/test_data_model_parser.py
+++ b/tests/unit/test_data_model_parser.py
@@ -100,14 +100,15 @@ class TestDataModelCSVParser:
             if not expected_type:
                 # If the expected type is None, we expect the column type to be missing
                 assert (
-                    "columnType" not in result[expected_attribute]
-                ), f"Expected no column type for '{expected_attribute}', but got '{result[expected_attribute].get('columnType')}'"
+                    "ColumnType" not in result[expected_attribute]["Relationships"]
+                ), f"Expected no column type for '{expected_attribute}', but got '{result[expected_attribute]['Relationships'].get('ColumnType')}'"
                 continue
 
             # AND the column type of each attribute should match the expected type if a column type is specified
             assert (
-                result[expected_attribute]["columnType"] == expected_type
-            ), f"Expected column type for '{expected_attribute}' to be '{expected_type}', but got '{result[expected_attribute]['columnType']}'"
+                result[expected_attribute]["Relationships"]["ColumnType"]
+                == expected_type
+            ), f"Expected column type for '{expected_attribute}' to be '{expected_type}', but got '{result[expected_attribute]['Relationships']['ColumnType']}'"
 
     def test_parse_csv_model_without_column_type(
         self,

--- a/tests/unit/test_data_model_relationships.py
+++ b/tests/unit/test_data_model_relationships.py
@@ -7,14 +7,38 @@ from schematic.schemas.data_model_relationships import DataModelRelationships
 class TestDataModelRelationships:
     """Tests for DataModelRelationships class"""
 
+    def test_get_relationship_value(self, dmr: DataModelRelationships) -> None:
+        """Test for DataModelRelationships.get_relationship_value"""
+        assert (
+            dmr.get_relationship_value("displayName", "jsonld_key") == "sms:displayName"
+        )
+
+    def test_get_relationship_value_return_none(
+        self, dmr: DataModelRelationships
+    ) -> None:
+        """
+        Test for DataModelRelationships.get_relationship_value when field is missing and
+          none_if_missing is True
+        """
+        assert (
+            dmr.get_relationship_value("displayName", "edge_dir", none_if_missing=True)
+            is None
+        )
+
+    def test_get_relationship_value_exceptions(
+        self, dmr: DataModelRelationships
+    ) -> None:
+        """
+        Test for DataModelRelationships.get_relationship_value when field is missing and
+          none_if_missing is False
+        """
+        with pytest.raises(
+            ValueError,
+            match="Value: 'edge_dir' not in relationship dictionary: 'displayName'",
+        ):
+            dmr.get_relationship_value("displayName", "edge_dir")
+
     def test_get_allowed_values(self, dmr: DataModelRelationships) -> None:
         """Tests for DataModelRelationships.get_allowed_values"""
         result = dmr.get_allowed_values("columnType")
-        assert result == ["string", "integer", "number", "boolean"]
-
-    def test_get_allowed_values_value_error(self, dmr: DataModelRelationships) -> None:
-        """Tests for DataModelRelationships.get_allowed_values with a ValueError"""
-        with pytest.raises(
-            ValueError, match="Relationship: 'not_a_relationship' not in dictionary"
-        ):
-            dmr.get_allowed_values("not_a_relationship")
+        assert result == ["string", "number", "integer", "boolean"]

--- a/tests/unit/test_data_model_relationships.py
+++ b/tests/unit/test_data_model_relationships.py
@@ -34,7 +34,7 @@ class TestDataModelRelationships:
         """
         with pytest.raises(
             ValueError,
-            match="Value: 'edge_dir' not in relationship dictionary: 'displayName'",
+            match="Value: 'edge_dir' not in relationship dictionary",
         ):
             dmr.get_relationship_value("displayName", "edge_dir")
 


### PR DESCRIPTION
[SCHEMATIC-306]

# **Problem:**
The `DataModelGrpahExplorer`(DMGE) class needs a way to access the columType attribute of a node

# **Solution:**
The DMGE class now has a `get_node_column_type` that gets the needed value

# **Testing:**
Tests were added for the `DMGE.get_node_column_type` and other helper methods.

# **Other**

I added a method to the DMGE class :
```
    def _get_node_label(
        self, node_label: Optional[str] = None, node_display_name: Optional[str] = None
    ) -> str:
        if not node_label:
            if not node_display_name:
                raise ValueError("must provide either node_label or node_display_name")
            node_label = self.get_node_label(node_display_name)
        return node_label
```
This logic was in several methods, so I pulled it out and added the error handling.

I also added this method to `DatamodelRelationships` (DMR):

```
    def get_relationship_value(
        self, relationship: str, value: str, none_if_missing: bool = False
    ) -> Any:
        if relationship not in self.relationships_dictionary:
            raise ValueError(f"Relationship: '{relationship}' not in dictionary")
        if value not in self.relationships_dictionary[relationship]:
            if not none_if_missing:
                raise ValueError(
                    f"Value: '{value}' not in relationship dictionary: '{relationship}'"
                )
            return None
        return self.relationships_dictionary[relationship][value]
```
There were several places in DMGE that used the DMR like:

```
self.rel_dict["domainIncludes"]["edge_key"] 
```
These got turned into:

```
self.dmr.get_relationship_value("domainIncludes", "edge_key")
```
This improves the error handling and reduces coupling between the classes.


[SCHEMATIC-306]: https://sagebionetworks.jira.com/browse/SCHEMATIC-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ