### PR TITLE
add lock to werkzeug version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5149,4 +5149,4 @@ aws = ["uWSGI"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.0,<3.11"
-content-hash = "cd3d87594cd0ebf017796a1f2cc9ff1f34c09efc2e7257e81bf795a1b686001a"
+content-hash = "5f25c4ac6c3d5293551cdd4bc68ba8a4b85694f4f453aaf55633561a56a7eaba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ opentelemetry-instrumentation-flask = ">=0.48b0"
 python-dotenv = "^0.21.0"
 cryptography = ">=42.0.4"
 deprecated = "^1.0.0"
+werkzeug = "<3.0.0"
 
 [tool.poetry.extras]
 api = ["Jinja2", "pyopenssl", "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http"]


### PR DESCRIPTION
# **Problem:**

A our version of flask was incompatible with the latest werkzeug version

# **Solution:**

The version of werkzeug was pinned

# **Testing:**

pre-release API tests pass after update

