### PR TITLE
Fix json creation bugs

### DIFF
--- a/schematic/schemas/create_json_schema.py
+++ b/schematic/schemas/create_json_schema.py
@@ -293,8 +293,8 @@ def _get_validation_rule_based_fields(
                 f"that conflicts with the implicit type: '{implicit_js_type}' "
                 f"derived from its validation rules: {validation_rules}"
             )
-            raise ValueError(msg)
-        if implicit_js_type:
+            warnings.warn(msg)
+        if not explicit_js_type and implicit_js_type:
             js_type = implicit_js_type
             msg = (
                 f"No explicit type set for property: '{name}', "

--- a/temp.py
+++ b/temp.py
@@ -1,0 +1,8 @@
+from schematic.schemas.create_json_schema import create_json_schema
+from schematic.schemas.data_model_graph import create_data_model_graph_explorer
+
+#dmge = create_data_model_graph_explorer("tests/data/example.model.csv")
+#x = create_json_schema(dmge=dmge,datatype="Patient", schema_name="test", schema_path="x.json")
+
+dmge = create_data_model_graph_explorer("/home/alamb/Downloads/ark.biospecimen_model.csv")
+x = create_json_schema(dmge=dmge,datatype="BiospecimenMetadataTemplate", schema_name="test", schema_path="x.json")

--- a/temp.py
+++ b/temp.py
@@ -1,8 +1,0 @@
-from schematic.schemas.create_json_schema import create_json_schema
-from schematic.schemas.data_model_graph import create_data_model_graph_explorer
-
-#dmge = create_data_model_graph_explorer("tests/data/example.model.csv")
-#x = create_json_schema(dmge=dmge,datatype="Patient", schema_name="test", schema_path="x.json")
-
-dmge = create_data_model_graph_explorer("/home/alamb/Downloads/ark.biospecimen_model.csv")
-x = create_json_schema(dmge=dmge,datatype="BiospecimenMetadataTemplate", schema_name="test", schema_path="x.json")

--- a/tests/unit/test_create_json_schema.py
+++ b/tests/unit/test_create_json_schema.py
@@ -365,36 +365,6 @@ def test_get_validation_rule_based_fields_with_explicit_type(
     assert maximum == expected_max
     assert pattern == expected_pattern
 
-
-@pytest.mark.parametrize(
-    "validation_rules, explicit_type",
-    [
-        (["str"], JSONSchemaType.INTEGER),
-        (["inRange 50 100"], JSONSchemaType.STRING),
-        (["regex search [a-f]"], JSONSchemaType.INTEGER),
-        (["date"], JSONSchemaType.INTEGER),
-        (["url"], JSONSchemaType.INTEGER),
-    ],
-    ids=[
-        "String rule, integer type",
-        "InRange rule, string type",
-        "Regex rule, integer type",
-        "Date rule, integer type",
-        "Url rule, integer type",
-    ],
-)
-def test_get_validation_rule_based_fields_with_exception(
-    validation_rules: list[str],
-    explicit_type: JSONSchemaType,
-) -> None:
-    """
-    Test for _get_validation_rule_based_fields
-    Tests that output is expected based on the input validation rules, and explicit type
-    """
-    with pytest.raises(ValueError):
-        _get_validation_rule_based_fields(validation_rules, explicit_type, "name")
-
-
 class TestGraphTraversalState:
     """Tests for GraphTraversalState class"""
 

--- a/tests/unit/test_create_json_schema.py
+++ b/tests/unit/test_create_json_schema.py
@@ -365,6 +365,7 @@ def test_get_validation_rule_based_fields_with_explicit_type(
     assert maximum == expected_max
     assert pattern == expected_pattern
 
+
 class TestGraphTraversalState:
     """Tests for GraphTraversalState class"""
 


### PR DESCRIPTION
# **Problem:**

- Users were getting incorrect warnings about not setting types in the "columnType" column.
- Users were getting incorrect errors about type conflicts with the `inRange` rule

# **Solution:**
Since using validation rules to determine type is deprecated and will be sunsetted in the Curator extension version, I've made some temporary fixes to get users going:

- The logic for the type warning was fixed
- The type error was changed to a warning so users could ignore it


