### PR TITLE
[SCHEMATIC-360] Add script to write jsonschemas to a synapse table

### DIFF
--- a/scripts/write_jsonschemas_to_table.py
+++ b/scripts/write_jsonschemas_to_table.py
@@ -28,6 +28,7 @@ def main():
         "sage.schemas.v2571",
         "sage.schemas.v2581",
         "MultiConsortiaCoordinatingCenter",
+        "org.synapse.nf",
     ]
     js = syn.service("json_schema")
     to_write_schemas = []
@@ -59,6 +60,9 @@ def main():
                     if organization_name == "MultiConsortiaCoordinatingCenter":
                         # only include the latest version of MCC schemas
                         dcc = "MC2"
+                        datatype = version["schemaName"]
+                    elif organization_name == "org.synapse.nf":
+                        dcc = "NF-OSI"
                         datatype = version["schemaName"]
                     else:
                         dcc = version["schemaName"].split(".")[0]

--- a/scripts/write_jsonschemas_to_table.py
+++ b/scripts/write_jsonschemas_to_table.py
@@ -22,6 +22,7 @@ def main():
         - link: a link to the JSONschema version in the Synapse repo
     """
     syn = synapseclient.login()
+    # json_schema_organizations = ["sage.schemas.v2571", "sage.schemas.v2581"]
     json_schema_organizations = ["sage.schemas.v2571", "sage.schemas.v2581"]
     js = syn.service("json_schema")
     to_write_schemas = []
@@ -29,19 +30,35 @@ def main():
         org = js.JsonSchemaOrganization(organization_name)
         schemas = org.list_json_schemas()
         for schema in schemas:
+            print(schema)
             versions = schema.list_versions()
-            for version in versions:
-                to_write_schemas.append(
-                    {
-                        "org": organization_name,
-                        "name": version.name,
-                        "dcc": version.name.split(".")[0],
-                        "datatype": version.name.split(".")[1],
-                        "uri": version.uri,
-                        "version": version.semantic_version,
-                        "link": f"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/{version.uri}",
-                    }
-                )
+            try:
+                for version in versions:
+                    if (
+                        (
+                            version.name.startswith("ad")
+                            and version.semantic_version == "0.1.0"
+                        )
+                        or (
+                            version.name.startswith("el")
+                            and version.semantic_version == "0.0.1"
+                        )
+                        or ".validation." in version.name
+                    ):
+                        continue
+                    to_write_schemas.append(
+                        {
+                            "org": organization_name,
+                            "name": version.name,
+                            "dcc": version.name.split(".")[0],
+                            "datatype": version.name.split(".")[1],
+                            "uri": version.uri,
+                            "version": version.semantic_version,
+                            "link": f"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/{version.uri}",
+                        }
+                    )
+            except Exception as e:
+                print(e)
 
     df = pd.DataFrame(to_write_schemas)
     # exclude HTAN1, HTAN2, and NF schemas as they have their own JSONschema organizations

--- a/scripts/write_jsonschemas_to_table.py
+++ b/scripts/write_jsonschemas_to_table.py
@@ -1,5 +1,6 @@
 import synapseclient
 from synapseclient.models import Table
+from synapseclient.services.json_schema import JsonSchemaService
 
 import pandas as pd
 
@@ -31,30 +32,34 @@ def main():
         schemas = org.list_json_schemas()
         for schema in schemas:
             print(schema)
-            versions = schema.list_versions()
+            # versions = schema.list_versions()
+            versions = JsonSchemaService(syn).list_json_schema_versions(
+                organization_name, schema.name
+            )
             try:
                 for version in versions:
                     if (
                         (
-                            version.name.startswith("ad")
-                            and version.semantic_version == "0.1.0"
+                            version["schemaName"].startswith("ad")
+                            and version.get("semanticVersion")
+                            in ["0.1.0", "1.99.9999", "1.99.99", None]
                         )
                         or (
-                            version.name.startswith("el")
-                            and version.semantic_version == "0.0.1"
+                            version["schemaName"].startswith("el")
+                            and version.get("semanticVersion") == "0.0.1"
                         )
-                        or ".validation." in version.name
+                        or ".validation." in version["schemaName"]
                     ):
                         continue
                     to_write_schemas.append(
                         {
                             "org": organization_name,
-                            "name": version.name,
-                            "dcc": version.name.split(".")[0],
-                            "datatype": version.name.split(".")[1],
-                            "uri": version.uri,
-                            "version": version.semantic_version,
-                            "link": f"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/{version.uri}",
+                            "name": version["schemaName"],
+                            "dcc": version["schemaName"].split(".")[0],
+                            "datatype": version["schemaName"].split(".")[1],
+                            "uri": version["$id"],
+                            "version": version["semanticVersion"],
+                            "link": f"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/{version['$id']}",
                         }
                     )
             except Exception as e:

--- a/scripts/write_jsonschemas_to_table.py
+++ b/scripts/write_jsonschemas_to_table.py
@@ -1,6 +1,6 @@
 import synapseclient
 from synapseclient.models import Table
-from synapseclient.services.json_schema import JsonSchemaService
+from synapseclient.models import SchemaOrganization
 
 import pandas as pd
 
@@ -30,53 +30,52 @@ def main():
         "MultiConsortiaCoordinatingCenter",
         "org.synapse.nf",
     ]
-    js = syn.service("json_schema")
+    # js = syn.service("json_schema")
     to_write_schemas = []
     for organization_name in json_schema_organizations:
-        org = js.JsonSchemaOrganization(organization_name)
-        schemas = org.list_json_schemas()
+        org = SchemaOrganization(name=organization_name).get()
+        # org = js.JsonSchemaOrganization(organization_name)
+        schemas = org.get_json_schemas()
         for schema in schemas:
             print(schema)
             # versions = schema.list_versions()
-            versions = JsonSchemaService(syn).list_json_schema_versions(
-                organization_name, schema.name
-            )
+            versions = schema.get_versions()
             try:
                 for version in versions:
                     print(version)
                     if (
                         (
-                            version["schemaName"].startswith("ad")
-                            and version.get("semanticVersion")
+                            version.schema_name.startswith("ad")
+                            and version.semantic_version
                             in ["0.1.0", "1.99.9999", "1.99.99", None]
                         )
                         or (
-                            version["schemaName"].startswith("el")
-                            and version.get("semanticVersion") == "0.0.1"
+                            version.schema_name.startswith("el")
+                            and version.semantic_version == "0.0.1"
                         )
-                        or ".validation." in version["schemaName"]
+                        or ".validation." in version.schema_name
                     ):
                         continue
                     if organization_name == "MultiConsortiaCoordinatingCenter":
                         # only include the latest version of MCC schemas
                         dcc = "MC2"
-                        datatype = version["schemaName"]
+                        datatype = version.schema_name
                     elif organization_name == "org.synapse.nf":
                         dcc = "NF-OSI"
-                        datatype = version["schemaName"]
+                        datatype = version.schema_name
                     else:
-                        dcc = version["schemaName"].split(".")[0]
-                        datatype = version["schemaName"].split(".")[1]
+                        dcc = version.schema_name.split(".")[0]
+                        datatype = version.schema_name.split(".")[1]
 
                     to_write_schemas.append(
                         {
                             "org": organization_name,
-                            "name": version["schemaName"],
+                            "name": version.schema_name,
                             "dcc": dcc,
                             "datatype": datatype,
-                            "uri": version["$id"],
-                            "version": version["semanticVersion"],
-                            "link": f"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/{version['$id']}",
+                            "uri": version.id,
+                            "version": version.semantic_version,
+                            "link": f"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/{version.id}",
                         }
                     )
             except Exception as e:

--- a/scripts/write_jsonschemas_to_table.py
+++ b/scripts/write_jsonschemas_to_table.py
@@ -24,7 +24,11 @@ def main():
     """
     syn = synapseclient.login()
     # json_schema_organizations = ["sage.schemas.v2571", "sage.schemas.v2581"]
-    json_schema_organizations = ["sage.schemas.v2571", "sage.schemas.v2581"]
+    json_schema_organizations = [
+        "sage.schemas.v2571",
+        "sage.schemas.v2581",
+        "MultiConsortiaCoordinatingCenter",
+    ]
     js = syn.service("json_schema")
     to_write_schemas = []
     for organization_name in json_schema_organizations:
@@ -38,6 +42,7 @@ def main():
             )
             try:
                 for version in versions:
+                    print(version)
                     if (
                         (
                             version["schemaName"].startswith("ad")
@@ -51,12 +56,20 @@ def main():
                         or ".validation." in version["schemaName"]
                     ):
                         continue
+                    if organization_name == "MultiConsortiaCoordinatingCenter":
+                        # only include the latest version of MCC schemas
+                        dcc = "MC2"
+                        datatype = version["schemaName"]
+                    else:
+                        dcc = version["schemaName"].split(".")[0]
+                        datatype = version["schemaName"].split(".")[1]
+
                     to_write_schemas.append(
                         {
                             "org": organization_name,
                             "name": version["schemaName"],
-                            "dcc": version["schemaName"].split(".")[0],
-                            "datatype": version["schemaName"].split(".")[1],
+                            "dcc": dcc,
+                            "datatype": datatype,
                             "uri": version["$id"],
                             "version": version["semanticVersion"],
                             "link": f"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/{version['$id']}",

--- a/scripts/write_jsonschemas_to_table.py
+++ b/scripts/write_jsonschemas_to_table.py
@@ -1,0 +1,54 @@
+import synapseclient
+from synapseclient.models import Table
+
+import pandas as pd
+
+
+def main():
+    """
+    The main entry point for this script.
+
+    This script logs in to Synapse, finds all the JSONschema organizations
+    and versions in the given list, and writes them to the Synapse table
+    with Synapse ID syn69735275.
+
+    The table will have the following columns:
+        - org: the name of the JSONschema organization
+        - name: the full name of the JSONschema version
+        - dcc: the name of the DCC
+        - datatype: the name of the datatype
+        - uri: the URI of the JSONschema version
+        - version: the semantic version of the JSONschema version
+        - link: a link to the JSONschema version in the Synapse repo
+    """
+    syn = synapseclient.login()
+    json_schema_organizations = ["sage.schemas.v2571", "sage.schemas.v2581"]
+    js = syn.service("json_schema")
+    to_write_schemas = []
+    for organization_name in json_schema_organizations:
+        org = js.JsonSchemaOrganization(organization_name)
+        schemas = org.list_json_schemas()
+        for schema in schemas:
+            versions = schema.list_versions()
+            for version in versions:
+                to_write_schemas.append(
+                    {
+                        "org": organization_name,
+                        "name": version.name,
+                        "dcc": version.name.split(".")[0],
+                        "datatype": version.name.split(".")[1],
+                        "uri": version.uri,
+                        "version": version.semantic_version,
+                        "link": f"https://repo-prod.prod.sagebase.org/repo/v1/schema/type/registered/{version.uri}",
+                    }
+                )
+
+    df = pd.DataFrame(to_write_schemas)
+    # exclude HTAN1, HTAN2, and NF schemas as they have their own JSONschema organizations
+    df = df[~df["dcc"].isin(["htan", "htan2", "nf"])]
+    table = Table(id="syn69735275").get(include_columns=True)
+    table.upsert_rows(values=df, primary_keys=["uri"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# **Problem:**

Currently, we maintain a Confluence page manually with the JSON schemas we generate that can be used for Curator MVP.  This won't scale as we create more JSON schemas. 

# **Solution:**
Add ad-hoc script to write jsonschemas that DPE generates to a synapse table for Curator MVP.  This is partially doing some of schematic-360 work and adds a 'script' directory


# **Testing:**

View Synapse table here: https://www.synapse.org/Synapse:syn69735275/tables/