### PR TITLE
[SCHEMATIC-314] JSONSchema Data Model Documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ release = toml_metadata["version"]
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx_click", "sphinx_rtd_theme"]
+extensions = ["sphinx_click", "sphinx_rtd_theme", "sphinx.ext.autosectionlabel"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -155,3 +155,4 @@ For the entire Python API reference documentation, you can visit the docs here: 
    troubleshooting
    cli_reference
    linkml
+   jsonschema_generation

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -44,7 +44,7 @@ Types can be set explicitly in the data model or inferred from an attribute's sp
 
 Explicit Type Setting
 ^^^^^^^^^^^^^^^^^^^^^^
-To explicitly set the type of a property in the JSONSchema, add the ``ColumnType`` column to the data model and specify one of the allowed types in that column for the appropriate attribute's row. It is acceptable to leave rows blank for attributes that you do not wish to specify type for.
+To explicitly set the type of a property in the JSONSchema, add the ``columnType`` column to the data model and specify one of the allowed types in that column for the appropriate attribute's row. It is acceptable to leave rows blank for attributes that you do not wish to specify type for.
 
 
 Implicit Type Inference

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -103,6 +103,7 @@ Type Checks
 ^^^^^^^^^^^^^^
 
 Types discussed above are enforced in JSONSchema validation.
+For more information about these rules see :ref:`the documentation for type rules<Type Validation Type>`.
 
 Valid Values
 ^^^^^^^^^^^^^^^
@@ -161,6 +162,7 @@ An attribute with an ``inRange`` validation rule::
       "type": "number"
     }
 
+For more information about the ``inRange`` rule see :ref:`the rule documentation<inRange>`.
 
 ``regex`` module
 """""""""""""""""""""
@@ -174,6 +176,10 @@ An attribute with a ``regex`` module specified::
       "type": "string",
       "title": "Check Regex Format"
     }
+
+
+For more information about the ``regex`` module rule see :ref:`the rule documentation<Regex Validation Type>`.
+
 
 ``date``
 """""""""""""
@@ -189,6 +195,9 @@ An attribute with a ``date`` validation rule specified::
       "title": "Check Date"
     }
 
+For more information about the ``date`` rule see :ref:`the rule documentation<date>`.
+
+
 ``URL``
 """""""""""""
 If the ``URL`` validation rule is specified for an attribute, the JSONSchema will include a ``format: uri`` key value pair.
@@ -201,6 +210,8 @@ An attribute with a ``URL`` validation rule specified::
       "format": "uri",
       "title": "Check URL"
     }
+
+For more information about the ``URL`` rule see :ref:`the rule documentation<URL Validation Type>`.
 
 
 Conditional Dependencies

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -9,6 +9,7 @@ JSONSchema Components and How to Set from Data Model
 ====================================================
 
 This document serves as a guide on what features in a CSV data model map to which components in a JSONSchema file. All examples of JSONSchema files were taken from this `example data model <https://github.com/Sage-Bionetworks/schematic/blob/develop/tests/data/example.model.column_type_component.csv>`_.
+For documentation on how to generate a JSONSchema file, see the :ref:`cli documentation<generate-jsonschema>`.
 
 Property Keys
 -------------

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -78,12 +78,9 @@ An attribute with a specified type::
 
 An attribute without a specified type::
 
-    "CheckDate": {
+    "YearofBirth": {
       "description": "TBD",
-      "not": {
-        "type": "null"
-      },
-      "title": "Check Date"
+      "title": "Year of Birth"
     }
 
 

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -166,9 +166,19 @@ For more information about the ``inRange`` rule see :ref:`the rule documentation
 
 ``regex`` module
 """""""""""""""""""""
-If the ``regex`` module is specified for an attribute, the JSONSchema will include a ``pattern`` keyword with the value being the regex string provided in the data model. Note that in cases where ``regex match`` is the specified rule, the character ``^`` will be pre-prended to the regex string, which enables the ``match`` functionality on the backend.
+If the ``regex`` module is specified for an attribute, the JSONSchema will include a ``pattern`` keyword with the value being the regex string provided in the data model. Note that in cases where ``regex match`` is the specified rule, the character ``^`` will be automatically pre-prended to the regex string, which enables the ``match`` functionality on the backend. This caret does not need to be added within the data model to enable this functionality.
 
-An attribute with a ``regex`` module specified::
+For example, an attribute with a ``regex`` rule ``regex search [a-f]`` specified will yield a property like::
+
+    "CheckRegexSingle": {
+      "description": "TBD",
+      "pattern": "[a-f]",
+      "type": "string",
+      "title": "Check Regex Single"
+    },
+
+
+While an attribute with a ``regex`` rule ``regex match [a-f]`` specified will yield a property like::
 
     "CheckRegexFormat": {
       "description": "TBD",
@@ -176,6 +186,7 @@ An attribute with a ``regex`` module specified::
       "type": "string",
       "title": "Check Regex Format"
     }
+
 
 
 For more information about the ``regex`` module rule see :ref:`the rule documentation<Regex Validation Type>`.

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -112,6 +112,24 @@ This will show up in the JSONSchema as an ``enum`` key with a list of valid valu
 
 An attribute with valid values specified::
 
+    "FileFormat": {
+      "description": "TBD",
+      "oneOf": [
+        {
+          "enum": [
+            "BAM",
+            "CRAM",
+            "CSV/TSV",
+            "FASTQ"
+          ],
+          "title": "enum"
+        }
+      ],
+      "title": "File Format"
+    },
+
+An attribute with valid values specified along with the ``list`` rule::
+
     "CheckListEnum": {
       "description": "TBD",
       "oneOf": [

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -8,7 +8,7 @@ Generate JSON Schema from Data Models
 JSONSchema Components and How to Set from Data Model
 ====================================================
 
-
+This document serves as a guide on what features in a CSV data model map to which components in a JSONSchema file. All examples of JSONSchema files were taken from this `example data model <https://github.com/Sage-Bionetworks/schematic/blob/develop/tests/data/example.model.column_type_component.csv>`_.
 
 Property Keys
 -------------
@@ -18,11 +18,28 @@ Description
 -----------
 The JSONSchema description is taken from the data model's description field. If the data model does not have a description, the description will be set to ``TBD``.
 
+An attribute with a description::
+
+  {"$id": "http://example.com/MockComponent_validation",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Component to hold mock attributes for testing all validation rules",
+  "properties": {...}
+  }
+
+An attribute without a description::
+
+    "CheckAges": {
+    "description": "TBD",
+    "not": {
+    "type": "null"
+    },
+    "title": "Check Ages"
+    },
+
 Type
 -------
 Multiple types can be enforced in JSONSchema. Currently allowed types are: ``string``, ``numnber``, ``integer``, and ``boolean``.
 Types can be set explicitly in the data model or inferred from an attribute's specified validation rules.
-In the cases where no type is provided and no type can be inferred, no ``type`` key will be added to the JSONSchema.
 
 Explicit Type Setting
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -48,6 +65,26 @@ datetime             format: date
 URL                  format: uri
 ===================  ================
 
+An attribute with a specified type::
+
+    "CheckRange": {
+      "description": "TBD",
+      "maximum": 100.0,
+      "minimum": 50.0,
+      "title": "Check Range",
+      "type": "number"
+    }
+
+An attribute without a specified type::
+
+    "CheckDate": {
+      "description": "TBD",
+      "not": {
+        "type": "null"
+      },
+      "title": "Check Date"
+    }
+
 
 Validation
 ----------
@@ -64,6 +101,41 @@ Valid Values
 If an attribute has valid values specified, the JSONSchema validation will enforce that provided values are one of the valid values specified.
 This will show up in the JSONSchema as an ``enum`` key with a list of valid values.
 
+An attribute with valid values specified::
+
+    "CheckListEnum": {
+      "description": "TBD",
+      "oneOf": [
+        {
+          "items": {
+            "enum": [
+              "ab",
+              "cd",
+              "ef",
+              "gh"
+            ]
+          },
+          "title": "array",
+          "type": "array"
+        }
+      ],
+      "title": "Check List Enum"
+    }
+
+Required
+^^^^^^^^^^^^^^
+For required attributes, the JSONSchema will have an additional ``not: {"type": "null"}`` key value pair added to the property.
+
+A required attribute::
+
+    "CheckDate": {
+      "description": "TBD",
+      "not": {
+        "type": "null"
+      },
+      "title": "Check Date"
+    }
+
 Validation Rules
 ^^^^^^^^^^^^^^^^^^
 
@@ -71,15 +143,230 @@ Validation Rules
 """"""""""""""
 Aside from the type validation checks, the ``inRange`` rule will also be translated to the JSONSchema if provided for an attribute. The attribute must be a numberical type, and the ``maximum`` and ``minimum`` keys will be added to the JSONSchema for the property, witht the values taken from the range specified in the data model.
 
+An attribute with an ``inRange`` validation rule::
+
+    "CheckRange": {
+      "description": "TBD",
+      "maximum": 100.0,
+      "minimum": 50.0,
+      "title": "Check Range",
+      "type": "number"
+    }
+
+
 ``regex`` module
 """""""""""""""""""""
 If the ``regex`` module is specified for an attribute, the JSONSchema will include a ``pattern`` keyword with the value being the regex string provided in the data model. Note that in cases where ``regex match`` is the specified rule, the character ``^`` will be pre-prended to the regex string, which enables the ``match`` functionality on the backend.
 
-Required
-^^^^^^^^^^^^^^
-For required attributes, the JSONSchema will have an additional ``not: {"type": "null"}`` key value pair added to the property.
+An attribute with a ``regex`` module specified::
+
+    "CheckRegexFormat": {
+      "description": "TBD",
+      "pattern": "^[a-f]",
+      "type": "string",
+      "title": "Check Regex Format"
+    }
+
+``date``
+"""""""""""""
+
+If the ``date`` validation rule is specified for an attribute, the JSONSchema will include a ``format: date`` key value pair.
+
+An attribute with a ``date`` validation rule specified::
+
+    "CheckDate": {
+      "description": "TBD",
+      "type": "string",
+      "format": "date",
+      "title": "Check Date"
+    }
+
+``URL``
+"""""""""""""
+If the ``URL`` validation rule is specified for an attribute, the JSONSchema will include a ``format: uri`` key value pair.
+
+An attribute with a ``URL`` validation rule specified::
+
+    "CheckURL": {
+      "description": "TBD",
+      "type": "string",
+      "format": "uri",
+      "title": "Check URL"
+    }
+
 
 Conditionals
 -------------
 
-Conditional properties will be added to the JSONSchema if present in the data model. The conditional formatting will look like a series of ``"if": {}, "then": {}`` key dictionary pairs.
+Conditional properties will be added to the JSONSchema if present in the data model. The conditional formatting will look like a series of ``"if": {}, "then": {}`` key dictionary pairs, in addition to the regular attribute dictionaries.
+
+An example of a data type with conditional dependencies::
+
+    {
+    "$id": "http://example.com/BulkRNA-seqAssay_validation",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "allOf": [
+        {
+        "if": {
+            "properties": {
+            "FileFormat": {
+                "enum": [
+                "BAM"
+                ]
+            }
+            }
+        },
+        "then": {
+            "properties": {
+            "GenomeBuild": {
+                "not": {
+                "type": "null"
+                }
+            }
+            },
+            "required": [
+            "GenomeBuild"
+            ]
+        }
+        },
+        {
+        "if": {
+            "properties": {
+            "FileFormat": {
+                "enum": [
+                "CRAM"
+                ]
+            }
+            }
+        },
+        "then": {
+            "properties": {
+            "GenomeBuild": {
+                "not": {
+                "type": "null"
+                }
+            }
+            },
+            "required": [
+            "GenomeBuild"
+            ]
+        }
+        },
+        {
+        "if": {
+            "properties": {
+            "FileFormat": {
+                "enum": [
+                "CSV/TSV"
+                ]
+            }
+            }
+        },
+        "then": {
+            "properties": {
+            "GenomeBuild": {
+                "not": {
+                "type": "null"
+                }
+            }
+            },
+            "required": [
+            "GenomeBuild"
+            ]
+        }
+        },
+        {
+        "if": {
+            "properties": {
+            "FileFormat": {
+                "enum": [
+                "CRAM"
+                ]
+            }
+            }
+        },
+        "then": {
+            "properties": {
+            "GenomeFASTA": {
+                "not": {
+                "type": "null"
+                }
+            }
+            },
+            "required": [
+            "GenomeFASTA"
+            ]
+        }
+        }
+    ],
+    "description": "TBD",
+    "properties": {
+        "Component": {
+        "description": "TBD",
+        "not": {
+            "type": "null"
+        },
+        "title": "Component"
+        },
+        "FileFormat": {
+        "description": "TBD",
+        "oneOf": [
+            {
+            "enum": [
+                "BAM",
+                "CRAM",
+                "CSV/TSV",
+                "FASTQ"
+            ],
+            "title": "enum"
+            }
+        ],
+        "title": "File Format"
+        },
+        "Filename": {
+        "description": "TBD",
+        "not": {
+            "type": "null"
+        },
+        "title": "Filename"
+        },
+        "GenomeBuild": {
+        "description": "TBD",
+        "oneOf": [
+            {
+            "enum": [
+                "GRCh37",
+                "GRCh38",
+                "GRCm38",
+                "GRCm39"
+            ],
+            "title": "enum"
+            },
+            {
+            "title": "null",
+            "type": "null"
+            }
+        ],
+        "title": "Genome Build"
+        },
+        "GenomeFASTA": {
+        "description": "TBD",
+        "title": "Genome FASTA"
+        },
+        "SampleID": {
+        "description": "TBD",
+        "not": {
+            "type": "null"
+        },
+        "title": "Sample ID"
+        }
+    },
+    "required": [
+        "Component",
+        "FileFormat",
+        "Filename",
+        "SampleID"
+    ],
+    "title": "BulkRNA-seqAssay_validation",
+    "type": "object"
+    }

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -1,0 +1,85 @@
+.. _jsonschema_generation:
+
+**************************************
+Generate JSON Schema from Data Models
+**************************************
+
+
+JSONSchema Components and How to Set from Data Model
+====================================================
+
+
+
+Property Keys
+-------------
+Property keys are taken from the Attribute names in the data model. Class labels can be used as well as display names, provided they do not contain any characters blacklisted by synapse: ``"(", ")", ".", " ", "-"``.
+
+Description
+-----------
+The JSONSchema description is taken from the data model's description field. If the data model does not have a description, the description will be set to ``TBD``.
+
+Type
+-------
+Multiple types can be enforced in JSONSchema. Currently allowed types are: ``string``, ``numnber``, ``integer``, and ``boolean``.
+Types can be set explicitly in the data model or inferred from an attribute's specified validation rules.
+In the cases where no type is provided and no type can be inferred, no ``type`` key will be added to the JSONSchema.
+
+Explicit Type Setting
+^^^^^^^^^^^^^^^^^^^^^^
+To explicitly set the type of a property in the JSONSchema, add the ``ColumnType`` column to the data model and specify one of the allowed types in that column for the appropriate attribute's row. It is acceptable to leave rows blank for attributes that you do not wish to specify type for.
+
+
+Implicit Type Inference
+^^^^^^^^^^^^^^^^^^^^^^^^
+Types are also inferred from the validation rules set for an attribute. The following validation rules map to the indicated JSONSchema types:
+
+===================  ================
+Validation Rule      JSONSchema Type
+===================  ================
+list                 array
+regex module         string
+float                number
+int                  integer
+num                  number
+string               string
+inRange              integer or number
+date                 string
+datetime             format: date
+URL                  format: uri
+===================  ================
+
+
+Validation
+----------
+
+Certain validation checks from schematic are also present in JSONSchema validation.
+
+Type Checks
+^^^^^^^^^^^^^^
+
+Types discussed above are enforced in JSONSchema validation.
+
+Valid Values
+^^^^^^^^^^^^^^^
+If an attribute has valid values specified, the JSONSchema validation will enforce that provided values are one of the valid values specified.
+This will show up in the JSONSchema as an ``enum`` key with a list of valid values.
+
+Validation Rules
+^^^^^^^^^^^^^^^^^^
+
+``inRange``
+""""""""""""""
+Aside from the type validation checks, the ``inRange`` rule will also be translated to the JSONSchema if provided for an attribute. The attribute must be a numberical type, and the ``maximum`` and ``minimum`` keys will be added to the JSONSchema for the property, witht the values taken from the range specified in the data model.
+
+``regex`` module
+"""""""""""""""""""""
+If the ``regex`` module is specified for an attribute, the JSONSchema will include a ``pattern`` keyword with the value being the regex string provided in the data model. Note that in cases where ``regex match`` is the specified rule, the character ``^`` will be pre-prended to the regex string, which enables the ``match`` functionality on the backend.
+
+Required
+^^^^^^^^^^^^^^
+For required attributes, the JSONSchema will have an additional ``not: {"type": "null"}`` key value pair added to the property.
+
+Conditionals
+-------------
+
+Conditional properties will be added to the JSONSchema if present in the data model. The conditional formatting will look like a series of ``"if": {}, "then": {}`` key dictionary pairs.

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -139,7 +139,7 @@ Validation Rules
 
 ``inRange``
 """"""""""""""
-Aside from the type validation checks, the ``inRange`` rule will also be translated to the JSONSchema if provided for an attribute. The attribute must be a numberical type, and the ``maximum`` and ``minimum`` keys will be added to the JSONSchema for the property, with the values taken from the range specified in the data model.
+Aside from the type validation checks, the ``inRange`` rule will also be translated to the JSONSchema if provided for an attribute. The attribute must be a ``number`` type, and the ``maximum`` and ``minimum`` keys will be added to the JSONSchema for the property, with the values taken from the range specified in the data model.
 
 An attribute with an ``inRange`` validation rule::
 

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -86,8 +86,8 @@ An attribute without a specified type::
     }
 
 
-Validation
-----------
+Validation Checks
+------------------
 
 Certain validation checks from schematic are also present in JSONSchema validation.
 
@@ -122,8 +122,8 @@ An attribute with valid values specified::
       "title": "Check List Enum"
     }
 
-Required
-^^^^^^^^^^^^^^
+Required Attributes
+^^^^^^^^^^^^^^^^^^^^^
 For required attributes, the JSONSchema will have an additional ``not: {"type": "null"}`` key value pair added to the property.
 
 A required attribute::
@@ -195,8 +195,8 @@ An attribute with a ``URL`` validation rule specified::
     }
 
 
-Conditionals
--------------
+Conditional Dependencies
+-------------------------
 
 Conditional properties will be added to the JSONSchema if present in the data model. The conditional formatting will look like a series of ``"if": {}, "then": {}`` key dictionary pairs, in addition to the regular attribute dictionaries.
 

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -139,7 +139,7 @@ Validation Rules
 
 ``inRange``
 """"""""""""""
-Aside from the type validation checks, the ``inRange`` rule will also be translated to the JSONSchema if provided for an attribute. The attribute must be a numberical type, and the ``maximum`` and ``minimum`` keys will be added to the JSONSchema for the property, witht the values taken from the range specified in the data model.
+Aside from the type validation checks, the ``inRange`` rule will also be translated to the JSONSchema if provided for an attribute. The attribute must be a numberical type, and the ``maximum`` and ``minimum`` keys will be added to the JSONSchema for the property, with the values taken from the range specified in the data model.
 
 An attribute with an ``inRange`` validation rule::
 

--- a/docs/source/jsonschema_generation.rst
+++ b/docs/source/jsonschema_generation.rst
@@ -39,12 +39,22 @@ An attribute without a description::
 
 Type
 -------
-Multiple types can be enforced in JSONSchema. Currently allowed types are: ``string``, ``numnber``, ``integer``, and ``boolean``.
-Types can be set explicitly in the data model or inferred from an attribute's specified validation rules.
+Multiple types can be enforced in JSONSchema. Currently allowed types are in the table below. Types can be set explicitly in the data model or inferred from an attribute's specified validation rules.
+
+.. list-table:: Currently Allowed Types
+    :widths: 60
+    :header-rows: 1
+
+    * - Type
+    * - ``string``
+    * - ``number``
+    * - ``integer``
+    * - ``boolean``
+
 
 Explicit Type Setting
 ^^^^^^^^^^^^^^^^^^^^^^
-To explicitly set the type of a property in the JSONSchema, add the ``columnType`` column to the data model and specify one of the allowed types in that column for the appropriate attribute's row. It is acceptable to leave rows blank for attributes that you do not wish to specify type for.
+To explicitly set the type of a property in the JSONSchema, add the ``olumnType`` column to the data model and specify one of the allowed types in that column for the appropriate attribute's row. It is acceptable to leave rows blank for attributes that you do not wish to specify type for.
 
 
 Implicit Type Inference


### PR DESCRIPTION
# **Problem:**

Users need documentation explaining how concepts in a data model map to fields in JSONSchema files.

# **Solution:**

A new documentation page covering how fields in JSONSchema files are set from concepts in a schematic data model.

# **Testing:**

Documentation (see [here](https://schematicpy--1622.org.readthedocs.build/en/1622/)) will be reviewed by others and feedback will be given.