### PR TITLE
Display schema column too small error in query_fileview

### DIFF
--- a/schematic/store/synapse.py
+++ b/schematic/store/synapse.py
@@ -419,6 +419,10 @@ class SynapseStorage(BaseStorage):
                     raise ValueError(
                         f"The columns {missing_column} specified in the query do not exist in the fileview. Please make sure that the column names are correct and that all expected columns have been added to the fileview."
                     )
+                elif "The column size needs to be at least" in exception_text:
+                    raise ValueError(
+                      f"Error in the fileview schema. " + exception_text
+                    )
                 else:
                     raise AccessCredentialsError(self.storageFileview)
 


### PR DESCRIPTION
# **Problem:**

A DCA user reported a `Forbidden` error trying to access folders within a project. This was caused by a 403 error returned from the `/storage/projects/` endpoint. The user and myself both had admin permission to the file view and folders, so it wasn't a 403 issue. Looking up the file view on Synapse, there was an error banner stating one of the schema columns was too short. The user rolled back the schema changes and resolved the issue.

<img width="970" height="319" alt="image" src="https://github.com/user-attachments/assets/989491c5-afe1-46ef-a847-1154528d5b6d" />

# **Solution:**

This PR adds a `elif` statement to check `query_table` errors for the specific text returned by Synapse when a schema column is too short. Avoiding the default 403 error for this case.
<img width="388" height="86" alt="Screenshot 2025-07-15 at 3 34 21 PM" src="https://github.com/user-attachments/assets/c49f1b53-bb9f-43b3-a2c4-7e7a767200c0" />
