### PR TITLE
[SCHEMATIC-308] Add ability for JSON Schema type to be set by columnType attribute

### DIFF
--- a/schematic/schemas/create_json_schema.py
+++ b/schematic/schemas/create_json_schema.py
@@ -275,7 +275,6 @@ def _get_validation_rule_based_fields(
 
         js_is_array = ValidationRuleName.LIST in validation_rule_names
 
-
         # The explicit JSON Schema type is the one set in the data model
         # The implicit JSON Schema type is the one implied by the presence
         #   of certain validation rules

--- a/schematic/schemas/create_json_schema.py
+++ b/schematic/schemas/create_json_schema.py
@@ -240,7 +240,7 @@ def _get_validation_rule_based_fields(
 
     Arguments:
         validation_rules: A list of input validation rules
-        explicit_js_type: If the type has been set explicitly in the data model, otherwise None
+        explicit_js_type: A JSONSchemaType if set explicitly in the data model, otherwise None
         name: The name of the node the validation rules belong to
 
     Raises:
@@ -276,15 +276,15 @@ def _get_validation_rule_based_fields(
         js_is_array = ValidationRuleName.LIST in validation_rule_names
 
 
-        # The explicit JSON Schema type is the one set in the data model.
+        # The explicit JSON Schema type is the one set in the data model
         # The implicit JSON Schema type is the one implied by the presence
-        #   of certain validation rules.
-        # Schematic will use the implicit type for if the explicit type isn't specified for now,
-        #   but this behavior is deprecated and will be removed in the future in SCHEMATIC-326
+        #   of certain validation rules
+        # Schematic will use the implicit type if the explicit type isn't specified for now,
+        #   but this behavior is deprecated and will be removed in the future by SCHEMATIC-326
         implicit_js_type = get_js_type_from_inputted_rules(validation_rules)
-        # If there is an explicit type that is used ...
+        # If there is an explicit type set...
         if explicit_js_type:
-            # unless there the implicit type conflicts the an exception is raised
+            # and the implicit type conflicts with the explicit type, then an exception is raised
             if explicit_js_type != implicit_js_type:
                 msg = (
                     f"Property: '{name}', has explicit type: '{explicit_js_type}' "
@@ -292,11 +292,15 @@ def _get_validation_rule_based_fields(
                     f"derived from its validation rules: {validation_rules}"
                 )
                 raise ValueError(msg)
+            # otherwise the explicit type is used
             js_type = explicit_js_type
-        # If there is no explicit type then the implicit type is used and ...
+        # If there is no explicit type...
         else:
-            # a warning is raised since this behavior is deprecated
+            # and there is an implicit type...
             if implicit_js_type:
+                # then the implicit type is used...
+                js_type = implicit_js_type
+                # and a warning is raised since this behavior is deprecated
                 msg = (
                     f"No explicit type set for property: '{name}', "
                     "using validation rules to set the type. "
@@ -304,7 +308,6 @@ def _get_validation_rule_based_fields(
                     "You should set the columnType for this property in your data model."
                 )
                 warnings.warn(msg)
-                js_type = implicit_js_type
 
         if ValidationRuleName.URL in validation_rule_names:
             js_format = JSONSchemaFormat.URI

--- a/tests/unit/test_create_json_schema.py
+++ b/tests/unit/test_create_json_schema.py
@@ -231,7 +231,7 @@ def test_node_init(
     ],
     ids=["No rules", "String", "List", "ListString", "InRange", "Regex", "Date", "URL"],
 )
-def test_get_validation_rule_based_fields(
+def test_get_validation_rule_based_fields_no_explicit_type(
     validation_rules: list[str],
     expected_type: Optional[JSONSchemaType],
     expected_is_array: bool,
@@ -240,7 +240,10 @@ def test_get_validation_rule_based_fields(
     expected_pattern: Optional[str],
     expected_format: Optional[JSONSchemaFormat],
 ) -> None:
-    """Tests for _get_validation_rule_based_fields"""
+    """
+    Test for _get_validation_rule_based_fields
+    Tests that output is expected based on the input validation rules
+    """
     (
         is_array,
         property_type,
@@ -248,13 +251,128 @@ def test_get_validation_rule_based_fields(
         minimum,
         maximum,
         pattern,
-    ) = _get_validation_rule_based_fields(validation_rules)
+    ) = _get_validation_rule_based_fields(validation_rules, None, "name")
     assert property_type == expected_type
     assert property_format == expected_format
     assert is_array == expected_is_array
     assert minimum == expected_min
     assert maximum == expected_max
     assert pattern == expected_pattern
+
+
+@pytest.mark.parametrize(
+    "validation_rules, explicit_type, expected_type, expected_is_array, expected_min, expected_max, expected_pattern, expected_format",
+    [
+        (
+            ["str"],
+            JSONSchemaType.STRING,
+            JSONSchemaType.STRING,
+            False,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            ["inRange 50 100"],
+            JSONSchemaType.NUMBER,
+            JSONSchemaType.NUMBER,
+            False,
+            50,
+            100,
+            None,
+            None,
+        ),
+        (
+            ["regex search [a-f]"],
+            JSONSchemaType.STRING,
+            JSONSchemaType.STRING,
+            False,
+            None,
+            None,
+            "[a-f]",
+            None,
+        ),
+        (
+            ["date"],
+            JSONSchemaType.STRING,
+            JSONSchemaType.STRING,
+            False,
+            None,
+            None,
+            None,
+            JSONSchemaFormat.DATE,
+        ),
+        (
+            ["url"],
+            JSONSchemaType.STRING,
+            JSONSchemaType.STRING,
+            False,
+            None,
+            None,
+            None,
+            JSONSchemaFormat.URI,
+        ),
+    ],
+    ids=["String", "InRange", "Regex", "Date", "URL"],
+)
+def test_get_validation_rule_based_fields_with_explicit_type(
+    validation_rules: list[str],
+    explicit_type: JSONSchemaType,
+    expected_type: Optional[JSONSchemaType],
+    expected_is_array: bool,
+    expected_min: Optional[float],
+    expected_max: Optional[float],
+    expected_pattern: Optional[str],
+    expected_format: Optional[JSONSchemaFormat],
+) -> None:
+    """
+    Test for _get_validation_rule_based_fields
+    Tests that output is expected based on the input validation rules, and explicit type
+    """
+    (
+        is_array,
+        property_type,
+        property_format,
+        minimum,
+        maximum,
+        pattern,
+    ) = _get_validation_rule_based_fields(validation_rules, explicit_type, "name")
+    assert property_type == expected_type
+    assert property_format == expected_format
+    assert is_array == expected_is_array
+    assert minimum == expected_min
+    assert maximum == expected_max
+    assert pattern == expected_pattern
+
+
+@pytest.mark.parametrize(
+    "validation_rules, explicit_type",
+    [
+        (["str"], JSONSchemaType.INTEGER),
+        (["inRange 50 100"], JSONSchemaType.STRING),
+        (["regex search [a-f]"], JSONSchemaType.INTEGER),
+        (["date"], JSONSchemaType.INTEGER),
+        (["url"], JSONSchemaType.INTEGER),
+    ],
+    ids=[
+        "String rule, integer type",
+        "InRange rule, string type",
+        "Regex rule, integer type",
+        "Date rule, integer type",
+        "Url rule, integer type",
+    ],
+)
+def test_get_validation_rule_based_fields_with_exception(
+    validation_rules: list[str],
+    explicit_type: JSONSchemaType,
+) -> None:
+    """
+    Test for _get_validation_rule_based_fields
+    Tests that output is expected based on the input validation rules, and explicit type
+    """
+    with pytest.raises(ValueError):
+        _get_validation_rule_based_fields(validation_rules, explicit_type, "name")
 
 
 class TestGraphTraversalState:


### PR DESCRIPTION
[SCHEMATIC-308]

# **Problem:**
When creating a JSON Schema, the type is inferred from existing validation rules if they exist. It would be better if the type were set explicitly in the data model.

# **Solution:**
The JSON Schema creation function will look for the columnType attribute in the data model graph and use it to set the JSON Schema type if it exists. Otherwise, it will continue to infer the type from the validation rules. Infering from validaiton rules has been deprecated and will be sunsetted in the future.

# **Testing:**
Unit tests for both when the node has the columType attribute and when it doesn't.


[SCHEMATIC-308]: https://sagebionetworks.jira.com/browse/SCHEMATIC-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ