### PR TITLE
update api Dockerfile(#1637)

### DIFF
--- a/schematic_api/Dockerfile
+++ b/schematic_api/Dockerfile
@@ -37,7 +37,7 @@ LABEL version=$TAG
 
 # run open ssl and generate certificate
 RUN apt update && \
-    apt-get install openssl && \
+    apt-get install -y openssl && \
     openssl req -x509 -nodes -days 365 \
     -subj  "/C=CA/ST=QC/O=Company" \
     -newkey rsa:2048 -keyout /etc/ssl/private/localhost.key \


### PR DESCRIPTION
# **Problem:**

the `Build and Push Docker Image` workflow fails with error:
```
ERROR: failed to build: failed to solve: process "/bin/sh -c apt update &&     apt-get install openssl &&     openssl req -x509 -nodes -days 365     -subj  \"/C=CA/ST=QC/O=Company\"     -newkey rsa:2048 -keyout /etc/ssl/private/localhost.key     -out /etc/ssl/certs/localhost.crt;" did not complete successfully: exit code: 1
```
# **Solution:**

Update the `openssl` install command with an additional parameter

# **Testing:**

The image can be built locally
